### PR TITLE
fix: Fix a few issues with cloud catalog and saving data as tables

### DIFF
--- a/src/fenic/_backends/cloud/catalog.py
+++ b/src/fenic/_backends/cloud/catalog.py
@@ -17,7 +17,6 @@ from fenic_cloud.hasura_client.generated_graphql_client.enums import (
     TypedefCatalogTypeReferenceEnum,
 )
 from fenic_cloud.hasura_client.generated_graphql_client.input_types import (
-    CatalogNamespaceInsertInput,
     CreateTableInput,
     NestedFieldInput,
     SchemaInput,
@@ -30,7 +29,6 @@ from fenic_cloud.hasura_client.generated_graphql_client.load_table import (
 )
 
 from fenic._backends.cloud.manager import CloudSessionManager
-from fenic._backends.cloud.session_state import CloudSessionState
 from fenic._backends.local.catalog import (
     DEFAULT_CATALOG_NAME,
     DEFAULT_DATABASE_NAME,
@@ -70,16 +68,21 @@ class CloudCatalog(BaseCatalog):
     all table reads and writes should go through this class for unified table name canonicalization.
     """
 
-    def __init__(self, session_state: CloudSessionState, cloud_session_manager: CloudSessionManager):
+    def __init__(self,
+        ephemeral_catalog_id: str,
+        asyncio_loop: asyncio.AbstractEventLoop,
+        cloud_session_manager: CloudSessionManager):
         """Initialize the remote catalog."""
-        self.session_state = session_state
+        self.cloud_session_manager = cloud_session_manager
         self.lock = threading.Lock()
-        self.current_catalog_id: UUID = UUID(session_state.ephemeral_catalog_id)
+        self.asyncio_loop = asyncio_loop
+        self.ephemeral_catalog_id: UUID = UUID(ephemeral_catalog_id)
+        self.current_catalog_id: UUID = self.ephemeral_catalog_id
         self.current_catalog_name: str = DEFAULT_CATALOG_NAME
         self.current_database_name: str = DEFAULT_DATABASE_NAME
-        self.user_id = cloud_session_manager.user_id
-        self.organization_id = cloud_session_manager.organization_id
-        self.user_client = cloud_session_manager.hasura_user_client
+        self.user_id = self.cloud_session_manager._client_id
+        self.organization_id = self.cloud_session_manager._organization_id
+        self.user_client = self.cloud_session_manager.hasura_user_client
 
     def does_catalog_exist(self, catalog_name: str) -> bool:
         """Checks if a catalog with the specified name exists."""
@@ -129,7 +132,6 @@ class CloudCatalog(BaseCatalog):
                     parent_organization_id=UUID(self.organization_id),
                     catalog_type=TypedefCatalogTypeReferenceEnum.INTERNAL_TYPEDEF,
                     catalog_warehouse="",
-                    catalog_description=None,
                 )
             )
             return True
@@ -342,14 +344,12 @@ class CloudCatalog(BaseCatalog):
                 raise DatabaseAlreadyExistsError(database_name)
 
         self._execute_catalog_command(
-            self.user_client.create_namespace(
-                namespace=CatalogNamespaceInsertInput(
-                    name=db_identifier.db,
-                    canonical_name=db_identifier.db.casefold(),
-                    parent_organization_id=self.organization_id,
-                    catalog_id=self.current_catalog_id,
-                    created_by_user_id=self.user_id,
-                )
+            self.user_client.sc_create_namespace(
+                dispatch=self._get_catalog_dispatch_input(self.current_catalog_id),
+                name=db_identifier.db,
+                canonical_name=db_identifier.db.casefold(),
+                description=None,
+                properties=[],
             )
         )
         return True
@@ -365,8 +365,8 @@ class CloudCatalog(BaseCatalog):
         if not self._does_database_exist(catalog_name, db_name):
             return False
 
-        tables = self._get_tables_for_database(catalog_name, db_name)
-        return any(compare_object_names(table, table_name) for table in tables)
+        table = self._get_table(catalog_name, db_name, table_name)
+        return table is not None
 
     def _set_current_catalog(self, catalog_name: str) -> None:
         if not catalog_name:
@@ -376,7 +376,7 @@ class CloudCatalog(BaseCatalog):
             return
 
         if compare_object_names(catalog_name, DEFAULT_CATALOG_NAME):
-            self.current_catalog_id = UUID(self.session_state.ephemeral_catalog_id)
+            self.current_catalog_id = self.ephemeral_catalog_id
             self.current_catalog_name = DEFAULT_CATALOG_NAME
             return
 
@@ -421,7 +421,7 @@ class CloudCatalog(BaseCatalog):
 
     def _execute_catalog_command(self, command: Coroutine[Any, Any, Any]) -> Any:
         return asyncio.run_coroutine_threadsafe(
-            command, self.session_state.asyncio_loop
+            command, self.asyncio_loop
         ).result()
 
     def _get_catalog_by_name(self, catalog_name: str) -> Optional[CatalogKey]:
@@ -481,18 +481,35 @@ class CloudCatalog(BaseCatalog):
         )
         return [dataset.name for dataset in result.catalog_dataset]
 
+    def _get_table(
+            self,
+            catalog_name: str,
+            db_name: str,
+            table_name: str,
+            ignore_if_not_exists: bool = True,
+    ) -> LoadTableSimpleCatalogLoadTable:
+        catalog_id = self._get_catalog_id(catalog_name)
+        try:
+            result = self._execute_catalog_command(
+                self.user_client.load_table(
+                    dispatch=self._get_catalog_dispatch_input(catalog_id),
+                    namespace=db_name,
+                    name=table_name,
+                )
+            )
+            return result.simple_catalog.load_table
+        except Exception as e:
+            if ignore_if_not_exists:
+                return None
+            logger.debug(f"Error getting table {table_name} from catalog {catalog_name} and database {db_name}: {e}")
+            raise e
+
+
     def _get_table_details(
         self, catalog_name: str, db_name: str, table_name: str
     ) -> Schema:
-        catalog_id = self._get_catalog_id(catalog_name)
-        result = self._execute_catalog_command(
-            self.user_client.load_table(
-                dispatch=self._get_catalog_dispatch_input(catalog_id),
-                namespace=db_name,
-                name=table_name,
-            )
-        )
-        return self._get_table_schema(result.simple_catalog.load_table)
+        load_table = self._get_table(catalog_name, db_name, table_name, ignore_if_not_exists=False)
+        return self._get_table_schema(load_table)
 
     def _get_catalog_dispatch_input(
         self,

--- a/src/fenic/_backends/cloud/execution.py
+++ b/src/fenic/_backends/cloud/execution.py
@@ -28,19 +28,24 @@ from fenic_cloud.protos.engine.v1.engine_pb2 import (
     SaveToFileExecutionRequest,
     ShowExecutionRequest,
     StartExecutionRequest,
-    TableIdentifier,
+)
+from fenic_cloud.protos.engine.v1.engine_pb2 import (
+    TableIdentifier as TableIdentifierProto,
 )
 from fenic_cloud.protos.engine.v1.engine_pb2_grpc import EngineServiceStub
 
 from fenic._backends.cloud.metrics import get_query_execution_metrics
 from fenic._backends.schema_serde import deserialize_schema, serialize_schema
+from fenic._backends.utils.catalog_utils import TableIdentifier
 from fenic.core._interfaces import BaseExecution
+from fenic.core._logical_plan.plans.sink import TableSink
 from fenic.core._logical_plan.serde import LogicalPlanSerde
 from fenic.core.error import (
     CloudExecutionError,
     CloudSessionError,
     ExecutionError,
     InternalError,
+    PlanError,
     ValidationError,
 )
 from fenic.core.metrics import LMMetrics, PhysicalPlanRepr, QueryMetrics, RMMetrics
@@ -164,16 +169,67 @@ class CloudExecution(BaseExecution):
     ) -> QueryMetrics:
         """Execute the logical plan and save the result as a table."""
         logger.debug(f"Saving plan {logical_plan} as table: {table_name}")
+
+        if isinstance(logical_plan, TableSink):
+            if not logical_plan.location:
+                raise ValidationError(
+                    f"Cannot save to table '{table_name}' - location is required. "
+                    f"Provide a location.")
+
+        table_identifier = TableIdentifier.from_string(table_name).enrich(
+            self.session_state.catalog.get_current_catalog(),
+            self.session_state.catalog.get_current_database(),
+        )
+
+        # If the table doesn't exist, create it, this has to be done in the user's context.
+        table_identifier_str = str(table_identifier)
+        table_exists = self.session_state.catalog.does_table_exist(table_identifier_str)
+        if table_exists:
+            if mode == "error":
+                raise PlanError(
+                    f"Cannot save to table '{table_name}' - it already exists and mode is 'error'. "
+                    f"Choose a different approach: "
+                    f"1) Use mode='overwrite' to replace the existing table, "
+                    f"2) Use mode='append' to add data to the existing table, "
+                    f"3) Use mode='ignore' to skip saving if table exists, "
+                    f"4) Use a different table name.")
+            if mode == "ignore":
+                logger.warning(f"Table {table_name} already exists, ignoring write.")
+                return QueryMetrics()
+            if mode == "append":
+                saved_schema = self.session_state.catalog.describe_table(table_identifier_str)
+                plan_schema = logical_plan.schema()
+                if saved_schema != plan_schema:
+                    raise PlanError(
+                        f"Cannot append to table '{table_name}' - schema mismatch detected. "
+                        f"The existing table has a different schema than your DataFrame. "
+                        f"Existing schema: {saved_schema} "
+                        f"Your DataFrame schema: {plan_schema} "
+                        f"To fix this: "
+                        f"1) Use mode='overwrite' to replace the table with your DataFrame's schema, "
+                        f"2) Modify your DataFrame to match the existing table's schema, "
+                        f"3) Use a different table name.")
+        else:
+            logger.debug(f"Creating table {table_identifier_str} with location: {logical_plan.location}")
+            # Create the table in the catalog.
+            result =self.session_state.catalog.create_table(
+                table_identifier_str,
+                logical_plan.schema(),
+                location=logical_plan.location,
+                ignore_if_exists=mode == "ignore",
+                file_format="PARQUET")
+            logger.debug(f"Table {table_identifier_str} created with result: {result}")
+
         # TODO (DY): check that current catalog and schema (if specified in table_name) match session state
-        table_identifier = TableIdentifier(
-            catalog=self.session_state.catalog,
-            schema=self.session_state.schema,
+        table_identifier_proto = TableIdentifierProto(
+            catalog=table_identifier.catalog,
+            schema=table_identifier.db,
             table=table_name,
         )
         request = StartExecutionRequest(
             save_as_table=SaveAsTableExecutionRequest(
                 serialized_plan=LogicalPlanSerde.serialize(logical_plan),
-                table_identifier=table_identifier,
+                table_identifier=table_identifier_proto,
                 mode=mode,
             )
         )

--- a/src/fenic/_backends/local/physical_plan/sink.py
+++ b/src/fenic/_backends/local/physical_plan/sink.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, Literal, Tuple
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple
 
 if TYPE_CHECKING:
     from fenic._backends.local.session_state import LocalSessionState
@@ -80,6 +80,7 @@ class DuckDBTableSinkExec(PhysicalPlan):
         cache_info: CacheInfo,
         session_state: LocalSessionState,
         schema: Schema,
+        location: Optional[str] = None,
     ):
         super().__init__(
             children=[child], cache_info=cache_info, session_state=session_state
@@ -87,6 +88,7 @@ class DuckDBTableSinkExec(PhysicalPlan):
         self.table_name = table_name
         self.mode = mode
         self.schema = schema
+        self.location = location
 
     def _execute(self, child_dfs: List[pl.DataFrame]) -> pl.DataFrame:
         if len(child_dfs) != 1:

--- a/src/fenic/_backends/local/transpiler/plan_converter.py
+++ b/src/fenic/_backends/local/transpiler/plan_converter.py
@@ -368,6 +368,7 @@ class PlanConverter:
                 cache_info=logical.cache_info,
                 session_state=self.session_state,
                 schema=logical.schema(),
+                location=logical.location,
             )
 
         elif isinstance(logical, SQL):

--- a/src/fenic/_backends/utils/catalog_utils.py
+++ b/src/fenic/_backends/utils/catalog_utils.py
@@ -103,6 +103,13 @@ class TableIdentifier(BaseIdentifier):
             table=self.table,
         )
 
+    def __str__(self) -> str:
+        str_identifier = self.table
+        if self.db:
+            str_identifier = f"{self.db}.{str_identifier}"
+        if self.catalog:
+            str_identifier = f"{self.catalog}.{str_identifier}"
+        return str_identifier
 
 @dataclass(frozen=True)
 class DBIdentifier(BaseIdentifier):
@@ -131,6 +138,12 @@ class DBIdentifier(BaseIdentifier):
         if self.catalog:
             return self
         return DBIdentifier(catalog=catalog_name, db=self.db)
+
+    def __str__(self) -> str:
+        str_identifier = self.db
+        if self.catalog:
+            str_identifier = f"{self.catalog}.{str_identifier}"
+        return str_identifier
 
 
 def compare_object_names(object_name_1: str, object_name_2: str) -> bool:

--- a/src/fenic/api/io/writer.py
+++ b/src/fenic/api/io/writer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 if TYPE_CHECKING:
     from fenic.api.dataframe import DataFrame
@@ -36,6 +36,7 @@ class DataFrameWriter:
         self,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+        location: Optional[str] = None,
     ) -> QueryMetrics:
         """Saves the content of the DataFrame as the specified table.
 
@@ -46,6 +47,7 @@ class DataFrameWriter:
                  - append: Appends data to table if it exists
                  - overwrite: Overwrites existing table
                  - ignore: Silently ignores operation if table exists
+            location: location where the table will be saved (only available for cloud execution)
 
         Returns:
             QueryMetrics: The query metrics
@@ -66,7 +68,7 @@ class DataFrameWriter:
             ```
         """
         sink_plan = TableSink(
-            child=self._dataframe._logical_plan, table_name=table_name, mode=mode
+            child=self._dataframe._logical_plan, table_name=table_name, mode=mode, location=location
         )
 
         metrics = self._dataframe._logical_plan.session_state.execution.save_as_table(

--- a/src/fenic/core/_logical_plan/plans/sink.py
+++ b/src/fenic/core/_logical_plan/plans/sink.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core.error import InternalError
@@ -80,6 +80,7 @@ class TableSink(LogicalPlan):
         child: LogicalPlan,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+        location: Optional[str] = None,
     ):
         """Initialize a table sink node.
 
@@ -91,10 +92,12 @@ class TableSink(LogicalPlan):
                  - append: Appends data to table if it exists
                  - overwrite: Overwrites existing table
                  - ignore: Silently ignores operation if table exists
+            location: location where the table will be saved (only available for cloud execution)
         """
         self.child = child
         self.table_name = table_name
         self.mode = mode
+        self.location = location
         super().__init__(self.child.session_state)
 
     def children(self) -> List[LogicalPlan]:
@@ -107,7 +110,7 @@ class TableSink(LogicalPlan):
 
     def _repr(self) -> str:
         """Return the string representation for this table sink plan."""
-        return f"TableSink(table_name='{self.table_name}', mode='{self.mode}')"
+        return f"TableSink(table_name='{self.table_name}', mode='{self.mode}, location={self.location}')"
 
     def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
         """Create a new table sink with the same properties but different children.
@@ -129,4 +132,5 @@ class TableSink(LogicalPlan):
             child=children[0],
             table_name=self.table_name,
             mode=self.mode,
+            location=self.location,
         )


### PR DESCRIPTION
### TL;DR

Refactored the CloudCatalog class to improve table operations and session management in the cloud backend.

### What changed?

- Refactored `CloudCatalog` initialization to take explicit parameters instead of depending on `CloudSessionState`
- Updated the cloud catalog operations to use the Sc methods
- Added support for specifying table location in `save_as_table` operations
- Enhanced `TableIdentifier` and `DBIdentifier` with `__str__` methods for better string representation
- Removed unused imports and parameters from various methods

### How to test?
1. Test table creation with location from a notebook (Medium and Custom Notebook)
   ```python
   df.write.save_as_table("my_table", location="s3://my-bucket/path")
   ```
2. Updated the UTs to use load table as the basis for does_table_exist
3. Created a separate python integration script for Cloud Catalog testing (not yet added to the PR).