### PR TITLE
fix: user should not have to provide admin secret for cloud session

### DIFF
--- a/src/fenic/_backends/cloud/manager.py
+++ b/src/fenic/_backends/cloud/manager.py
@@ -115,7 +115,6 @@ class CloudSessionManager:
         hasura_client = HasuraClient(
             graphql_uri=settings.hasura_graphql_uri,
             graphql_ws_uri=settings.hasura_graphql_ws_uri,
-            admin_secret=settings.hasura_admin_secret,
         )
         return CloudSessionManagerConfigDependencies(
             settings=settings,

--- a/src/fenic/_backends/cloud/settings.py
+++ b/src/fenic/_backends/cloud/settings.py
@@ -7,7 +7,6 @@ from pydantic_settings import BaseSettings
 class CloudSettings(BaseSettings):
     client_id: str = Field(..., alias="TYPEDEF_CLIENT_ID")
     client_secret: str = Field(..., alias="TYPEDEF_CLIENT_SECRET")
-    hasura_admin_secret: str = Field(..., alias="HASURA_GRAPHQL_ADMIN_SECRET")
     auth_provider_uri: str = Field(..., alias="CLOUD_SESSION_AUTH_PROVIDER_URI")
     typedef_instance: str = Field(
         default="dev1", alias="CLOUD_SESSION_TYPEDEF_INSTANCE"


### PR DESCRIPTION
The user should not have to provide the admin secret when configuring `CloudSettings()` -- the client side code should only ever use the `get_user_client()` function that takes the auth token as input and returns a client that uses the `Authorization` header accordingly. 