### PR TITLE
fix: support google models in cloud

### DIFF
--- a/src/fenic/__init__.py
+++ b/src/fenic/__init__.py
@@ -3,6 +3,7 @@
 from fenic.api import (
     AnthropicModelConfig,
     Catalog,
+    CloudConfig,
     Column,
     ColumnOrName,
     DataFrame,
@@ -92,6 +93,7 @@ __all__ = [
     # Session
     "Session",
     "SessionConfig",
+    "CloudConfig",
     "OpenAIModelConfig",
     "AnthropicModelConfig",
     "GoogleGLAModelConfig",

--- a/src/fenic/api/__init__.py
+++ b/src/fenic/api/__init__.py
@@ -39,6 +39,7 @@ from fenic.api.io import DataFrameReader, DataFrameWriter
 from fenic.api.lineage import Lineage
 from fenic.api.session import (
     AnthropicModelConfig,
+    CloudConfig,
     GoogleGLAModelConfig,
     GoogleVertexModelConfig,
     OpenAIModelConfig,
@@ -56,6 +57,7 @@ __all__ = [
     "GoogleGLAModelConfig",
     "GoogleVertexModelConfig",
     "SemanticConfig",
+    "CloudConfig",
     # IO
     "DataFrameReader",
     "DataFrameWriter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from fenic import (
+    GoogleVertexModelConfig,
     SemanticConfig,
     Session,
     SessionConfig,
@@ -17,7 +18,6 @@ from fenic._inference.model_catalog import ModelProvider
 from fenic.api.session.config import (
     AnthropicModelConfig,
     GoogleGLAModelConfig,
-    GoogleVertexModelConfig,
     OpenAIModelConfig,
 )
 
@@ -153,14 +153,16 @@ def examples_session_config(app_name) -> SessionConfig:
 def multi_model_local_session_config(app_name, request) -> SessionConfig:
     """Creates a test session config."""
     model_provider = ModelProvider(request.config.getoption(MODEL_PROVIDER_ARG))
-    # these limits are purposely low so we don't consume our entire project limit while running multiple tests in multiple branches
-    if model_provider == ModelProvider.OPENAI:
-        language_models = {
-            "model_1": OpenAIModelConfig(
+    nano = OpenAIModelConfig(
                 model_name="gpt-4.1-nano",
                 rpm=250,
                 tpm=50_000
-            ),
+            )
+    # these limits are purposely low so we don't consume our entire project limit while running multiple tests in multiple branches
+
+    if model_provider == ModelProvider.OPENAI:
+        language_models = {
+            "model_1": nano,
             "model_2": OpenAIModelConfig(
                 model_name="gpt-4.1-mini",
                 rpm=250,
@@ -169,11 +171,7 @@ def multi_model_local_session_config(app_name, request) -> SessionConfig:
         }
     elif model_provider == ModelProvider.ANTHROPIC:
         language_models = {
-            "model_1": OpenAIModelConfig(
-                model_name="gpt-4.1-nano",
-                rpm=500,
-                tpm=100_000
-            ),
+            "model_1": nano,
             "model_2" : AnthropicModelConfig(
                 model_name="claude-3-5-haiku-latest",
                 rpm=500,
@@ -183,11 +181,7 @@ def multi_model_local_session_config(app_name, request) -> SessionConfig:
         }
     elif model_provider == ModelProvider.GOOGLE_GLA:
         language_models = {
-            "model_1": OpenAIModelConfig(
-                model_name="gpt-4.1-nano",
-                rpm=500,
-                tpm=100_000
-            ),
+            "model_1": nano,
             "model_2" : GoogleGLAModelConfig(
                 model_name=request.config.getoption(MODEL_NAME_ARG),
                 rpm=1000,
@@ -196,12 +190,8 @@ def multi_model_local_session_config(app_name, request) -> SessionConfig:
         }
     elif model_provider == ModelProvider.GOOGLE_VERTEX:
         language_models = {
-            "model_1": OpenAIModelConfig(
-                model_name="gpt-4.1-nano",
-                rpm=500,
-                tpm=100_000
-            ),
-            "model_2" : GoogleGLAModelConfig(
+            "model_1": nano,
+            "model_2" : GoogleVertexModelConfig(
                 model_name=request.config.getoption(MODEL_NAME_ARG),
                 rpm=1000,
                 tpm=500_000,
@@ -221,7 +211,7 @@ def multi_model_local_session_config(app_name, request) -> SessionConfig:
             default_language_model="model_1",
             embedding_models={"oai-small": embedding_model},
             default_embedding_model="oai-small",
-        ),
+        )
     )
 
 @pytest.fixture


### PR DESCRIPTION
### TL;DR

Added support for Google GLA and Vertex AI models with proper API key handling.

### What changed?

- Added `CloudConfig` to the public API exports
- Enhanced model provider configuration in `EngineConfig` to support Google models:
  - Added special handling for Google GLA models to check for either `GOOGLE_API_KEY` or `GEMINI_API_KEY`
  - Added support for Google Vertex models which require `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` environment variables
- Updated the model provider detection logic to handle Google model configurations
- Refactored test configurations to reduce code duplication by creating a reusable OpenAI nano model configuration
