### PR TITLE
chore: enable rust unit tests in ci using cargo test with feature flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Run Rust unit tests
         if: steps.rust_changed.outputs.changed == 'true'
         working-directory: rust
-        run: cargo test --no-default-features --locked
+        run: cargo test --lib --no-default-features --locked
       # yamllint disable-line rule:line-length
       - name: run ${{ matrix.test }} tests with ${{ matrix.dependency == 'true' && 'synced' || matrix.dependency }} dependencies
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,9 @@ jobs:
       - name: Run Rust unit tests
         if: steps.rust_changed.outputs.changed == 'true'
         working-directory: rust
-        run: cargo test --lib --no-default-features --locked
+        run: |
+          export LD_LIBRARY_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"):$LD_LIBRARY_PATH
+          cargo test --no-default-features --locked
       # yamllint disable-line rule:line-length
       - name: run ${{ matrix.test }} tests with ${{ matrix.dependency == 'true' && 'synced' || matrix.dependency }} dependencies
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,24 @@ jobs:
           toolchain: stable
           cache: true
           cache-shared-key: shared-rust-cache
+      - name: Check if Rust unit tests need to be run
+        id: rust_changed
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if git diff --quiet origin/${{ github.base_ref }} -- rust/; then
+              echo "changed=false" >> $GITHUB_OUTPUT
+            else
+              echo "changed=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            # For schedule and manual triggers, always run tests
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Run Rust unit tests
+        if: steps.rust_changed.outputs.changed == 'true'
+        working-directory: rust
+        run: cargo test --no-default-features --locked
       # yamllint disable-line rule:line-length
       - name: run ${{ matrix.test }} tests with ${{ matrix.dependency == 'true' && 'synced' || matrix.dependency }} dependencies
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
-# Contributing
+# Contributing to Fenic
 
-## 📁 Directory Structure
+Welcome! This guide will help you get set up for local development and testing.
 
-The repository is organized as follows:
+---
+
+## 📁 Directory Overview
 
 ```bash
 fenic/
@@ -28,14 +30,18 @@ fenic/
 
 ## 🛠️ Development Setup
 
-Local development requires uv and a Rust toolchain.
+### Requirements
 
-> [!OPTIONAL]
-> Not required, but recommended: [just](https://just.systems/)
+- [`uv`](https://github.com/astral-sh/uv) — manages Python dependencies and environments
+- A working **Rust toolchain**
 
-### First-Time Setup
+> **Optional but recommended:** [`just`](https://just.systems/) for simpler task running
 
-From the root of the repo:
+---
+
+### One-Time Setup
+
+From the project root:
 
 ```bash
 just setup
@@ -47,45 +53,42 @@ uv run maturin develop --uv
 This will:
 
 - Create a virtual environment
-- Build the Rust crate
-- Install Python dependencies
-- Set up the package in editable mode
+- Install all Python dev dependencies (including `maturin`)
+- Build and install the Rust plugin as an editable Python package
 
-> This command also places the built dynamic Rust library inside `src/fenic`.
+---
 
 ### Making Changes
 
-- To apply changes made to Python code:
+#### Python Code
 
-  ```bash
-  just sync
-  # without just
-  uv sync
-  ```
+```bash
+just sync
+# or
+uv sync
+```
 
-- To apply changes made to Rust code:
+#### Rust Code (PyO3 Plugin)
 
-  ```bash
-  just sync-rust
-  # without just
-  uv run maturin develop --uv
-  ```
+```bash
+just sync-rust
+# or
+uv run maturin develop --uv
+```
 
-  Add `--release` or `-r` to build the Rust crate in release mode (better performance).
+Add `--release` for optimized builds:
 
-- To preview changes to the documentation from docstring or other changes:
-
-  ```bash
-  just preview-docs
-  # without just
-  uv run --group docs mkdocs serve
-  ```
+```bash
+uv run maturin develop --uv --release
+```
 
 ---
 
 ## ✅ Running Tests
 
-Run an individual test file:
+### Python Tests
+
+Run a specific test file:
 
 ```bash
 uv run pytest tests/path/to/test_foo.py
@@ -118,24 +121,38 @@ Run all tests for the **cloud backend**:
 
 ```bash
 just test-cloud
+# or
+uv sync --extra=cloud
+uv run pytest -m cloud tests
 ```
 
-> ⚠️ Note: All tests require a valid OpenAI/Anthropic API key set in the environment variables.
+---
+
+### Rust Tests
+
+From the `rust/` directory:
+
+```bash
+cargo test --no-default-features
+```
+
+> Skipping default features avoids Python-specific linking, making it easier to test the Rust library independently of the Python bindings.
 
 ---
 
 ## 📓 Running Notebooks (VSCode / Cursor)
 
-To run demo notebooks:
+To run the demo notebooks:
 
-1. Install the **Jupyter** extension.
-2. Add the `.venv` path to **Python: Venv Folders** in VSCode settings:
-   - Open settings: `Preferences: Open User Settings`
+1. Install the **Jupyter** extension in your editor.
+2. Add `.venv` to the **Python: Venv Folders** setting in VSCode:
+   - Open `Preferences: Open User Settings`
    - Go to Extensions → Python → **Python: Venv Folders**
-3. Open a notebook, select the correct kernel from your virtual environment, and run cells.
-
-> Restart the kernel to reflect any code changes made to the `fenic` source.
+3. Open a notebook and select the correct Python kernel from the virtual environment.
+4. Restart the kernel if you make changes to the `fenic` source code.
 
 ---
 
-Have questions or want to contribute? Let us know in the [Discord](https://discord.gg/GdqF3J7huR)!
+## 🙋 Need Help?
+
+Have questions or want to contribute? Join us on [Discord](https://discord.gg/GdqF3J7huR)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ uv run pytest -m cloud tests
 From the `rust/` directory:
 
 ```bash
