### PR TITLE
feat: Consume query metrics

### DIFF
--- a/src/fenic/_backends/cloud/execution.py
+++ b/src/fenic/_backends/cloud/execution.py
@@ -90,12 +90,7 @@ class CloudExecution(BaseExecution):
             self.session_state.asyncio_loop,
         )
         execution_id = future.result()
-
-        result_future = asyncio.run_coroutine_threadsafe(
-            self._get_execution_result_from_arrow(execution_id),
-            self.session_state.asyncio_loop,
-        )
-        df = result_future.result()
+        df = self._get_execution_result_from_arrow(execution_id)
 
         return df, self._get_query_execution_metrics(execution_id)
 
@@ -364,7 +359,7 @@ class CloudExecution(BaseExecution):
             ) from e
         return result_response
 
-    async def _get_execution_result_from_arrow(self, execution_id: str) -> pl.DataFrame:
+    def _get_execution_result_from_arrow(self, execution_id: str) -> pl.DataFrame:
         """Get the result of an execution as a Polars DataFrame."""
         try:
             arrow_client = pa.flight.connect(

--- a/src/fenic/_backends/utils/catalog_utils.py
+++ b/src/fenic/_backends/utils/catalog_utils.py
@@ -1,7 +1,21 @@
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
+from fenic_cloud.hasura_client.generated_graphql_client import Client
+from fenic_cloud.hasura_client.generated_graphql_client.list_query_execution_metric_by_query_execution_id import (
+    ListQueryExecutionMetricByQueryExecutionId,
+)
+
 from fenic.core.error import ValidationError
+from fenic.core.metrics import (
+    LMMetrics,
+    PhysicalPlanRepr,
+    QueryMetrics,
+    RMMetrics,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class QualifiedNameParser:
@@ -140,3 +154,38 @@ def compare_object_names(object_name_1: str, object_name_2: str) -> bool:
 def normalize_object_name(name: str) -> str:
     """Normalize an object name, handling DuckDB's naming conventions."""
     return name.casefold()
+
+
+async def get_query_execution_metrics(client: Client, execution_id: str) -> QueryMetrics:
+    """Get query execution metrics from the cloud catalog."""
+    query_metrics = QueryMetrics(
+        execution_time_ms=0,
+        num_output_rows=0,
+        total_lm_metrics=LMMetrics(),
+        total_rm_metrics=RMMetrics(),
+        _plan_repr=PhysicalPlanRepr(operator_id="empty"),
+    )
+
+    cloud_query_metrics: ListQueryExecutionMetricByQueryExecutionId = await client.list_query_execution_metric_by_query_execution_id(execution_id)
+    if cloud_query_metrics.typedef_query_execution_by_pk.query_execution_metrics:
+        for metric in cloud_query_metrics.typedef_query_execution_by_pk.query_execution_metrics:
+            if metric.metric_name == "execution_time_ms":
+                query_metrics.execution_time_ms = metric.metric_value
+            elif metric.metric_name == "num_output_rows":
+                query_metrics.num_output_rows = metric.metric_value
+            elif metric.metric_name == "lm_num_uncached_input_tokens":
+                query_metrics.total_lm_metrics.num_uncached_input_tokens = metric.metric_value
+            elif metric.metric_name == "lm_num_cached_input_tokens":
+                query_metrics.total_lm_metrics.num_cached_input_tokens = metric.metric_value
+            elif metric.metric_name == "lm_num_output_tokens":
+                query_metrics.total_lm_metrics.num_output_tokens = metric.metric_value
+            elif metric.metric_name == "rm_num_input_tokens":
+                query_metrics.total_rm_metrics.num_input_tokens = metric.metric_value
+            elif metric.metric_name == "rm_num_requests":
+                query_metrics.total_rm_metrics.num_requests = metric.metric_value
+            elif metric.metric_name == "rm_cost":
+                query_metrics.total_rm_metrics.cost = metric.metric_value
+    else:
+        logger.error(f"couldn't find metrics for execution_id: {execution_id}")
+
+    return query_metrics

--- a/tests/_backends/cloud/test_cloud_execution.py
+++ b/tests/_backends/cloud/test_cloud_execution.py
@@ -13,6 +13,12 @@ from fenic.api.session.config import OpenAIModelConfig
 pytest.importorskip("grpc")
 pytest.importorskip("fenic_cloud.hasura_client")
 
+from fenic_cloud.hasura_client.generated_graphql_client.list_query_execution_metric_by_query_execution_id import (
+    ListQueryExecutionMetricByQueryExecutionId,
+)
+from fenic_cloud.hasura_client.generated_graphql_client.list_query_execution_metric_by_query_execution_id import (
+    ListQueryExecutionMetricByQueryExecutionIdTypedefQueryExecutionByPk as QueryExecutionMetricByPk,
+)
 from fenic_cloud.protos.engine.v1.engine_pb2 import (
     ConfigSessionRequest,
     ConfigSessionResponse,
@@ -105,6 +111,13 @@ class MockHasuraUserClient:
 
     def query_execution_details(self, query_execution_id):
         return MockAsyncIterator(self.updates)
+
+    async def list_query_execution_metric_by_query_execution_id(self, query_execution_id):
+        return ListQueryExecutionMetricByQueryExecutionId(
+            typedef_query_execution_by_pk=QueryExecutionMetricByPk(
+                query_execution_metrics=[]
+            )
+        )
 
 
 class MockHasuraClient:

--- a/tools/test_cloud_session_external_source.py
+++ b/tools/test_cloud_session_external_source.py
@@ -127,6 +127,12 @@ def main(): # noqa: D103
     df = df.select("*", text.concat(col("group") + col("age")).alias("group_age"))
     df.show()
 
+    logger.info("Testing collect")
+    df = session.create_dataframe(data)
+    df = df.select("*", text.concat(col("group") + col("age")).alias("group_age"))
+    result = df.collect()
+    logger.info("Collect result: %s", result)
+
     logger.info("Testing simple to_polars")
     df = session.create_dataframe(data)
     result = df.to_polars()


### PR DESCRIPTION
1. For cloud execution, the Query Metrics are available in the catalog, they can be retrieved using the execution_id
2. Reading the arrow results for an execution using collect doesn't have to be async (pyarrow has its own threading model)