### PR TITLE
docs: add documentation configuration, symlink all examples into docs to render on site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
-# fenic
-Build reliable AI and agentic applications with DataFrames
+# fenic: The dataframe (re)built for LLM inference
+
+[![PyPI version](https://img.shields.io/pypi/v/fenic.svg)](https://pypi.org/project/fenic/)
+[![Python versions](https://img.shields.io/pypi/pyversions/fenic.svg)](https://pypi.org/project/fenic/)
+[![License](https://img.shields.io/github/license/typedef-ai/fenic.svg)](https://github.com/typedef-ai/fenic/blob/main/LICENSE)
+[![Discord](https://img.shields.io/discord/1381706122322513952?label=Discord&logo=discord)](https://discord.gg/aAvsqRW3)
+
+fenic is an opinionated, PySpark-inspired DataFrame framework for building AI and agentic applications. Transform unstructured and structured data into insights using familiar DataFrame operations enhanced with semantic intelligence. With first-class support for markdown, transcripts, and semantic operators, plus efficient batch inference across any model provider.
+
+## Install
+
+fenic requires Python 3.9 or later.
+
+```bash
+pip install fenic
+```
+
+### LLM Provider Setup
+
+fenic requires an API key from at least one LLM provider. Set the appropriate environment variable for your chosen provider:
+
+```bash
+# For OpenAI
+export OPENAI_API_KEY="your-openai-api-key"
+
+# For Anthropic
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+
+# For Google
+export GEMINI_API_KEY="your-google-api-key"
+```
+
+## Quickstart
+
+The fastest way to learn about fenic is by checking the examples.
+
+Below is a quick list of the examples in this repo:
+
+| Example                                                                 | Description                                                                                                                         |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Hello World!](examples/hello_world)                                    | Introduction to semantic extraction and classification using fenic's core operators through error log analysis.                     |
+| [Enrichment](examples/enrichment)                                       | Multi-stage DataFrames with template-based text extraction, joins, and LLM-powered transformations demonstrated via log enrichment. |
+| [Meeting Transcript Processing](examples/meeting_transcript_processing) | Native transcript parsing, Pydantic schema integration, and complex aggregations shown through meeting analysis.                    |
+| [News Analysis](examples/news_analysis)                                 | Analyze and extract insights from news articles using semantic operators and structured data processing.                            |
+| [Podcast Summarization](examples/podcast_summarization)                 | Process and summarize podcast transcripts with speaker-aware analysis and key point extraction.                                     |
+| [Semantic Join](examples/semantic_search)                               | Instead of simple fuzzy matching, use fenic's powerful semantic join functionality to match data across tables.                     |
+| [Named Entity Recognition](examples/named_entity_recognition)           | Extract and classify named entities from text using semantic extraction and classification.                                         |
+| [Markdown Processing](examples/markdown_processing)                     | Process and transform markdown documents with structured data extraction and formatting.                                            |
+| [JSON Processing](examples/json_processing)                             | Handle complex JSON data structures with semantic operations and schema validation.                                                 |
+| [Feedback Clustering](examples/feedback_clustering)                     | Group and analyze feedback using semantic similarity and clustering operations.                                                     |
+| [Document Extraction](examples/document_extraction)                     | Extract structured information from various document formats using semantic operators.                                              |
+
+(Feel free to click any example above to jump right to its folder.)
+
+## Why use fenic?
+
+fenic is an opinionated, PySpark-inspired DataFrame framework for building production AI and agentic applications.
+
+Unlike traditional data tools retrofitted for LLMs, fenic's query engine is built from the ground up with inference in mind.
+
+Transform structured and unstructured data into insights using familiar DataFrame operations enhanced with semantic intelligence. With first-class support for markdown, transcripts, and semantic operators, plus efficient batch inference across any model provider.
+
+fenic brings the reliability of traditional data pipelines to AI workloads.
+
+### Key Features
+
+#### Purpose-Built for LLM Inference
+
+- Query engine designed from scratch for AI workloads, not retrofitted
+- Automatic batch optimization for API calls
+- Built-in retry logic and rate limiting
+- Token counting and cost tracking
+
+#### Semantic Operators as First-Class Citizens
+
+- `semantic.analyze_sentiment` - Built-in sentiment analysis
+- `semantic.classify` - Categorize text with few-shot examples
+- `semantic.extract` - Transform unstructured text into structured data with schemas
+- `semantic.group_by` - Group data by semantic similarity
+- `semantic.join` - Join DataFrames on meaning, not just values
+- `semantic.map` - Apply natural language transformations
+- `semantic.predicate` - Create predicates using natural language to filter rows
+- `semantic.reduce` - Aggregate grouped data with LLM operations
+
+#### Native Unstructured Data Support
+
+Goes beyond typical multimodal data types (audio, images) by creating specialized types for text-heavy workloads:
+
+- Markdown parsing and extraction as a first-class data type
+- Transcript processing (SRT, generic formats) with speaker and timestamp awareness
+- JSON manipulation with JQ expressions for nested data
+- Automatic text chunking with configurable overlap for long documents
+
+#### Production-Ready Infrastructure
+
+- Multi-provider support (OpenAI, Anthropic)
+- Local and cloud execution backends
+- Comprehensive error handling and logging
+- Pydantic integration for type safety
+
+#### Familiar DataFrame API
+
+- PySpark-compatible operations
+- Lazy evaluation and query optimization
+- SQL support for complex queries
+- Seamless integration with existing data pipelines
+
+### Why DataFrames for LLM and Agentic Applications?
+
+AI and agentic applications are fundamentally pipelines and workflows - exactly what DataFrame APIs were designed to handle. Rather than reinventing patterns for data transformation, filtering, and aggregation, fenic leverages decades of proven engineering practices.
+
+#### Decoupled Architecture for Better Agents
+
+fenic creates a clear separation between heavy inference tasks and real-time agent interactions. By moving batch processing out of the agent runtime, you get:
+
+- More predictable and responsive agents
+- Better resource utilization with batched LLM calls
+- Cleaner separation between planning/orchestration and execution
+
+#### Built for All Engineers
+
+DataFrames aren't just for data practitioners. The fluent, composable API design makes it accessible to any engineer:
+
+- Chain operations naturally: `df.filter(...).semantic.group_by()`
+- Mix imperative and declarative styles seamlessly
+- Get started quickly with familiar patterns from pandas/PySpark or SQL
+
+## Support
+
+Join our community on [Discord](https://discord.gg/aAvsqRW3) where you can connect with other users, ask questions, and get help with your fenic projects. Our community is always happy to welcome newcomers!
+
+If you find fenic useful, consider giving us a ⭐ at the top of this repository. Your support helps us grow and improve the framework for everyone!
+
+## Contributing
+
+We welcome contributions of all kinds! Whether you're interested in writing code, improving documentation, testing features, or proposing new ideas, your help is valuable to us.
+
+For developers planning to submit code changes, we encourage you to first open an issue to discuss your ideas before creating a Pull Request. This helps ensure alignment with the project's direction and prevents duplicate efforts.
+
+Please refer to our [contribution guidelines](CONTRIBUTING.md) for detailed information about the development process and project setup.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/examples/document_extraction.md
+++ b/docs/examples/document_extraction.md
@@ -1,0 +1,1 @@
+../../examples/document_extraction/README.md

--- a/docs/examples/enrichment.md
+++ b/docs/examples/enrichment.md
@@ -1,0 +1,1 @@
+../../examples/enrichment/README.md

--- a/docs/examples/feedback_clustering.md
+++ b/docs/examples/feedback_clustering.md
@@ -1,0 +1,1 @@
+../../examples/feedback_clustering/README.md

--- a/docs/examples/hello_world.md
+++ b/docs/examples/hello_world.md
@@ -1,0 +1,1 @@
+../../examples/hello_world/README.md

--- a/docs/examples/json_processing.md
+++ b/docs/examples/json_processing.md
@@ -1,0 +1,1 @@
+../../examples/json_processing/README.md

--- a/docs/examples/markdown_processing.md
+++ b/docs/examples/markdown_processing.md
@@ -1,0 +1,1 @@
+../../examples/markdown_processing/README.md

--- a/docs/examples/meeting_transcript_processing.md
+++ b/docs/examples/meeting_transcript_processing.md
@@ -1,0 +1,1 @@
+../../examples/meeting_transcript_processing/README.md

--- a/docs/examples/named_entity_recognition.md
+++ b/docs/examples/named_entity_recognition.md
@@ -1,0 +1,1 @@
+../../examples/named_entity_recognition/README.md

--- a/docs/examples/podcast_summarization.md
+++ b/docs/examples/podcast_summarization.md
@@ -1,0 +1,1 @@
+../../examples/podcast_summarization/README.md

--- a/docs/examples/semantic_search.md
+++ b/docs/examples/semantic_search.md
@@ -1,0 +1,1 @@
+../../examples/semantic_search/README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,3 @@
+.md-main__inner.md-grid {
+  max-width: initial;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+---
+site_name: fenic, by typedef
+docs_dir: docs
+repo_url: https://github.com/typedef-ai/fenic
+theme:
+  name: material
+  features:
+    - announce.dismiss
+    - content.action.edit
+    - content.action.view
+    - content.code.annotate
+    - content.code.copy
+    - content.tooltips
+    - navigation.footer
+    - navigation.instant
+    - navigation.path
+    - navigation.tracking
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+nav:
+  - Overview:
+      - What is fenic?: index.md
+      - Examples:
+          - Introduction:
+              - Hello World!: examples/hello_world.md
+              - Log Enrichment: examples/enrichment.md
+          - Unstructured Data Clustering/Classification:
+              - Feedback Clustering: examples/feedback_clustering.md
+          - Semantic Joins on Unstructured Data: examples/semantic_search.md
+          - Extracting Structured Data from Unstructured Text:
+              - Document Extraction: examples/document_extraction.md
+          - Semi-Structured Data Processing/Enrichment:
+              - Named Entity Recognition: examples/named_entity_recognition.md
+              - Podcast Summarization: examples/podcast_summarization.md
+              - Meeting Transcript Processing: examples/meeting_transcript_processing.md
+              - JSON Processing: examples/json_processing.md
+              - Markdown Processing: examples/markdown_processing.md
+      - Contributing: CONTRIBUTING.md
+  - API Reference
+watch:
+  - src/fenic/api
+  - docs
+  - mkdocs.yml
+extra:
+  version:
+    provider: mike
+extra_css:
+  - stylesheets/extra.css
+plugins:
+  - search
+  - section-index
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - src
+          options:
+            docstring_section_style: list # table/list/spacy
+            docstring_style: google
+            filters: ["!^_"]
+            heading_level: 1
+            merge_init_into_class: true
+            parameter_headings: false
+            separate_signature: true
+            show_root_heading: true
+            show_signature_annotations: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_inheritance_diagram: true
+            summary:
+              modules: false
+              attributes: true
+              classes: true
+              functions: true
+  - api-autonav:
+      modules: [src/fenic]
+      exclude:
+        - fenic.api.window # WIP
+      exclude_private: true
+      nav_section_title: API Reference
+  - mike:
+      canonical_version: latest
+      version_selector: true

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -301,6 +302,7 @@ requires-dist = [
     { name = "sqlglot", specifier = ">=26.25.3" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
+provides-extras = ["anthropic", "google", "cloud"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
### TL;DR

Added MkDocs configuration for generating documentation website from existing README and example files.

### What changed?

- Created `mkdocs.yml` configuration file with site structure, theme settings, and plugin configurations
- Added symbolic links in the `docs/` directory to existing documentation:
  - Linked main README.md as index.md
  - Linked CONTRIBUTING.md
  - Created symbolic links to all example README files in docs/examples/
- Added a custom CSS file for documentation styling
- Updated uv.lock with revision and provides-extras fields

### How to test?

1. Run `just preview-docs` to build and serve the documentation site.
3. Navigate to http://localhost:8000 to view the generated documentation
4. Verify that all example pages, API reference, and navigation work correctly

### Why make this change?

This change improves the project's documentation by creating a dedicated documentation website using MkDocs. It reuses existing documentation files through symbolic links, ensuring content stays in sync while providing a more structured and navigable interface for users. The Material theme and configured plugins enhance readability and searchability of the documentation.