### PR TITLE
feat: convert AggregateExpr -> AggregateFunction 

### DIFF
--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -25,7 +25,6 @@ from fenic._backends.local.semantic_operators import Reduce as SemanticReduce
 from fenic._backends.local.template import TemplateFormatReader
 from fenic._backends.schema_serde import serialize_data_type
 from fenic.core._logical_plan.expressions import (
-    AggregateExpr,
     AliasExpr,
     AnalyzeSentimentExpr,
     ArithmeticExpr,
@@ -96,6 +95,7 @@ from fenic.core._logical_plan.expressions import (
     UDFExpr,
     WhenExpr,
 )
+from fenic.core._logical_plan.signatures import AggregateFunction
 from fenic.core._utils.extract import convert_extract_schema_to_pydantic_type
 from fenic.core._utils.schema import (
     convert_custom_dtype_to_polars,
@@ -270,8 +270,8 @@ class ExprConverter:
         else:
             return converted_expr.mean()
 
-    @_convert_expr.register(AggregateExpr)
-    def _convert_aggregate_expr(self, logical: AggregateExpr) -> pl.Expr:
+    @_convert_expr.register(AggregateFunction)
+    def _convert_aggregate_expr(self, logical: AggregateFunction) -> pl.Expr:
         # Special handling for AvgExpr
         if isinstance(logical, AvgExpr):
             return self._convert_avg_expr(logical)

--- a/src/fenic/api/dataframe/_base_grouped_data.py
+++ b/src/fenic/api/dataframe/_base_grouped_data.py
@@ -7,7 +7,8 @@ from typing import Dict, List, Tuple, Union
 
 from fenic.api.column import Column
 from fenic.api.functions import avg, col, count, max, min, sum
-from fenic.core._logical_plan.expressions import AggregateExpr, AliasExpr
+from fenic.core._logical_plan.expressions import AliasExpr
+from fenic.core._logical_plan.signatures import AggregateFunction
 
 
 class BaseGroupedData:
@@ -42,11 +43,11 @@ class BaseGroupedData:
         """Process Column-style aggregation expressions."""
         agg_exprs = []
         for column in cols:
-            if isinstance(column._logical_expr, AggregateExpr):
+            if isinstance(column._logical_expr, AggregateFunction):
                 column = column.alias(str(column._logical_expr))
                 agg_exprs.append(column._logical_expr)
             elif isinstance(column._logical_expr, AliasExpr) and isinstance(
-                column._logical_expr.expr, AggregateExpr
+                column._logical_expr.expr, AggregateFunction
             ):
                 agg_exprs.append(column._logical_expr)
             else:

--- a/src/fenic/core/_logical_plan/expressions/__init__.py
+++ b/src/fenic/core/_logical_plan/expressions/__init__.py
@@ -1,8 +1,5 @@
 """Expression classes for internal implementation of column operations."""
 
-from fenic.core._logical_plan.expressions.aggregate import (
-    AggregateExpr as AggregateExpr,
-)
 from fenic.core._logical_plan.expressions.aggregate import AvgExpr as AvgExpr
 from fenic.core._logical_plan.expressions.aggregate import CountExpr as CountExpr
 from fenic.core._logical_plan.expressions.aggregate import FirstExpr as FirstExpr
@@ -81,9 +78,6 @@ from fenic.core._logical_plan.expressions.semantic import (
 )
 from fenic.core._logical_plan.expressions.semantic import (
     SemanticExtractExpr as SemanticExtractExpr,
-)
-from fenic.core._logical_plan.expressions.semantic import (
-    SemanticFunction as SemanticFunction,
 )
 from fenic.core._logical_plan.expressions.semantic import (
     SemanticMapExpr as SemanticMapExpr,

--- a/src/fenic/core/_logical_plan/expressions/aggregate.py
+++ b/src/fenic/core/_logical_plan/expressions/aggregate.py
@@ -16,6 +16,7 @@ from fenic.core.types import (
     EmbeddingType,
 )
 
+
 class SumExpr(AggregateFunction):
     function_name = "sum"
 

--- a/src/fenic/core/_logical_plan/expressions/aggregate.py
+++ b/src/fenic/core/_logical_plan/expressions/aggregate.py
@@ -7,182 +7,94 @@ if TYPE_CHECKING:
 
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.expressions.basic import LiteralExpr
+from fenic.core._logical_plan.signatures.function_base import AggregateFunction
 from fenic.core.types import (
     ArrayType,
-    BooleanType,
     ColumnField,
+    DataType,
     DoubleType,
     EmbeddingType,
-    FloatType,
-    IntegerType,
-    StringType,
 )
 
-SUMMABLE_TYPES = (IntegerType, FloatType, DoubleType, BooleanType)
+class SumExpr(AggregateFunction):
+    function_name = "sum"
 
-
-class AggregateExpr(LogicalExpr):
-    def __init__(self, agg_name: str, expr: LogicalExpr):
-        self.agg_name = agg_name
-        self.expr = expr
-
-    def __str__(self):
-        return f"{self.agg_name}({str(self.expr)})"
-
-    def children(self) -> List[LogicalExpr]:
-        return [self.expr]
-
-
-class MdGroupSchemaExpr(AggregateExpr):
     def __init__(self, expr: LogicalExpr):
-        super().__init__("md_group_schema", expr)
-
-    def _validate_types(self, plan: LogicalPlan):
-        input_field = self.expr.to_column_field(plan)
-        if input_field.data_type != StringType:
-            raise TypeError(
-                f"md_group_schema requires a string input, got {input_field.data_type}"
-            )
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
-        return ColumnField(name=str(self), data_type=StringType)
+        super().__init__(expr)
 
 
-class SumExpr(AggregateExpr):
+class AvgExpr(AggregateFunction):
+    function_name = "avg"
+
     def __init__(self, expr: LogicalExpr):
-        super().__init__("sum", expr)
-
-    def _validate_types(self, plan: LogicalPlan):
-        expr_type = self.expr.to_column_field(plan).data_type
-        if expr_type not in SUMMABLE_TYPES:
-            raise TypeError(
-                f"Type mismatch: Cannot apply sum function to non-numeric types. "
-                f"Type: {expr_type}. "
-                f"Only numeric types ({', '.join(t for t in SUMMABLE_TYPES)}) are supported."
-            )
-
-        return
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
-        return ColumnField(str(self), self.expr.to_column_field(plan).data_type)
-
-
-class AvgExpr(AggregateExpr):
-    def __init__(self, expr: LogicalExpr):
-        super().__init__("avg", expr)
+        super().__init__(expr)
         self.input_type = None  # Will be set during validation
 
-    def _validate_types(self, plan: LogicalPlan):
-        expr_type = self.expr.to_column_field(plan).data_type
-        self.input_type = expr_type
-
-        if expr_type not in SUMMABLE_TYPES and not isinstance(expr_type, EmbeddingType):
-            raise TypeError(
-                f"Type mismatch: Cannot apply avg function to non-numeric types. "
-                f"Type: {expr_type}. "
-                f"Only numeric types ({', '.join(str(t) for t in SUMMABLE_TYPES)}) and EmbeddingType are supported."
-            )
-        return
-
     def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+        """Use signature to validate and get return type, storing input type for transpiler."""
+        # Get the input type first
+        self.input_type = self.expr.to_column_field(plan).data_type
 
-        # If averaging embeddings, return the same embedding type
-        if isinstance(self.input_type, EmbeddingType):
-            return ColumnField(str(self), self.input_type)
+        # Now use the parent implementation to validate and get return type
+        return super().to_column_field(plan)
+
+    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+        """Return EmbeddingType for embeddings, DoubleType for numeric types."""
+        input_type = arg_types[0]
+        if isinstance(input_type, EmbeddingType):
+            return input_type
         else:
-            return ColumnField(str(self), DoubleType)
+            return DoubleType
 
 
-class MinExpr(AggregateExpr):
+class MinExpr(AggregateFunction):
+    function_name = "min"
+
     def __init__(self, expr: LogicalExpr):
-        super().__init__("min", expr)
+        super().__init__(expr)
 
-    def _validate_types(self, plan: LogicalPlan):
-        expr_type = self.expr.to_column_field(plan).data_type
 
-        if expr_type not in SUMMABLE_TYPES:
+class MaxExpr(AggregateFunction):
+    function_name = "max"
+
+    def __init__(self, expr: LogicalExpr):
+        super().__init__(expr)
+
+
+class CountExpr(AggregateFunction):
+    function_name = "count"
+
+    def __init__(self, expr: LogicalExpr):
+        super().__init__(expr)
+
+
+class ListExpr(AggregateFunction):
+    function_name = "list"
+
+    def __init__(self, expr: LogicalExpr):
+        # Check for literal expressions upfront
+        if isinstance(expr, LiteralExpr):
             raise TypeError(
-                f"Type mismatch: Cannot apply min function to non-numeric types. "
-                f"Type: {expr_type}. "
-                f"Only numeric types ({', '.join(t for t in SUMMABLE_TYPES)}) are supported."
+                "Type mismatch: Cannot apply collect_list function to literal value. "
+                "Only non-literal values are supported."
             )
-        return
+        super().__init__(expr)
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
-        return ColumnField(str(self), self.expr.to_column_field(plan).data_type)
+    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+        """Return ArrayType with element type matching the input type."""
+        return ArrayType(arg_types[0])
 
+    def __str__(self) -> str:
+        return f"collect_list({self.expr})"
 
-class MaxExpr(AggregateExpr):
+class FirstExpr(AggregateFunction):
+    function_name = "first"
+
     def __init__(self, expr: LogicalExpr):
-        super().__init__("max", expr)
+        super().__init__(expr)
 
-    def _validate_types(self, plan: LogicalPlan):
-        expr_type = self.expr.to_column_field(plan).data_type
+class StdDevExpr(AggregateFunction):
+    function_name = "stddev"
 
-        if expr_type not in SUMMABLE_TYPES:
-            raise TypeError(
-                f"Type mismatch: Cannot apply max function to non-numeric types. "
-                f"Type: {expr_type}. "
-                f"Only numeric types ({', '.join(t for t in SUMMABLE_TYPES)}) are supported."
-            )
-        return
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
-        return ColumnField(str(self), self.expr.to_column_field(plan).data_type)
-
-
-class CountExpr(AggregateExpr):
     def __init__(self, expr: LogicalExpr):
-        super().__init__("count", expr)
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self.expr.to_column_field(plan)
-        return ColumnField(str(self), IntegerType)
-
-    def children(self) -> List[LogicalExpr]:
-        return [self.expr]
-
-
-class ListExpr(AggregateExpr):
-    def __init__(self, expr: LogicalExpr):
-        super().__init__("collect_list", expr)
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        if isinstance(self.expr, LiteralExpr):
-            raise TypeError(
-                f"Type mismatch: Cannot apply collect_list function to literal value."
-                f"Type: {self.expr.to_column_field(plan).data_type}. "
-                f"Only non-literal values are supported."
-            )
-        else:
-            return ColumnField(
-                str(self), ArrayType(self.expr.to_column_field(plan).data_type)
-            )
-
-class FirstExpr(AggregateExpr):
-    def __init__(self, expr: LogicalExpr):
-        super().__init__("first", expr)
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return ColumnField(str(self), self.expr.to_column_field(plan).data_type)
-
-class StdDevExpr(AggregateExpr):
-    def __init__(self, expr: LogicalExpr):
-        super().__init__("stddev", expr)
-
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return ColumnField(str(self), DoubleType)
-
-    def _validate_types(self, plan: LogicalPlan):
-        expr_type = self.expr.to_column_field(plan).data_type
-        if expr_type not in SUMMABLE_TYPES:
-            raise TypeError(
-                f"Type mismatch: Cannot apply stddev function to non-numeric types. "
-                f"Type: {expr_type}. "
-                f"Only numeric types ({', '.join(str(t) for t in SUMMABLE_TYPES)}) are supported."
-            )
+        super().__init__(expr)

--- a/src/fenic/core/_logical_plan/expressions/basic.py
+++ b/src/fenic/core/_logical_plan/expressions/basic.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 
 from fenic.core._logical_plan.expressions.base import LogicalExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 from fenic.core.error import PlanError, TypeMismatchError
 from fenic.core.types import (
     ArrayType,

--- a/src/fenic/core/_logical_plan/expressions/embedding.py
+++ b/src/fenic/core/_logical_plan/expressions/embedding.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from fenic.core._logical_plan import LogicalPlan
 
 from fenic.core._logical_plan.expressions.base import LogicalExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 from fenic.core.error import ValidationError
 from fenic.core.types import (
     ColumnField,

--- a/src/fenic/core/_logical_plan/expressions/json.py
+++ b/src/fenic/core/_logical_plan/expressions/json.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 from fenic._polars_plugins import py_validate_jq_query  # noqa: F401
 from fenic.core._logical_plan.expressions.base import LogicalExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 from fenic.core.error import ValidationError
 
 

--- a/src/fenic/core/_logical_plan/expressions/markdown.py
+++ b/src/fenic/core/_logical_plan/expressions/markdown.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     pass
 
 from fenic.core._logical_plan.expressions.base import LogicalExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 
 
 class MdToJsonExpr(ScalarFunction):

--- a/src/fenic/core/_logical_plan/expressions/semantic.py
+++ b/src/fenic/core/_logical_plan/expressions/semantic.py
@@ -20,10 +20,10 @@ from fenic._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
-from fenic.core._logical_plan.expressions.aggregate import AggregateExpr
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.expressions.basic import ColumnExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures import AggregateFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 from fenic.core._utils.extract import convert_extract_schema_to_pydantic_type
 from fenic.core._utils.schema import convert_pydantic_type_to_custom_struct_type
 from fenic.core.error import ValidationError
@@ -35,7 +35,14 @@ from fenic.core.types.extract_schema import ExtractSchema
 from fenic.core.types.schema import ColumnField
 
 
-class SemanticFunction(ScalarFunction):
+class SemanticFunction:
+    """Marker class for semantic functions that use LLM models.
+
+    Provides common functionality for completion parameter validation
+    and model configuration handling.
+    """
+
+class SemanticScalarFunction(SemanticFunction, ScalarFunction):
     """Base class for semantic functions that use LLM models.
     
     Provides common functionality for completion parameter validation
@@ -58,8 +65,24 @@ class SemanticFunction(ScalarFunction):
         result = super().to_column_field(plan)
         return result
 
+class SemanticAggregateFunction(SemanticFunction, AggregateFunction):
+    def __init__(self, *args: LogicalExpr):
+        """Initialize semantic function."""
+        super().__init__(*args)
 
-class SemanticMapExpr(SemanticFunction):
+    @abstractmethod
+    def _validate_completion_parameters(self, plan: LogicalPlan):
+        pass
+
+    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+        """Handle signature validation and completion parameter validation."""
+        # Common validation for all semantic functions
+        self._validate_completion_parameters(plan)
+        # Call parent to handle signature validation
+        result = super().to_column_field(plan)
+        return result
+
+class SemanticMapExpr(SemanticScalarFunction):
     function_name = "semantic.map"
     
     def __init__(
@@ -111,7 +134,7 @@ class SemanticMapExpr(SemanticFunction):
         return self.exprs
 
 
-class SemanticExtractExpr(SemanticFunction):
+class SemanticExtractExpr(SemanticScalarFunction):
     function_name = "semantic.extract"
     
     def __init__(
@@ -159,7 +182,7 @@ class SemanticExtractExpr(SemanticFunction):
         return [self.expr]
 
 
-class SemanticPredExpr(SemanticFunction):
+class SemanticPredExpr(SemanticScalarFunction):
     function_name = "semantic.predicate"
     
     def __init__(
@@ -201,7 +224,7 @@ class SemanticPredExpr(SemanticFunction):
         return self.exprs
 
 
-class SemanticReduceExpr(SemanticFunction, AggregateExpr):
+class SemanticReduceExpr(SemanticAggregateFunction):
     function_name = "semantic.reduce"
     
     def __init__(self,
@@ -246,7 +269,7 @@ class SemanticReduceExpr(SemanticFunction, AggregateExpr):
         return self.exprs
 
 
-class SemanticClassifyExpr(SemanticFunction):
+class SemanticClassifyExpr(SemanticScalarFunction):
     function_name = "semantic.classify"
     
     def __init__(
@@ -327,7 +350,7 @@ class SemanticClassifyExpr(SemanticFunction):
         return label_value.upper().replace(" ", "_")
 
 
-class AnalyzeSentimentExpr(SemanticFunction):
+class AnalyzeSentimentExpr(SemanticScalarFunction):
     function_name = "semantic.analyze_sentiment"
     
     def __init__(
@@ -354,7 +377,7 @@ class AnalyzeSentimentExpr(SemanticFunction):
         return [self.expr]
 
 
-class EmbeddingsExpr(SemanticFunction):
+class EmbeddingsExpr(SemanticScalarFunction):
     """Expression for generating embeddings for a string column.
 
     This expression creates a new column of embeddings for each value in the input string column.

--- a/src/fenic/core/_logical_plan/expressions/text.py
+++ b/src/fenic/core/_logical_plan/expressions/text.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from pydantic import BaseModel, Field
 
 from fenic.core._logical_plan.expressions.base import LogicalExpr
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
+from fenic.core._logical_plan.signatures.function_base import ScalarFunction
 from fenic.core.types import (
     DataType,
     StringType,

--- a/src/fenic/core/_logical_plan/optimizer/semantic_filter_rewrite_rule.py
+++ b/src/fenic/core/_logical_plan/optimizer/semantic_filter_rewrite_rule.py
@@ -1,19 +1,19 @@
 from typing import List, Tuple
 
 from fenic.core._logical_plan.expressions import (
-    AggregateExpr,
     BooleanExpr,
     LogicalExpr,
     Operator,
     SortExpr,
 )
-from fenic.core._logical_plan.expressions.semantic import SemanticFunction
+from fenic.core._logical_plan.expressions.semantic import SemanticScalarFunction
 from fenic.core._logical_plan.optimizer.base import (
     LogicalPlanOptimizerRule,
     OptimizationResult,
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core._logical_plan.plans.transform import Filter
+from fenic.core._logical_plan.signatures import AggregateFunction
 
 
 class SemanticFilterRewriteRule(LogicalPlanOptimizerRule):
@@ -134,11 +134,11 @@ class SemanticFilterRewriteRule(LogicalPlanOptimizerRule):
     @staticmethod
     def count_semantic_predicate_expressions(expr: LogicalExpr) -> int:
         """Count the number of semantic predicate expressions in the expression tree."""
-        if isinstance(expr, AggregateExpr):
-            raise ValueError("AggregateExpr cannot be used in filter predicates.")
-        elif isinstance(expr, SortExpr):
+        if isinstance(expr, AggregateFunction):
+            raise ValueError("AggregateFunction cannot be used in filter predicates.")
+        if isinstance(expr, SortExpr):
             raise ValueError("SortExpr cannot be used in filter predicates.")
-        return int(isinstance(expr, SemanticFunction)) + sum(
+        return int(isinstance(expr, SemanticScalarFunction)) + sum(
             SemanticFilterRewriteRule.count_semantic_predicate_expressions(child)
             for child in expr.children()
         )

--- a/src/fenic/core/_logical_plan/plans/aggregate.py
+++ b/src/fenic/core/_logical_plan/plans/aggregate.py
@@ -1,12 +1,12 @@
 from typing import List
 
 from fenic.core._logical_plan.expressions import (
-    AggregateExpr,
     AliasExpr,
     LogicalExpr,
     SortExpr,
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.signatures import AggregateFunction
 from fenic.core.types import Schema
 
 
@@ -21,7 +21,7 @@ class Aggregate(LogicalPlan):
         self._group_exprs = group_exprs
         self._agg_exprs = agg_exprs
         for expr in agg_exprs:
-            if not isinstance(expr.expr, AggregateExpr):
+            if not isinstance(expr.expr, AggregateFunction):
                 raise ValueError(f"Expression {expr} is not an aggregation")
             _validate_agg_expr(expr.expr, group_exprs)
         for expr in group_exprs:
@@ -58,7 +58,7 @@ def _validate_agg_expr(
     in_agg_function: bool = False,
 ):
     """Validate aggregation expressions."""
-    if isinstance(expr, AggregateExpr):
+    if isinstance(expr, AggregateFunction):
         if in_agg_function:
             raise ValueError(
                 f"Nested aggregation functions are not allowed. Found inner aggregation '{expr.children()[0]}' inside outer aggregation '{expr}'. "
@@ -74,7 +74,7 @@ def _validate_agg_expr(
 
 def _validate_groupby_expr(expr: LogicalExpr):
     """Validate groupby expressions."""
-    if isinstance(expr, AggregateExpr):
+    if isinstance(expr, AggregateFunction):
         raise ValueError(
             f"Aggregate function: {expr} cannot be used in the group by clause."
         )

--- a/src/fenic/core/_logical_plan/plans/transform.py
+++ b/src/fenic/core/_logical_plan/plans/transform.py
@@ -12,7 +12,6 @@ import sqlglot.expressions as sqlglot_exprs
 from fenic._constants import SQL_PLACEHOLDER_RE
 from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions import (
-    AggregateExpr,
     ColumnExpr,
     LogicalExpr,
     SortExpr,
@@ -48,11 +47,8 @@ class Projection(LogicalPlan):
     def _build_schema(self) -> Schema:
         fields = []
         for expr in self._exprs:
-            if isinstance(expr, AggregateExpr):
-                raise ValueError(
-                    "Aggregate expressions are not allowed in projections. "
-                    "Please use the agg() method instead."
-                )
+            # AggregateExpr is no longer used - replaced by AggregateFunction
+            # Note: AggregateFunction expressions are not allowed in projections either
             fields.append(expr.to_column_field(self._input))
         return Schema(fields)
 
@@ -83,11 +79,8 @@ class Filter(LogicalPlan):
                 "- df.filter(col('status') == 'active')\n"
                 "- df.filter(col('is_valid'))"
             )
-        if isinstance(predicate, AggregateExpr):
-            raise ValueError(
-                "Aggregate expressions are not allowed in projections. "
-                "Please use the agg() method instead."
-            )
+        # AggregateExpr is no longer used - replaced by AggregateFunction
+        # Note: AggregateFunction expressions are not allowed in filter predicates either
         if isinstance(predicate, SortExpr):
             raise ValueError(
                 "Sort expressions are not allowed in projections. "

--- a/src/fenic/core/_logical_plan/signatures/__init__.py
+++ b/src/fenic/core/_logical_plan/signatures/__init__.py
@@ -7,6 +7,7 @@ and inferring return types.
 # Import signature modules to register them
 
 from fenic.core._logical_plan.signatures import (
+    aggregate,  # noqa: F401
     builtin,  # noqa: F401
     embedding,  # noqa: F401
     json,  # noqa: F401
@@ -14,8 +15,11 @@ from fenic.core._logical_plan.signatures import (
     semantic,  # noqa: F401
     text,  # noqa: F401
 )
+from fenic.core._logical_plan.signatures.function_base import (
+    AggregateFunction,
+    ScalarFunction,
+)
 from fenic.core._logical_plan.signatures.registry import FunctionRegistry
-from fenic.core._logical_plan.signatures.scalar_function import ScalarFunction
 from fenic.core._logical_plan.signatures.signature import (
     FunctionSignature,
     ReturnTypeStrategy,
@@ -61,4 +65,5 @@ __all__ = [
     "ReturnTypeStrategy",
     "FunctionRegistry",
     "ScalarFunction",
+    "AggregateFunction",
 ]

--- a/src/fenic/core/_logical_plan/signatures/aggregate.py
+++ b/src/fenic/core/_logical_plan/signatures/aggregate.py
@@ -1,0 +1,117 @@
+"""Aggregate function signatures for the fenic signature system.
+
+This module registers function signatures for aggregate functions,
+providing centralized type validation and return type inference.
+"""
+from fenic.core._logical_plan.signatures.registry import FunctionRegistry
+from fenic.core._logical_plan.signatures.signature import (
+    FunctionSignature,
+    ReturnTypeStrategy,
+)
+from fenic.core._logical_plan.signatures.types import Exact, InstanceOf, OneOf
+from fenic.core.types.datatypes import (
+    BooleanType,
+    DoubleType,
+    EmbeddingType,
+    FloatType,
+    IntegerType,
+    StringType,
+)
+
+# Constants for type validation
+SUMMABLE_TYPES = (IntegerType, FloatType, DoubleType, BooleanType)
+
+
+def register_aggregate_signatures():
+    """Register all aggregate function signatures for AggregateFunctions."""
+    # Sum - numeric types only, returns same type as input
+    FunctionRegistry.register("sum", FunctionSignature(
+        function_name="sum",
+        type_signature=OneOf([
+            Exact([IntegerType]),
+            Exact([FloatType]),
+            Exact([DoubleType]),
+            Exact([BooleanType])
+        ]),
+        return_type=ReturnTypeStrategy.SAME_AS_INPUT
+    ))
+    
+    # Average - numeric types and embeddings, returns DoubleType for numeric, same type for embeddings
+    FunctionRegistry.register("avg", FunctionSignature(
+        function_name="avg",
+        type_signature=OneOf([
+            Exact([IntegerType]),
+            Exact([FloatType]),
+            Exact([DoubleType]),
+            Exact([BooleanType]),
+            InstanceOf([EmbeddingType])
+        ]),
+        return_type=ReturnTypeStrategy.DYNAMIC  # Special logic needed for embeddings vs numeric
+    ))
+    
+    # Min/Max - numeric types only, returns same type as input
+    FunctionRegistry.register("min", FunctionSignature(
+        function_name="min",
+        type_signature=OneOf([
+            Exact([IntegerType]),
+            Exact([FloatType]),
+            Exact([DoubleType]),
+            Exact([BooleanType])
+        ]),
+        return_type=ReturnTypeStrategy.SAME_AS_INPUT
+    ))
+    
+    FunctionRegistry.register("max", FunctionSignature(
+        function_name="max",
+        type_signature=OneOf([
+            Exact([IntegerType]),
+            Exact([FloatType]),
+            Exact([DoubleType]),
+            Exact([BooleanType])
+        ]),
+        return_type=ReturnTypeStrategy.SAME_AS_INPUT
+    ))
+    
+    # Count - accepts any type, always returns IntegerType
+    FunctionRegistry.register("count", FunctionSignature(
+        function_name="count",
+        type_signature=Exact([object]),  # Accepts any DataType
+        return_type=IntegerType
+    ))
+    
+    # List aggregation - accepts any type except literals, returns ArrayType of input element type
+    FunctionRegistry.register("list", FunctionSignature(
+        function_name="list",
+        type_signature=Exact([object]),  # Accepts any DataType (literal check done separately)
+        return_type=ReturnTypeStrategy.DYNAMIC  # Returns ArrayType(input_type)
+    ))
+    
+    # First - accepts any type, returns same type as input
+    FunctionRegistry.register("first", FunctionSignature(
+        function_name="first",
+        type_signature=Exact([object]),  # Accepts any DataType
+        return_type=ReturnTypeStrategy.SAME_AS_INPUT
+    ))
+    
+    # Standard deviation - numeric types only, returns DoubleType
+    FunctionRegistry.register("stddev", FunctionSignature(
+        function_name="stddev",
+        type_signature=OneOf([
+            Exact([IntegerType]),
+            Exact([FloatType]),
+            Exact([DoubleType]),
+            Exact([BooleanType])
+        ]),
+        return_type=DoubleType
+    ))
+    
+    # Markdown group schema - string input only, returns StringType
+    FunctionRegistry.register("md_group_schema", FunctionSignature(
+        function_name="md_group_schema",
+        type_signature=Exact([StringType]),
+        return_type=StringType
+    ))
+
+
+# Register all signatures when module is imported
+register_aggregate_signatures()

--- a/src/fenic/core/_logical_plan/signatures/aggregate.py
+++ b/src/fenic/core/_logical_plan/signatures/aggregate.py
@@ -8,14 +8,19 @@ from fenic.core._logical_plan.signatures.signature import (
     FunctionSignature,
     ReturnTypeStrategy,
 )
-from fenic.core._logical_plan.signatures.types import Exact, InstanceOf, OneOf
+from fenic.core._logical_plan.signatures.types import (
+    Any,
+    Exact,
+    InstanceOf,
+    Numeric,
+    OneOf,
+)
 from fenic.core.types.datatypes import (
     BooleanType,
     DoubleType,
     EmbeddingType,
     FloatType,
     IntegerType,
-    StringType,
 )
 
 # Constants for type validation
@@ -28,9 +33,7 @@ def register_aggregate_signatures():
     FunctionRegistry.register("sum", FunctionSignature(
         function_name="sum",
         type_signature=OneOf([
-            Exact([IntegerType]),
-            Exact([FloatType]),
-            Exact([DoubleType]),
+            Numeric(1),
             Exact([BooleanType])
         ]),
         return_type=ReturnTypeStrategy.SAME_AS_INPUT
@@ -40,9 +43,7 @@ def register_aggregate_signatures():
     FunctionRegistry.register("avg", FunctionSignature(
         function_name="avg",
         type_signature=OneOf([
-            Exact([IntegerType]),
-            Exact([FloatType]),
-            Exact([DoubleType]),
+            Numeric(1),
             Exact([BooleanType]),
             InstanceOf([EmbeddingType])
         ]),
@@ -53,9 +54,7 @@ def register_aggregate_signatures():
     FunctionRegistry.register("min", FunctionSignature(
         function_name="min",
         type_signature=OneOf([
-            Exact([IntegerType]),
-            Exact([FloatType]),
-            Exact([DoubleType]),
+            Numeric(1),
             Exact([BooleanType])
         ]),
         return_type=ReturnTypeStrategy.SAME_AS_INPUT
@@ -64,9 +63,7 @@ def register_aggregate_signatures():
     FunctionRegistry.register("max", FunctionSignature(
         function_name="max",
         type_signature=OneOf([
-            Exact([IntegerType]),
-            Exact([FloatType]),
-            Exact([DoubleType]),
+            Numeric(1),
             Exact([BooleanType])
         ]),
         return_type=ReturnTypeStrategy.SAME_AS_INPUT
@@ -75,21 +72,21 @@ def register_aggregate_signatures():
     # Count - accepts any type, always returns IntegerType
     FunctionRegistry.register("count", FunctionSignature(
         function_name="count",
-        type_signature=Exact([object]),  # Accepts any DataType
+        type_signature=Any(1),  # Accepts one argument of any DataType
         return_type=IntegerType
     ))
     
     # List aggregation - accepts any type except literals, returns ArrayType of input element type
     FunctionRegistry.register("list", FunctionSignature(
         function_name="list",
-        type_signature=Exact([object]),  # Accepts any DataType (literal check done separately)
+        type_signature=Any(1),  # Accepts any DataType (literal check done separately)
         return_type=ReturnTypeStrategy.DYNAMIC  # Returns ArrayType(input_type)
     ))
     
     # First - accepts any type, returns same type as input
     FunctionRegistry.register("first", FunctionSignature(
         function_name="first",
-        type_signature=Exact([object]),  # Accepts any DataType
+        type_signature=Any(1),  # Accepts one argument of any DataType
         return_type=ReturnTypeStrategy.SAME_AS_INPUT
     ))
     
@@ -97,20 +94,12 @@ def register_aggregate_signatures():
     FunctionRegistry.register("stddev", FunctionSignature(
         function_name="stddev",
         type_signature=OneOf([
-            Exact([IntegerType]),
-            Exact([FloatType]),
-            Exact([DoubleType]),
+            Numeric(1),
             Exact([BooleanType])
         ]),
         return_type=DoubleType
     ))
-    
-    # Markdown group schema - string input only, returns StringType
-    FunctionRegistry.register("md_group_schema", FunctionSignature(
-        function_name="md_group_schema",
-        type_signature=Exact([StringType]),
-        return_type=StringType
-    ))
+
 
 
 # Register all signatures when module is imported

--- a/src/fenic/core/_logical_plan/signatures/function_base.py
+++ b/src/fenic/core/_logical_plan/signatures/function_base.py
@@ -1,6 +1,6 @@
-"""ScalarFunction base class for functions with centralized signature validation.
+"""Base classes for functions with centralized signature validation.
 
-This module provides the ScalarFunction class that uses the registry system
+This module provides ScalarFunction and AggregateFunction classes that use the registry system
 for type validation and return type inference.
 """
 
@@ -50,4 +50,14 @@ class ScalarFunction(LogicalExpr):
     def __str__(self) -> str:
         args_str = ", ".join(str(arg) for arg in self.args)
         return f"{self.function_name}({args_str})"
-    
+
+
+class AggregateFunction(ScalarFunction):
+    """Base class for aggregate functions - marker class that extends ScalarFunction."""
+
+    def __init__(self, *args: LogicalExpr):
+        """Initialize AggregateFunction with logical expression arguments."""
+        super().__init__(*args)
+        # Store expr for backward compatibility with existing single-arg aggregate code
+        if len(args) == 1:
+            self.expr = args[0]

--- a/src/fenic/core/_logical_plan/signatures/types.py
+++ b/src/fenic/core/_logical_plan/signatures/types.py
@@ -149,6 +149,19 @@ class PositionalSignature(TypeSignature):
         return expected_types
 
 
+class Any(TypeSignature):
+    """All arguments can be of any type, but an exact number of arguments is required."""
+
+    def __init__(self, expected_num_args: int):
+        self.expected_num_args = expected_num_args
+
+    def validate(self, arg_types: List[DataType], func_name: str) -> None:
+        if len(arg_types) != self.expected_num_args:
+            raise ValidationError(
+                f"{func_name} expects {self.expected_num_args} arguments, "
+                f"got {len(arg_types)}"
+            )
+
 class Exact(PositionalSignature):
     """Exact argument types for functions (e.g., length(str) -> int).
 

--- a/tests/_backends/local/test_column.py
+++ b/tests/_backends/local/test_column.py
@@ -17,7 +17,6 @@ from fenic import (
     when,
 )
 from fenic.core._logical_plan.expressions import (
-    AggregateExpr,
     AliasExpr,
     ArithmeticExpr,
     BooleanExpr,
@@ -28,6 +27,7 @@ from fenic.core._logical_plan.expressions import (
     NumericComparisonExpr,
     Operator,
 )
+from fenic.core._logical_plan.signatures import AggregateFunction
 from fenic.core.error import TypeMismatchError, ValidationError
 
 
@@ -221,32 +221,32 @@ def test_nested_expression():
 
 def test_sum_aggregation():
     column = sum(col("age"))
-    assert isinstance(column._logical_expr, AggregateExpr)
-    assert column._logical_expr.agg_name == "sum"
+    assert isinstance(column._logical_expr, AggregateFunction)
+    assert column._logical_expr.function_name == "sum"
     assert isinstance(column._logical_expr.expr, ColumnExpr)
     assert column._logical_expr.expr.name == "age"
 
 
 def test_avg_aggregation():
     column = avg(col("age"))
-    assert isinstance(column._logical_expr, AggregateExpr)
-    assert column._logical_expr.agg_name == "avg"
+    assert isinstance(column._logical_expr, AggregateFunction)
+    assert column._logical_expr.function_name == "avg"
     assert isinstance(column._logical_expr.expr, ColumnExpr)
     assert column._logical_expr.expr.name == "age"
 
 
 def test_min_aggregation():
     column = min(col("age"))
-    assert isinstance(column._logical_expr, AggregateExpr)
-    assert column._logical_expr.agg_name == "min"
+    assert isinstance(column._logical_expr, AggregateFunction)
+    assert column._logical_expr.function_name == "min"
     assert isinstance(column._logical_expr.expr, ColumnExpr)
     assert column._logical_expr.expr.name == "age"
 
 
 def test_max_aggregation():
     column = max(col("age"))
-    assert isinstance(column._logical_expr, AggregateExpr)
-    assert column._logical_expr.agg_name == "max"
+    assert isinstance(column._logical_expr, AggregateFunction)
+    assert column._logical_expr.function_name == "max"
     assert isinstance(column._logical_expr.expr, ColumnExpr)
     assert column._logical_expr.expr.name == "age"
 

--- a/tests/_logical_plan/signatures/test_aggregate_function.py
+++ b/tests/_logical_plan/signatures/test_aggregate_function.py
@@ -1,0 +1,146 @@
+"""Tests for AggregateFunction base class functionality."""
+
+import pytest
+
+from fenic.core._logical_plan.expressions.aggregate import AvgExpr, CountExpr, SumExpr
+from fenic.core._logical_plan.signatures import (
+    FunctionRegistry,
+    FunctionSignature,
+)
+from fenic.core.error import InternalError, TypeMismatchError
+from fenic.core.types.datatypes import (
+    DoubleType,
+    EmbeddingType,
+    IntegerType,
+    StringType,
+)
+from fenic.core.types.schema import ColumnField
+
+
+class MockColumn:
+    """Mock column expression for testing."""
+    
+    def __init__(self, name: str, data_type):
+        self.name = name
+        self.data_type = data_type
+    
+    def to_column_field(self, plan):
+        return ColumnField(self.name, self.data_type)
+    
+    def __str__(self):
+        return self.name
+
+
+class MockPlan:
+    """Mock logical plan for testing."""
+    
+    def __init__(self, columns=None):
+        self.columns = columns or []
+
+
+class TestAggregateFunction:
+    """Test AggregateFunction base class."""
+    
+    def test_aggregate_function_uses_registry_for_validation(self):
+        """Test that AggregateFunction uses function registry for validation."""
+        # SumExpr should use the registry system
+        int_col = MockColumn("int_col", IntegerType)
+        plan = MockPlan()
+        
+        sum_expr = SumExpr(int_col)
+        result = sum_expr.to_column_field(plan)
+        
+        # Should validate successfully and return same type for sum
+        assert result.data_type == IntegerType
+        assert result.name == "sum(int_col)"
+    
+    def test_aggregate_function_signature_validation(self):
+        """Test that signature validation works for aggregate functions."""
+        # Sum should reject string types
+        string_col = MockColumn("str_col", StringType) 
+        plan = MockPlan()
+        
+        sum_expr = SumExpr(string_col)
+        
+        # Should fail validation
+        with pytest.raises(TypeMismatchError):
+            sum_expr.to_column_field(plan)
+    
+    def test_avg_dynamic_return_type(self):
+        """Test that AvgExpr correctly handles dynamic return types."""
+        plan = MockPlan()
+        
+        # Test numeric types return DoubleType
+        int_col = MockColumn("int_col", IntegerType)
+        avg_expr = AvgExpr(int_col)
+        result = avg_expr.to_column_field(plan)
+        assert result.data_type == DoubleType
+        
+        # Test embedding types return same type
+        embedding_col = MockColumn("emb_col", EmbeddingType(dimensions=128, embedding_model="test"))
+        avg_expr_emb = AvgExpr(embedding_col)
+        result_emb = avg_expr_emb.to_column_field(plan)
+        assert isinstance(result_emb.data_type, EmbeddingType)
+        assert result_emb.data_type.embedding_model == "test"
+        assert result_emb.data_type.dimensions == 128
+    
+    def test_count_accepts_any_type(self):
+        """Test that CountExpr accepts any input type."""
+        plan = MockPlan()
+        
+        # Test various types
+        for data_type in [IntegerType, StringType, DoubleType]:
+            col = MockColumn("col", data_type)
+            count_expr = CountExpr(col)
+            result = count_expr.to_column_field(plan)
+            
+            # Count always returns IntegerType
+            assert result.data_type == IntegerType
+            assert result.name == "count(col)"
+    
+    def test_aggregate_function_children(self):
+        """Test that children() method works correctly."""
+        int_col = MockColumn("int_col", IntegerType)
+        sum_expr = SumExpr(int_col)
+        
+        children = sum_expr.children()
+        assert len(children) == 1
+        assert children[0] is int_col
+    
+    def test_aggregate_function_str_representation(self):
+        """Test string representation of aggregate functions."""
+        int_col = MockColumn("int_col", IntegerType)
+        sum_expr = SumExpr(int_col)
+        
+        assert str(sum_expr) == "sum(int_col)"
+
+
+class TestAggregateSignatures:
+    """Test that aggregate function signatures are properly registered."""
+    
+    def test_all_aggregate_functions_registered(self):
+        """Test that all expected aggregate functions are registered."""
+        expected_functions = [
+            "sum", "avg", "min", "max", "count", 
+            "list", "first", "stddev", "md_group_schema"
+        ]
+        
+        registered_functions = FunctionRegistry.list_functions()
+        
+        for func_name in expected_functions:
+            assert func_name in registered_functions, f"Function {func_name} not registered"
+    
+    def test_registry_lookup_works(self):
+        """Test that registry lookup works for aggregate functions."""
+        signature = FunctionRegistry.get_signature("sum")
+        assert isinstance(signature, FunctionSignature)
+        assert signature.function_name == "sum"
+    
+    def test_unknown_aggregate_function_error(self):
+        """Test that unknown function names raise proper errors."""
+        with pytest.raises(InternalError, match="Unknown function: nonexistent_agg"):
+            FunctionRegistry.get_signature("nonexistent_agg")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/_logical_plan/signatures/test_aggregate_function.py
+++ b/tests/_logical_plan/signatures/test_aggregate_function.py
@@ -122,7 +122,7 @@ class TestAggregateSignatures:
         """Test that all expected aggregate functions are registered."""
         expected_functions = [
             "sum", "avg", "min", "max", "count", 
-            "list", "first", "stddev", "md_group_schema"
+            "list", "first", "stddev"
         ]
         
         registered_functions = FunctionRegistry.list_functions()


### PR DESCRIPTION
Following onto the previous PRs in this stack -- creates AggregateFunction as an marker class on top of ScalarFunction, but keeping all of the same validation logic. This lets us express the aggregate expressions in the type signature system, and still have logic elsewhere in the project that depends on Aggregate Expressions all extending from the same superclass for things like plan optimization and expr_converter dispatch. 