-cargo test --no-default-features
+cargo test --lib --no-default-features
 ```
 
 > Skipping default features avoids Python-specific linking, making it easier to test the Rust library independently of the Python bindings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,16 @@ Add `--release` for optimized builds:
 uv run maturin develop --uv --release
 ````
 
+#### Documentation
+
+To preview changes to the documentation from docstring or other changes:
+
+```bash
+just preview-docs
+# without just
+uv run --group docs mkdocs serve
+```
+
 ---
 
 ## ✅ Running Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,17 +70,26 @@ uv sync
 
 #### Rust Code (PyO3 Plugin)
 
+To compile and install the Rust crate with Python bindings into your virtual environment:
+
 ```bash
 just sync-rust
 # or
 uv run maturin develop --uv
 ```
 
+This builds the Rust crate with Python bindings and makes it available inside the `.venv`.
+
+To **only compile** the Rust crate _without_ Python bindings (e.g., for Rust unit tests), run this **from the `rust/` directory**:
+
+````bash
+cargo build --no-default-features
+
 Add `--release` for optimized builds:
 
 ```bash
 uv run maturin develop --uv --release
-```
+````
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ uv sync --extra=cloud
 uv run pytest -m cloud tests
 ```
 
+> ⚠️ Note: All tests require a valid OpenAI/Anthropic API key set in the environment variables.
+
 ---
 
 ### Rust Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ uv run pytest -m cloud tests
 From the `rust/` directory:
 
 ```bash
-cargo test --lib --no-default-features
+cargo test --no-default-features
 ```
 
 > Skipping default features avoids Python-specific linking, making it easier to test the Rust library independently of the Python bindings.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0.98"
 memchr = "2.7.4"
 polars-arrow = "0.48.1"
-pyo3 = { version = "0.24.2", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.24.2", features = ["abi3-py39"] }
 pyo3-polars = { version = "0.21.0", features = ["derive", "dtype-struct"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
@@ -27,6 +27,10 @@ criterion = "0.5.1"
 indoc = "2.0"
 rstest = "0.25.0"
 reqwest = { version = "0.12.15", features = ["json", "blocking"] }
+
+[features]
+extension-module = ["pyo3/extension-module"]
+default = ["extension-module"]
 
 [[bench]]
 name = "transcript_parsing"


### PR DESCRIPTION
# Fix PyO3 Linking Issues During Rust Unit Tests

This PR resolves linker errors that occur when running `cargo test` on the `polars-plugin` crate by disabling PyO3's `extension-module` feature during test builds.

## Problem

The `polars-plugin` crate uses PyO3 to build a Python extension module. By default, it enables the `extension-module` feature, which is necessary for tools like `maturin` to build shared libraries (`*.so`/`*.pyd`) that are importable from Python.

However, enabling `extension-module` tells PyO3:
* To assume it is running inside a Python process
* To rely on Python symbols (e.g. `_PyExc_SystemError`) being available at runtime

This works fine for extension builds, but causes issues when running `cargo test`, because:
* The test binary is not loaded by Python
* No Python interpreter is running
* Python symbols are undefined at link or runtime

Typical errors include:

```
undefined reference to _PyExc_SystemError
symbol not found: _PyList_New
```

## Solution

To fix this, we disable the `extension-module` feature during testing. This switches PyO3 to its default behavior where:
* Python is initialized explicitly by the Rust binary (if needed)
* Python symbols are linked at build time via `libpython`

This allows Rust tests to compile and run without requiring a running Python interpreter or `maturin`.

Reference: [PyO3 FAQ – Linker issues](https://pyo3.rs/v0.25.1/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror)

## Changes

1. **Cargo.toml** The crate already uses feature-based control of the extension module:

   ```toml
   [features]
   extension-module = ["pyo3/extension-module"]
   default = ["extension-module"]
   ```
   
   This lets us disable Python extension mode via `--no-default-features`.

2. **GitHub Actions** - Run Rust tests in CI now that we can
   * Updated CI to run `cargo test --no-default-features` to avoid linking to Python during tests
   * Sets `LD_LIBRARY_PATH` to locate `libpython` at build time
   * Limits test runs to Rust-related file changes to avoid running it needlessly
   
 3. Update CONTRIBUTING.md with instructions on running Rust only unit tests locally.