### PR TITLE
fix: fix bug in session.sql() when handling columns with embedding types

### DIFF
--- a/src/fenic/core/_utils/schema.py
+++ b/src/fenic/core/_utils/schema.py
@@ -185,7 +185,7 @@ def convert_custom_dtype_to_polars(
     elif custom_dtype == JsonType:
         return pl.String
     elif isinstance(custom_dtype, EmbeddingType):
-        return pl.Array(pl.Float32, list_length=custom_dtype.dimensions)
+        return pl.Array(pl.Float32, custom_dtype.dimensions)
     else:
         raise ValueError(f"Unsupported custom data type: {custom_dtype}")
 


### PR DESCRIPTION
This bug occurred when using session.sql() on a DataFrame that included an embedding column. The issue arose during schema conversion—specifically, when converting the custom schema to a Polars schema to construct an empty DataFrame for planning the DuckDB query.

The failure was caused by a typo in the pl.Array constructor. This fix corrects the typo and adds a test to cover this code path and ensure proper handling of embedding types during SQL planning and during schema conversion to Polars dtypes more generally.