### PR TITLE
fix: suppress noisy gemini logs

### DIFF
--- a/src/fenic/logging.py
+++ b/src/fenic/logging.py
@@ -4,6 +4,8 @@ import logging
 import sys
 from typing import Optional, TextIO
 
+NOISY_LOGGER_NAMES = ("openai", "httpx", "google_genai")
+
 
 def configure_logging(
     log_level: int = logging.INFO,
@@ -37,7 +39,7 @@ def configure_logging(
         root_logger.addHandler(handler)
 
         # Silence noisy dependencies
-        for noisy_logger_name in ("openai", "httpx"):
+        for noisy_logger_name in NOISY_LOGGER_NAMES:
             noisy_logger = logging.getLogger(noisy_logger_name)
             noisy_logger.setLevel(logging.ERROR)
 


### PR DESCRIPTION
TD-1570

Added `google_genai` to the list of noisy logger names to suppress non-error logs from. Also moved the list of noisy loggers to a constant so it's easier to see at a glance what's being ignored. 