### PR TITLE
test: update examples test to pass a session config, so we can use gemini model rate limits in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
     name: test ${{ matrix.python-version }}, ${{ matrix.test }}, ${{ matrix.dependency }}
     runs-on: ubuntu-latest
     env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/test.yaml
       - rust/**
       - src/**
+      - tests/**
   schedule:
     # daily at 8am Pacific (15:00 UTC)
     - cron: 0 15 * * *

--- a/examples/document_extraction/document_extraction.py
+++ b/examples/document_extraction/document_extraction.py
@@ -4,17 +4,17 @@ This example demonstrates how to extract structured metadata from unstructured
 document text using both ExtractSchema and Pydantic model approaches.
 """
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Extract metadata from document excerpts using semantic operations."""
     # Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="document_extraction",
         semantic=fc.SemanticConfig(
             language_models={

--- a/examples/enrichment/enrichment.py
+++ b/examples/enrichment/enrichment.py
@@ -1,11 +1,13 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     # Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="log_enrichment",
         semantic=fc.SemanticConfig(
             language_models= {

--- a/examples/feedback_clustering/feedback_clustering.py
+++ b/examples/feedback_clustering/feedback_clustering.py
@@ -5,13 +5,15 @@ to automatically cluster customer feedback into themes and generate summaries
 for each discovered category.
 """
 
+from typing import Optional
+
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Analyze customer feedback using semantic clustering and summarization."""
     # Configure session with both language models and embedding models
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="feedback_clustering",
         semantic=fc.SemanticConfig(
             language_models={

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import fenic as fc
 
 # Create schema for extracting error analysis information
@@ -31,9 +33,9 @@ ERROR_PATTERN_SCHEMA = fc.ExtractSchema([
     ])
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     # 1. Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="hello_debug",
         semantic=fc.SemanticConfig(
             language_models= {

--- a/examples/json_processing/json_processing.py
+++ b/examples/json_processing/json_processing.py
@@ -21,10 +21,13 @@ This showcases how Fenic bridges JSON processing with traditional DataFrame
 analytics for real-world use cases like audio transcript analysis.
 """
 
+from pathlib import Path
+from typing import Optional
+
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Process whisper transcript JSON data into structured DataFrames.
 
     This function demonstrates a complete JSON processing pipeline that:
@@ -43,7 +46,7 @@ def main():
         None: Prints results and analysis to console
     """
     # Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="json_processing",
         semantic=fc.SemanticConfig(
             language_models={
@@ -58,18 +61,13 @@ def main():
 
     # Create session
     session = fc.Session.get_or_create(config)
-
+    transcript_path = Path(__file__).parent / "whisper-transcript.json"
     print("🔧 JSON Processing with Fenic")
     print("=" * 50)
 
-    try:
-        # Try reading from source root first
-        with open("examples/json_processing/whisper-transcript.json", "r") as f:
-            json_content = f.read()
-    except FileNotFoundError:
-        # Fall back to current directory
-        with open("whisper-transcript.json", "r") as f:
-            json_content = f.read()
+    # Try reading from source root first
+    with open(transcript_path, "r") as f:
+        json_content = f.read()
 
     # Create dataframe with the JSON string
     df = session.create_dataframe([{"json_string": json_content}])

--- a/examples/markdown_processing/markdown_processing.py
+++ b/examples/markdown_processing/markdown_processing.py
@@ -12,11 +12,12 @@ We'll use the "Attention Is All You Need" paper to show:
 """
 
 from pathlib import Path
+from typing import Optional
 
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Process academic paper markdown content using fenic's specialized functions.
 
     This function demonstrates the key capabilities of fenic for processing structured markdown:
@@ -32,7 +33,7 @@ def main():
     The example uses the "Attention Is All You Need" paper to show real-world document processing.
     """
     # Configure session with semantic capabilities (not used in this example but shows proper setup)
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="markdown_processing",
         semantic=fc.SemanticConfig(
             language_models= {

--- a/examples/meeting_transcript_processing/transcript_processing.py
+++ b/examples/meeting_transcript_processing/transcript_processing.py
@@ -5,6 +5,8 @@ transcript processing capabilities, including format detection, parsing, and sem
 extraction of structured information from unstructured meeting content.
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 import fenic as fc
@@ -113,10 +115,10 @@ Emma (00:02:35)
 # Create DataFrame with meeting transcripts
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Process meeting transcripts to extract insights using fenic's semantic operations."""
     # 1. Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="meeting_transcript_processing",
         semantic=fc.SemanticConfig(
             language_models={

--- a/examples/named_entity_recognition/ner.py
+++ b/examples/named_entity_recognition/ner.py
@@ -1,13 +1,14 @@
 import re
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     # Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="security_vulnerability_ner",
         semantic=fc.SemanticConfig(
             language_models= {

--- a/examples/news_analysis/news_analysis.py
+++ b/examples/news_analysis/news_analysis.py
@@ -14,20 +14,22 @@ Usage:
     python news_analysis.py
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 import fenic as fc
 from fenic import col, lit
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Main analysis pipeline for news article bias detection."""
     # Configure session with semantic capabilities
     # Set your `OPENAI_API_KEY` environment variable.
     # Alternatively, you can run the example with an Gemini (`GEMINI_API_KEY`) model by uncommenting the provided additional model configurations.
     # Using an Anthropic model requires installing fenic with the `anthropic` extra package, and setting the `ANTHROPIC_API_KEY` environment variable
     print("🔧 Configuring fenic session...")
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="news_analysis",
         semantic=fc.SemanticConfig(
             language_models={

--- a/examples/podcast_summarization/podcast_summarization.py
+++ b/examples/podcast_summarization/podcast_summarization.py
@@ -6,14 +6,15 @@ and few-shot prompting, and recursive summarization techniques.
 """
 
 from pathlib import Path
+from typing import Optional
 
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Process podcast transcript to generate various types of summaries."""
     # 1. Configure session with semantic capabilities
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="podcast_summarization",
         semantic=fc.SemanticConfig(
             language_models={

--- a/examples/semantic_joins/semantic_joins.py
+++ b/examples/semantic_joins/semantic_joins.py
@@ -4,13 +4,15 @@ This example demonstrates how to perform LLM-powered semantic joins that use
 natural language reasoning to match data across different DataFrames.
 """
 
+from typing import Optional
+
 import fenic as fc
 
 
-def main():
+def main(config: Optional[fc.SessionConfig] = None):
     """Demonstrate semantic join capabilities using LLM reasoning."""
     # Configure session with language models (no embeddings needed)
-    config = fc.SessionConfig(
+    config = config or fc.SessionConfig(
         app_name="semantic_joins",
         semantic=fc.SemanticConfig(
             language_models={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,30 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
+def examples_session_config(app_name) -> SessionConfig:
+    """Creates a test session config."""
+    embedding_model = OpenAIModelConfig(
+        model_name="text-embedding-3-small",
+        rpm=3000,
+        tpm=1_000_000
+    )
+    # limits are small so we can run the examples in parallel
+    flash_lite_model = GoogleGLAModelConfig(
+        model_name="gemini-2.0-flash-lite",
+        rpm=250,
+        tpm=125_000,
+    )
+    return SessionConfig(
+        app_name=app_name,
+        semantic=SemanticConfig(
+            language_models={
+                "flash-lite": flash_lite_model,
+            },
+            embedding_models={"oai-small": embedding_model},
+        ),
+    )
+
+@pytest.fixture
 def multi_model_local_session_config(app_name, request) -> SessionConfig:
     """Creates a test session config."""
     model_provider = ModelProvider(request.config.getoption(MODEL_PROVIDER_ARG))

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,8 +25,8 @@ def get_example_scripts():
 
 # This smoke test runs each script we provide as examples to ensure they run without errors after changes.
 @pytest.mark.parametrize("script_path", get_example_scripts())
-def test_example_script(script_path):
+def test_example_script(script_path, examples_session_config):
     """Test that each example script's main function runs without errors."""
     module = import_module_from_path(script_path)
     assert hasattr(module, "main"), f"Script {script_path} does not have a main() function"
-    module.main()  # Run the main function
+    module.main(examples_session_config)  # Run the main function


### PR DESCRIPTION
### TL;DR

Added optional `SessionConfig` parameter to all example scripts to enable testing with custom configurations.

### What changed?

- Modified all example scripts to accept an optional `SessionConfig` parameter in their `main()` functions
- Updated the implementation to use the provided config or create a default one if none is provided
- Fixed file path handling in the JSON processing example to use `Path` for more reliable file location
- Added a `gemini_session_config` fixture in `conftest.py` for testing examples
- Updated the example test to pass the test configuration to each example's main function

### How to test?

Run the example tests with:
```bash
pytest tests/examples/test_examples.py
```

You can also manually test any example by importing and calling its main function with a custom config:
```python
import fenic as fc
from examples.hello_world.hello_world import main

custom_config = fc.SessionConfig(...)
main(custom_config)
```

### Why make this change?

This change improves testability of the example scripts by allowing them to run with controlled configurations during testing. It also makes the examples more flexible for users who want to reuse the example code with their own configurations. The standardized parameter pattern across all examples creates consistency and allows for better integration testing.