### PR TITLE
docs: fenic docs, now with *dark mode*

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,15 @@ docs_dir: docs
 repo_url: https://github.com/typedef-ai/fenic
 theme:
   name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - announce.dismiss
     - content.action.edit


### PR DESCRIPTION
Add a toggle to allow users to switch between light/dark mode for the docs.