### PR TITLE
fix: split plan creation from validation

### DIFF
--- a/src/fenic/_backends/local/transpiler/plan_converter.py
+++ b/src/fenic/_backends/local/transpiler/plan_converter.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
 from fenic._backends.local.transpiler.expr_converter import (
     ExprConverter,
 )
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
 
 class PlanConverter:
@@ -69,10 +70,7 @@ class PlanConverter:
         self.session_state = session_state
         self.expr_converter = ExprConverter(session_state)
 
-    def convert(
-        self,
-        logical: LogicalPlan,
-    ) -> PhysicalPlan:
+    def convert(self, logical_plan: LogicalPlan) -> PhysicalPlan:
         # Note the order of the rules is important here.
         # NotFilterPushdownRule() and MergeFiltersRule() can be applied
         # in any order, but both must be applied before SemanticFilterRewriteRule()
@@ -81,11 +79,17 @@ class PlanConverter:
             LogicalPlanOptimizer(
                 [NotFilterPushdownRule(), MergeFiltersRule(), SemanticFilterRewriteRule()]
             )
-            .optimize(logical)
+            .optimize(logical_plan)
             .plan
         )
+        return self.convert_logical_plan_node_tree(logical.logical_plan_node)
+
+    def convert_logical_plan_node_tree(
+        self,
+        logical: LogicalPlanNode,
+    ) -> PhysicalPlan:
         if isinstance(logical, Projection):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
             physical_exprs = [
@@ -100,7 +104,7 @@ class PlanConverter:
             )
 
         elif isinstance(logical, Filter):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
             physical_expr = self.expr_converter.convert(
@@ -116,7 +120,7 @@ class PlanConverter:
 
         elif isinstance(logical, Union):
             children_physical = [
-                self.convert(child)
+                self.convert_logical_plan_node_tree(child)
                 for child in logical.children()
             ]
             return UnionExec(
@@ -143,7 +147,7 @@ class PlanConverter:
                 session_state=self.session_state,
             )
         elif isinstance(logical, Limit):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
             return LimitExec(
@@ -154,7 +158,7 @@ class PlanConverter:
             )
 
         elif isinstance(logical, Aggregate):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
             physical_group_exprs = [
@@ -177,10 +181,10 @@ class PlanConverter:
             left_logical = logical.children()[0]
             right_logical = logical.children()[1]
 
-            left_physical = self.convert(
+            left_physical = self.convert_logical_plan_node_tree(
                 left_logical
             )
-            right_physical = self.convert(
+            right_physical = self.convert_logical_plan_node_tree(
                 right_logical
             )
             left_on_exprs = [
@@ -202,10 +206,10 @@ class PlanConverter:
             )
 
         elif isinstance(logical, SemanticJoin):
-            left_physical = self.convert(
+            left_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
-            right_physical = self.convert(
+            right_physical = self.convert_logical_plan_node_tree(
                 logical.children()[1]
             )
 
@@ -223,10 +227,10 @@ class PlanConverter:
             )
 
         elif isinstance(logical, SemanticSimilarityJoin):
-            left_physical = self.convert(
+            left_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
-            right_physical = self.convert(
+            right_physical = self.convert_logical_plan_node_tree(
                 logical.children()[1]
             )
             return SemanticSimilarityJoinExec(
@@ -254,7 +258,7 @@ class PlanConverter:
             )
 
         elif isinstance(logical, SemanticCluster):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.children()[0]
             )
             physical_by_expr = self.expr_converter.convert(
@@ -278,7 +282,7 @@ class PlanConverter:
             physical_expr = self.expr_converter.convert(
                 logical._expr
             )
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 child_logical
             )
             target_field = logical._expr.to_column_field(child_logical)
@@ -292,7 +296,7 @@ class PlanConverter:
 
         elif isinstance(logical, DropDuplicates):
             child_logical = logical.children()[0]
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 child_logical
             )
 
@@ -305,7 +309,7 @@ class PlanConverter:
 
         elif isinstance(logical, Sort):
             child_logical = logical.children()[0]
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 child_logical
             )
 
@@ -336,7 +340,7 @@ class PlanConverter:
 
         elif isinstance(logical, Unnest):
             child_logical = logical.children()[0]
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 child_logical
             )
             return UnnestExec(
@@ -347,7 +351,7 @@ class PlanConverter:
             )
 
         elif isinstance(logical, FileSink):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.child
             )
             return FileSinkExec(
@@ -360,7 +364,7 @@ class PlanConverter:
             )
 
         elif isinstance(logical, TableSink):
-            child_physical = self.convert(
+            child_physical = self.convert_logical_plan_node_tree(
                 logical.child
             )
             return DuckDBTableSinkExec(
@@ -374,7 +378,7 @@ class PlanConverter:
 
         elif isinstance(logical, SQL):
             return SQLExec(
-                children=[self.convert(child) for child in logical.children()],
+                children=[self.convert_logical_plan_node_tree(child) for child in logical.children()],
                 query=logical.resolved_query,
                 cache_info=logical.cache_info,
                 session_state=self.session_state,

--- a/src/fenic/api/dataframe/dataframe.py
+++ b/src/fenic/api/dataframe/dataframe.py
@@ -44,6 +44,7 @@ from fenic.core._logical_plan.plans import (
 from fenic.core._logical_plan.plans import (
     Union as UnionLogicalPlan,
 )
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core.error import ValidationError
 from fenic.core.metrics import QueryMetrics
 from fenic.core.types import Schema
@@ -97,23 +98,15 @@ class DataFrame:
 
     @classmethod
     def _from_logical_plan(
-        cls, logical_plan: LogicalPlan
+        cls,
+        logical_plan: LogicalPlan,
+        node: LogicalPlanNode
     ) -> DataFrame:
-        """Factory method to create DataFrame instances.
-
-        This method is intended for internal use by the Session class and other
-        DataFrame methods that need to create new DataFrame instances.
-
-        Args:
-            logical_plan: The logical plan for this DataFrame
-
-        Returns:
-            A new DataFrame instance
-        """
+        """Factory method to create DataFrame instances."""
         if not isinstance(logical_plan, LogicalPlan):
             raise TypeError(f"Expected LogicalPlan, got {type(logical_plan)}")
         df = super().__new__(cls)
-        df._logical_plan = logical_plan
+        df._logical_plan = logical_plan.add_node(node)
         return df
 
     @property
@@ -400,7 +393,10 @@ class DataFrame:
         table_name = f"cache_{uuid.uuid4().hex}"
         cache_info = CacheInfo(duckdb_table_name=table_name)
         self._logical_plan.set_cache_info(cache_info)
-        return self._from_logical_plan(self._logical_plan)
+
+        return self._from_logical_plan(
+            LogicalPlan(self._logical_plan.session_state),
+            self._logical_plan.logical_plan_node)
 
     def cache(self) -> DataFrame:
         """Alias for persist(). Mark DataFrame for caching after first computation.
@@ -479,7 +475,8 @@ class DataFrame:
                 exprs.append(c._logical_expr)
 
         return self._from_logical_plan(
-            Projection(self._logical_plan, exprs)
+            self._logical_plan,
+            Projection(exprs)
         )
 
     def where(self, condition: Column) -> DataFrame:
@@ -548,7 +545,8 @@ class DataFrame:
             ```
         """
         return self._from_logical_plan(
-            Filter(self._logical_plan, condition._logical_expr),
+            self._logical_plan,
+            Filter(condition._logical_expr),
         )
 
     def with_column(self, col_name: str, col: Union[Any, Column]) -> DataFrame:
@@ -634,7 +632,8 @@ class DataFrame:
         exprs.append(col.alias(col_name)._logical_expr)
 
         return self._from_logical_plan(
-            Projection(self._logical_plan, exprs)
+            self._logical_plan,
+            Projection(exprs)
         )
 
     def with_column_renamed(self, col_name: str, new_col_name: str) -> DataFrame:
@@ -699,7 +698,8 @@ class DataFrame:
             return self
 
         return self._from_logical_plan(
-            Projection(self._logical_plan, exprs)
+            self._logical_plan,
+            Projection(exprs)
         )
 
     def drop(self, *col_names: str) -> DataFrame:
@@ -780,7 +780,8 @@ class DataFrame:
             raise ValueError("Cannot drop all columns from DataFrame")
 
         return self._from_logical_plan(
-            Projection(self._logical_plan, remaining_cols)
+            self._logical_plan,
+            Projection(remaining_cols)
         )
 
     def union(self, other: DataFrame) -> DataFrame:
@@ -859,8 +860,14 @@ class DataFrame:
             # +---+-----+
             ```
         """
+        UnionLogicalPlan.validate_same_session(
+            self._logical_plan.session_state,
+            [other._logical_plan.session_state])
         return self._from_logical_plan(
-            UnionLogicalPlan([self._logical_plan, other._logical_plan]),
+            self._logical_plan,
+            UnionLogicalPlan(
+                [self._logical_plan.logical_plan_node,
+                 other._logical_plan.logical_plan_node])
         )
 
     def limit(self, n: int) -> DataFrame:
@@ -908,7 +915,10 @@ class DataFrame:
             # +---+-------+
             ```
         """
-        return self._from_logical_plan(Limit(self._logical_plan, n))
+        return self._from_logical_plan(
+            self._logical_plan,
+            Limit(n)
+        )
 
     @overload
     def join(
@@ -1035,10 +1045,21 @@ class DataFrame:
 
         # Build join conditions
         left_conditions, right_conditions = build_join_conditions(on, left_on, right_on)
+        Join.validate_same_session(
+            self._logical_plan.session_state,
+            other._logical_plan.session_state)
 
         return self._from_logical_plan(
-            Join(self._logical_plan, other._logical_plan, left_conditions, right_conditions, how),
+            self._logical_plan,
+            Join(
+                self._logical_plan.logical_plan_node,
+                other._logical_plan.logical_plan_node,
+                left_conditions,
+                right_conditions,
+                how
+            )
         )
+
 
     def explode(self, column: ColumnOrName) -> DataFrame:
         """Create a new row for each element in an array column.
@@ -1094,8 +1115,14 @@ class DataFrame:
             # +---+-----+-----+
             ```
         """
+        # return self._from_logical_plan(
+        #     Explode(self._logical_plan, Column._from_col_or_name(column)._logical_expr),
+        # )
         return self._from_logical_plan(
-            Explode(self._logical_plan, Column._from_col_or_name(column)._logical_expr),
+            self._logical_plan,
+            Explode(
+                Column._from_col_or_name(column)._logical_expr
+            )
         )
 
     def group_by(self, *cols: ColumnOrName) -> GroupedData:
@@ -1256,7 +1283,8 @@ class DataFrame:
                 exprs.append(col(c)._logical_expr)
 
         return self._from_logical_plan(
-            DropDuplicates(self._logical_plan, exprs),
+            self._logical_plan,
+            DropDuplicates(exprs),
         )
 
     def sort(
@@ -1368,7 +1396,8 @@ class DataFrame:
         col_args = cols
         if cols is None:
             return self._from_logical_plan(
-                Sort(self._logical_plan, [])
+                self._logical_plan,
+                Sort([])
             )
         elif not isinstance(cols, List):
             col_args = [cols]
@@ -1418,7 +1447,8 @@ class DataFrame:
                 sort_exprs.append(SortExpr(c_expr, ascending=asc_bool))
 
         return self._from_logical_plan(
-            Sort(self._logical_plan, sort_exprs),
+            self._logical_plan,
+            Sort(sort_exprs),
         )
 
     def order_by(
@@ -1508,7 +1538,8 @@ class DataFrame:
                 raise TypeError(f"Column {c} not found in DataFrame.")
             exprs.append(col(c)._logical_expr)
         return self._from_logical_plan(
-            Unnest(self._logical_plan, exprs),
+            self._logical_plan,
+            Unnest(exprs),
         )
 
 

--- a/src/fenic/api/dataframe/grouped_data.py
+++ b/src/fenic/api/dataframe/grouped_data.py
@@ -89,5 +89,6 @@ class GroupedData(BaseGroupedData):
 
         agg_exprs = self._process_agg_exprs(exprs)
         return self._df._from_logical_plan(
-            Aggregate(self._df._logical_plan, self._by_exprs, agg_exprs),
+            self._df._logical_plan,
+            Aggregate(self._by_exprs, agg_exprs),
         )

--- a/src/fenic/api/dataframe/semantic_extensions.py
+++ b/src/fenic/api/dataframe/semantic_extensions.py
@@ -125,8 +125,8 @@ class SemanticExtensions:
             )
 
         return self._df._from_logical_plan(
+            self._df._logical_plan,
             SemanticCluster(
-                self._df._logical_plan,
                 by_expr,
                 num_clusters=num_clusters,
                 max_iter=max_iter,
@@ -242,10 +242,14 @@ class SemanticExtensions:
                 "join_instruction must contain exactly one :left and one :right column"
             )
 
+        SemanticJoin.validate_same_session(
+            self._df._logical_plan.session_state,
+            other._logical_plan.session_state)
         return self._df._from_logical_plan(
+            self._df._logical_plan,
             SemanticJoin(
-                left=self._df._logical_plan,
-                right=other._logical_plan,
+                left=self._df._logical_plan.logical_plan_node,
+                right=other._logical_plan.logical_plan_node,
                 left_on=left_on._logical_expr,
                 right_on=right_on._logical_expr,
                 join_instruction=join_instruction,
@@ -353,10 +357,14 @@ class SemanticExtensions:
         _validate_column(left_on, "left_on")
         _validate_column(right_on, "right_on")
 
+        SemanticSimilarityJoin.validate_same_session(
+            self._df._logical_plan.session_state,
+            other._logical_plan.session_state)
         return self._df._from_logical_plan(
+            self._df._logical_plan,
             SemanticSimilarityJoin(
-                self._df._logical_plan,
-                other._logical_plan,
+                self._df._logical_plan.logical_plan_node,
+                other._logical_plan.logical_plan_node,
                 Column._from_col_or_name(left_on)._logical_expr,
                 Column._from_col_or_name(right_on)._logical_expr,
                 k,

--- a/src/fenic/api/io/reader.py
+++ b/src/fenic/api/io/reader.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from fenic.api.dataframe import DataFrame
     from fenic.core._interfaces import BaseSessionState
 
-from fenic.core._logical_plan.plans import FileSource
+from fenic.core._logical_plan.plans import FileSource, LogicalPlan
 from fenic.core.error import ValidationError
 
 
@@ -217,12 +217,12 @@ class DataFrameReader:
         # Convert all paths to strings
         paths_str = [str(p) for p in paths_list]
 
-        logical_node = FileSource(
-            paths=paths_str,
-            file_format=file_format,
-            session_state=self._session_state,
-            options=options,
-        )
         from fenic.api.dataframe import DataFrame
 
-        return DataFrame._from_logical_plan(logical_node)
+        return DataFrame._from_logical_plan(
+            LogicalPlan(self._session_state),
+            FileSource(
+                paths=paths_str,
+                file_format=file_format,
+                options=options,
+            ))

--- a/src/fenic/api/io/writer.py
+++ b/src/fenic/api/io/writer.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from pydantic import ConfigDict, validate_call
 
-from fenic.core._logical_plan.plans import FileSink, TableSink
+from fenic.core._logical_plan.plans import FileSink, LogicalPlan, TableSink
 from fenic.core.error import ValidationError
 from fenic.core.metrics import QueryMetrics
 
@@ -65,9 +65,8 @@ class DataFrameWriter:
             df.write.save_as_table("my_table", mode="overwrite")  # Replaces existing table
             ```
         """
-        sink_plan = TableSink(
-            child=self._dataframe._logical_plan, table_name=table_name, mode=mode
-        )
+        sink_plan = LogicalPlan(self._dataframe._logical_plan.session_state)
+        sink_plan = sink_plan.add_node(TableSink(self._dataframe._logical_plan.logical_plan_node, table_name, mode))
 
         metrics = self._dataframe._logical_plan.session_state.execution.save_as_table(
             sink_plan, table_name=table_name, mode=mode
@@ -114,12 +113,8 @@ class DataFrameWriter:
                 f"Your path '{file_path}' is missing the extension."
             )
 
-        sink_plan = FileSink(
-            child=self._dataframe._logical_plan,
-            sink_type="csv",
-            path=file_path,
-            mode=mode,
-        )
+        sink_plan = LogicalPlan(self._dataframe._logical_plan.session_state)
+        sink_plan = sink_plan.add_node(FileSink(self._dataframe._logical_plan.logical_plan_node, "csv", file_path, mode))
 
         metrics = self._dataframe._logical_plan.session_state.execution.save_to_file(
             sink_plan, file_path=file_path, mode=mode
@@ -166,12 +161,8 @@ class DataFrameWriter:
                 f"Your path '{file_path}' is missing the extension."
             )
 
-        sink_plan = FileSink(
-            child=self._dataframe._logical_plan,
-            sink_type="parquet",
-            path=file_path,
-            mode=mode,
-        )
+        sink_plan = LogicalPlan(self._dataframe._logical_plan.session_state)
+        sink_plan = sink_plan.add_node(FileSink(self._dataframe._logical_plan.logical_plan_node, "parquet", file_path, mode))
 
         metrics = self._dataframe._logical_plan.session_state.execution.save_to_file(
             sink_plan, file_path=file_path, mode=mode

--- a/src/fenic/api/session/session.py
+++ b/src/fenic/api/session/session.py
@@ -23,6 +23,7 @@ from pydantic import ConfigDict, validate_call
 
 from fenic.api.catalog import Catalog
 from fenic.api.session.config import SessionConfig
+from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core.error import PlanError, ValidationError
 from fenic.core.types.query_result import DataLike
 
@@ -214,7 +215,8 @@ class Session:
             raise PlanError(f"Failed to create DataFrame from {data}") from e
 
         return DataFrame._from_logical_plan(
-            InMemorySource(pl_df, self._session_state)
+            LogicalPlan(self._session_state),
+            InMemorySource(pl_df)
         )
 
     def table(self, table_name: str) -> DataFrame:
@@ -237,7 +239,8 @@ class Session:
         if not self._session_state.catalog.does_table_exist(table_name):
             raise ValueError(f"Table {table_name} does not exist")
         return DataFrame._from_logical_plan(
-            TableSource(table_name, self._session_state),
+            LogicalPlan(self._session_state),
+            TableSource(table_name),
         )
 
     def sql(self, query: str, /, **tables: DataFrame) -> DataFrame:
@@ -297,15 +300,21 @@ class Session:
                 f"Make sure to pass them as keyword arguments, e.g., sql(..., {next(iter(missing))}=df)."
             )
 
+        session_states = []
         logical_plans = []
         template_names = []
         for name, table in tables.items():
             if name in placeholders:
                 template_names.append(name)
-                logical_plans.append(table._logical_plan)
+                logical_plans.append(table._logical_plan.logical_plan_node)
+                session_states.append(table._logical_plan.session_state)
 
+        SQL.validate_same_session(
+            self._session_state,
+            session_states)
         return DataFrame._from_logical_plan(
-            SQL(logical_plans, template_names, query, self._session_state),
+            LogicalPlan(self._session_state),
+            SQL(logical_plans, template_names, query),
         )
 
     def stop(self):

--- a/src/fenic/core/_logical_plan/expressions/aggregate.py
+++ b/src/fenic/core/_logical_plan/expressions/aggregate.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     AggregateExpr,
     LogicalExpr,
@@ -52,15 +53,19 @@ class AvgExpr(ValidatedDynamicSignature, AggregateExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Use signature to validate and get return type, storing input type for transpiler."""
         # Get the input type first
-        self.input_type = self.expr.to_column_field(plan).data_type
+        self.input_type = self.expr.to_column_field(node, session_state).data_type
 
         # Now use the mixin implementation to validate and get return type
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+            self,
+            arg_types: List[DataType],
+            node: LogicalPlanNode,
+            session_state: BaseSessionState) -> DataType:
         """Return EmbeddingType for embeddings, DoubleType for numeric types."""
         input_type = arg_types[0]
         if isinstance(input_type, EmbeddingType):
@@ -135,7 +140,11 @@ class ListExpr(ValidatedDynamicSignature, AggregateExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr]
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+            self,
+            arg_types: List[DataType],
+            node: LogicalPlanNode,
+            session_state: BaseSessionState) -> DataType:
         """Return ArrayType with element type matching the input type."""
         return ArrayType(arg_types[0])
 

--- a/src/fenic/core/_logical_plan/expressions/arithmetic.py
+++ b/src/fenic/core/_logical_plan/expressions/arithmetic.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import BinaryExpr
 from fenic.core.types.datatypes import (
     DataType,
@@ -41,9 +42,9 @@ class ArithmeticExpr(BinaryExpr):
         else:
             return IntegerType
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        left_field = self.left.to_column_field(plan)
-        right_field = self.right.to_column_field(plan)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        left_field = self.left.to_column_field(node, session_state)
+        right_field = self.right.to_column_field(node, session_state)
         self._validate_types(left_field.data_type, right_field.data_type)
         result_type = self._promote_type(left_field.data_type, right_field.data_type)
         return ColumnField(str(self), result_type)

--- a/src/fenic/core/_logical_plan/expressions/base.py
+++ b/src/fenic/core/_logical_plan/expressions/base.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
     from fenic.core._logical_plan.signatures import SignatureValidator
     from fenic.core.types.datatypes import DataType
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core.types import ColumnField
 
 
@@ -40,8 +41,8 @@ class LogicalExpr(ABC):
         pass
 
     @abstractmethod
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        """Returns the schema field for the expression within the given plan."""
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        """Returns the schema field for the expression within the given plan node."""
         pass
 
     @abstractmethod
@@ -59,7 +60,7 @@ class SemanticExpr(LogicalExpr):
     """Marker class for semantic expressions that use LLM models."""
     
     @abstractmethod
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, plan: LogicalPlanNode):
         """Common validation for semantic functions."""
         pass
 
@@ -90,9 +91,9 @@ class ValidatedSignature:
     def children(self) -> List[LogicalExpr]:
         pass
     
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Default implementation using validator property."""
-        return_type = self.validator.validate_and_infer_type(self.children(), plan)
+        return_type = self.validator.validate_and_infer_type(self.children(), node, session_state)
         return ColumnField(name=str(self), data_type=return_type)
 
     def __str__(self) -> str:
@@ -128,22 +129,27 @@ class ValidatedDynamicSignature:
         pass
 
     @abstractmethod
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Must be implemented by subclass for dynamic return type inference.
         
         Args:
             arg_types: List of argument data types after validation
-            plan: LogicalPlan for schema context
+            node: LogicalPlanNode for schema context
+            session_state: BaseSessionState for session state
             
         Returns:
             DataType: The dynamically inferred return type
         """
         pass
     
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Default implementation using validator property with dynamic return type."""
         return_type = self.validator.validate_and_infer_type(
-            self.children(), plan, self._infer_dynamic_return_type
+            self.children(), node, session_state, self._infer_dynamic_return_type
         )
         return ColumnField(name=str(self), data_type=return_type)
 

--- a/src/fenic/core/_logical_plan/expressions/basic.py
+++ b/src/fenic/core/_logical_plan/expressions/basic.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, List, Literal
+from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     LogicalExpr,
     ValidatedDynamicSignature,
@@ -44,14 +45,14 @@ class ColumnExpr(LogicalExpr):
     def __str__(self) -> str:
         return self.name
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         column_field = next(
-            (f for f in plan.schema().column_fields if f.name == self.name), None
+            (f for f in node.schema().column_fields if f.name == self.name), None
         )
         if column_field is None:
             raise ValueError(
                 f"Column '{self.name}' not found in schema. "
-                f"Available columns: {', '.join(sorted(f.name for f in plan.schema().column_fields))}"
+                f"Available columns: {', '.join(sorted(f.name for f in node.schema().column_fields))}"
             )
         return column_field
 
@@ -69,7 +70,7 @@ class LiteralExpr(LogicalExpr):
     def __str__(self) -> str:
         return f"lit({self.literal})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         return ColumnField(str(self), self.data_type)
 
     def children(self) -> List[LogicalExpr]:
@@ -86,8 +87,8 @@ class AliasExpr(LogicalExpr):
     def __str__(self) -> str:
         return f"{self.expr} AS {self.name}"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return ColumnField(str(self.name), self.expr.to_column_field(plan).data_type)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        return ColumnField(str(self.name), self.expr.to_column_field(node, session_state).data_type)
 
     def children(self) -> List[LogicalExpr]:
         return [self.expr]
@@ -105,8 +106,8 @@ class SortExpr(LogicalExpr):
         direction = "asc" if self.ascending else "desc"
         return f"{direction}({self.expr})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return ColumnField(str(self), self.expr.to_column_field(plan).data_type)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        return ColumnField(str(self), self.expr.to_column_field(node, session_state).data_type)
 
     def column_expr(self) -> LogicalExpr:
         return self.expr
@@ -126,9 +127,9 @@ class IndexExpr(LogicalExpr):
     def __str__(self) -> str:
         return f"{self.expr}[{self.index}]"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        expr_field = self.expr.to_column_field(plan)
-        index_field = self.index.to_column_field(plan)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        expr_field = self.expr.to_column_field(node, session_state)
+        index_field = self.index.to_column_field(node, session_state)
         expr_type = expr_field.data_type
         index_type = index_field.data_type
 
@@ -184,7 +185,11 @@ class ArrayExpr(ValidatedDynamicSignature, LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return self.exprs
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Return ArrayType with element type matching the first argument."""
         # Signature validation ensures all args have the same type
         return ArrayType(arg_types[0])
@@ -206,7 +211,11 @@ class StructExpr(ValidatedDynamicSignature, LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return self.exprs
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Return StructType with fields based on argument names and types."""
         struct_fields = []
         for (arg, arg_type) in zip(self.children(), arg_types, strict=True):
@@ -231,9 +240,9 @@ class UDFExpr(LogicalExpr):
         args_str = ", ".join(str(arg) for arg in self.args)
         return f"{self.func.__name__}({args_str})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         for arg in self.args:
-            _ = arg.to_column_field(plan)
+            _ = arg.to_column_field(node, session_state)
         return ColumnField(str(self), self.return_type)
 
     def children(self) -> List[LogicalExpr]:
@@ -248,7 +257,7 @@ class IsNullExpr(LogicalExpr):
     def __str__(self):
         return f"{self.expr} IS {'' if self.is_null else 'NOT'} NULL"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         return ColumnField(str(self), BooleanType)
 
     def children(self) -> List[LogicalExpr]:
@@ -298,8 +307,8 @@ class CastExpr(LogicalExpr):
     def __str__(self):
         return f"cast({self.expr} AS {self.dest_type})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self.source_type = self.expr.to_column_field(plan).data_type
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        self.source_type = self.expr.to_column_field(node, session_state).data_type
         src = self.source_type
         dst = self.dest_type
         if not _can_cast(src, dst):
@@ -317,11 +326,11 @@ class NotExpr(LogicalExpr):
     def __str__(self):
         return f"NOT {self.expr}"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        if self.expr.to_column_field(plan).data_type != BooleanType:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        if self.expr.to_column_field(node, session_state).data_type != BooleanType:
             raise TypeError(
                 f"Type mismatch: Cannot apply NOT to non-boolean types. "
-                f"Type: {self.expr.to_column_field(plan).data_type}. "
+                f"Type: {self.expr.to_column_field(node, session_state).data_type}. "
                 f"Only boolean types are supported."
             )
         return ColumnField(str(self), BooleanType)
@@ -355,18 +364,18 @@ class InExpr(LogicalExpr):
     def __str__(self):
         return f"{self.expr} IN {self.other}"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        if not isinstance(self.other.to_column_field(plan).data_type, ArrayType):
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        if not isinstance(self.other.to_column_field(node, session_state).data_type, ArrayType):
             raise TypeMismatchError.from_message(
                 f"The 'other' argument to IN must be an ArrayType. "
-                f"Got: {self.other.to_column_field(plan).data_type}. "
+                f"Got: {self.other.to_column_field(node, session_state).data_type}. "
                 f"Expression: {self.expr} IN {self.other}"
             )
-        if self.expr.to_column_field(plan).data_type != self.other.to_column_field(plan).data_type.element_type:
+        if self.expr.to_column_field(node, session_state).data_type != self.other.to_column_field(node, session_state).data_type.element_type:
             raise TypeMismatchError.from_message(
                 f"The element being searched for must match the array's element type. "
-                f"Searched element type: {self.expr.to_column_field(plan).data_type}, "
-                f"Array element type: {self.other.to_column_field(plan).data_type.element_type}. "
+                f"Searched element type: {self.expr.to_column_field(node, session_state).data_type}, "
+                f"Array element type: {self.other.to_column_field(node, session_state).data_type.element_type}. "
                 f"Expression: {self.expr} IN {self.other}"
             )
         return ColumnField(str(self), BooleanType)

--- a/src/fenic/core/_logical_plan/expressions/case.py
+++ b/src/fenic/core/_logical_plan/expressions/case.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core.types import BooleanType, ColumnField
 
@@ -18,14 +19,14 @@ class WhenExpr(LogicalExpr):
     def __str__(self):
         return f"{'CASE' if self.expr is None else self.expr} WHEN ({self.condition}) THEN ({self.value})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        if self.condition.to_column_field(plan).data_type != BooleanType:
+    def to_column_field(self, node: LogicalPlanNode, session_state: BaseSessionState) -> ColumnField:
+        if self.condition.to_column_field(node, session_state).data_type != BooleanType:
             raise TypeError(
                 "when() condition must be a boolean expression.  Got type: "
-                f"{self.condition.to_column_field(plan).data_type}"
+                f"{self.condition.to_column_field(node, session_state).data_type}"
             )
 
-        return self.value.to_column_field(plan)
+        return self.value.to_column_field(node, session_state)
 
     def children(self) -> List[LogicalExpr]:
         children = []
@@ -45,8 +46,8 @@ class OtherwiseExpr(LogicalExpr):
     def __str__(self):
         return f"{self.expr} ELSE ({self.value})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return self.value.to_column_field(plan)
+    def  to_column_field(self, node: LogicalPlanNode, session_state: BaseSessionState) -> ColumnField:
+        return self.value.to_column_field(node, session_state)
 
     def children(self) -> List[LogicalExpr]:
         return [self.expr, self.value]

--- a/src/fenic/core/_logical_plan/expressions/comparison.py
+++ b/src/fenic/core/_logical_plan/expressions/comparison.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Optional
 
-if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
-
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import BinaryExpr
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core.types import (
     BooleanType,
     ColumnField,
@@ -14,9 +13,9 @@ from fenic.core.types.datatypes import is_dtype_numeric
 
 
 class EqualityComparisonExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, node: LogicalPlanNode, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(node, session_state).data_type
+        right_type = self.right.to_column_field(node, session_state).data_type
 
         if left_type != right_type:
             raise TypeError(
@@ -26,15 +25,15 @@ class EqualityComparisonExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        self._validate_types(node, session_state)
         return ColumnField(str(self), BooleanType)
 
 
 class NumericComparisonExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, node: LogicalPlanNode, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(node, session_state).data_type
+        right_type = self.right.to_column_field(node, session_state).data_type
 
         if not is_dtype_numeric(left_type) or not is_dtype_numeric(right_type):
             raise TypeError(
@@ -44,15 +43,15 @@ class NumericComparisonExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
+        self._validate_types(node, session_state)
         return ColumnField(str(self), BooleanType)
 
 
 class BooleanExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, node: LogicalPlanNode, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(node, session_state).data_type
+        right_type = self.right.to_column_field(node, session_state).data_type
 
         if left_type != BooleanType or right_type != BooleanType:
             raise TypeError(
@@ -62,6 +61,6 @@ class BooleanExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, node: LogicalPlanNode, session_state: BaseSessionState    ) -> ColumnField:
+        self._validate_types(node, session_state)
         return ColumnField(str(self), BooleanType)

--- a/src/fenic/core/_logical_plan/expressions/embedding.py
+++ b/src/fenic/core/_logical_plan/expressions/embedding.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 
-if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
-
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr, ValidatedSignature
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._logical_plan.signatures.signature_validator import SignatureValidator
 from fenic.core.error import ValidationError
 from fenic.core.types import (
@@ -32,11 +31,11 @@ class EmbeddingNormalizeExpr(ValidatedSignature, LogicalExpr):
     def validator(self) -> SignatureValidator:
         return self._validator
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         # Use validator to handle signature validation (which ensures EmbeddingType)
-        super().to_column_field(plan)
+        super().to_column_field(node, session_state)
         # Get the actual input field to extract dimensions
-        input_field = self.expr.to_column_field(plan)
+        input_field = self.expr.to_column_field(node, session_state)
         self.dimensions = input_field.data_type.dimensions
         # Return same EmbeddingType - normalization preserves the model
         return ColumnField(name=str(self), data_type=input_field.data_type)
@@ -70,21 +69,21 @@ class EmbeddingSimilarityExpr(ValidatedSignature, LogicalExpr):
         else:
             return f"embedding.compute_similarity({self.expr}, query_vector, metric={self.metric})"
 
-    def _validate_query_vector_dimensions(self, plan: LogicalPlan):
+    def _validate_query_vector_dimensions(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None):
         """Validate query vector dimensions match embedding dimensions."""
         if not isinstance(self.other, LogicalExpr):
             # Column vs query vector - check dimensions
-            input_field = self.expr.to_column_field(plan)
+            input_field = self.expr.to_column_field(node, session_state)
             if input_field.data_type.dimensions != len(self.other):
                 raise ValidationError(
                     f"Query vector dimensions ({len(self.other)}) must match embedding dimensions ({input_field.data_type.dimensions})"
                 )
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         # If comparison field is a query vector, validate its dimensions
-        self._validate_query_vector_dimensions(plan)
+        self._validate_query_vector_dimensions(node, session_state)
         # Use mixin's validation by calling super()
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
     def children(self) -> List[LogicalExpr]:
         return self._children

--- a/src/fenic/core/_logical_plan/expressions/semantic.py
+++ b/src/fenic/core/_logical_plan/expressions/semantic.py
@@ -15,12 +15,13 @@ from fenic.core.types import (
 )
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan import LogicalPlan
+    pass
 import fenic.core._utils.misc as utils
 from fenic._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     AggregateExpr,
     LogicalExpr,
@@ -29,6 +30,7 @@ from fenic.core._logical_plan.expressions.base import (
     ValidatedSignature,
 )
 from fenic.core._logical_plan.expressions.basic import ColumnExpr
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._logical_plan.signatures.signature_validator import SignatureValidator
 from fenic.core._utils.schema import convert_pydantic_type_to_custom_struct_type
 from fenic.core.error import ValidationError
@@ -81,18 +83,18 @@ class SemanticMapExpr(ValidatedDynamicSignature, SemanticExpr):
         """Return the child expressions."""
         return self.exprs
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation with dynamic return type
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters."""
         validate_completion_parameters(
             self.model_alias,
-            plan.session_state.session_config,
+            session_state.session_config,
             self.temperature,
             self.max_tokens
         )
@@ -132,28 +134,32 @@ class SemanticExtractExpr(ValidatedDynamicSignature, SemanticExpr):
         """Return the child expressions."""
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation with dynamic return type
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
     def __str__(self):
         schema_hash = utils.get_content_hash(str(self.schema))
         expr_str = str(self.expr)
         return f"semantic.extract_{schema_hash}({expr_str})"
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters."""
         validate_completion_parameters(
             self.model_alias,
-            plan.session_state.session_config,
+            session_state.session_config,
             self.temperature,
             self.max_tokens
         )
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Return StructType based on the schema."""
         return convert_pydantic_type_to_custom_struct_type(self.schema)
 
@@ -196,21 +202,21 @@ class SemanticPredExpr(ValidatedSignature, SemanticExpr):
         """Return the child expressions."""
         return self.exprs
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
     def __str__(self):
         instruction_hash = utils.get_content_hash(self.instruction)
         exprs_str = ", ".join(str(expr) for expr in self.exprs)
         return f"semantic.predicate_{instruction_hash}({exprs_str})"
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters (no max_tokens for predicate)."""
-        validate_completion_parameters(self.model_alias, plan.session_state.session_config, self.temperature)
+        validate_completion_parameters(self.model_alias, session_state.session_config, self.temperature)
 
 
 class SemanticReduceExpr(ValidatedSignature, SemanticExpr, AggregateExpr):
@@ -248,18 +254,18 @@ class SemanticReduceExpr(ValidatedSignature, SemanticExpr, AggregateExpr):
         """Return the child expressions."""
         return self.exprs
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters."""
         validate_completion_parameters(
             self.model_alias,
-            plan.session_state.session_config,
+            session_state.session_config,
             self.temperature,
             self.max_tokens
         )
@@ -315,16 +321,16 @@ class SemanticClassifyExpr(ValidatedSignature, SemanticExpr):
         labels_str = ", ".join(f"'{class_def.label}'" for class_def in self.classes)
         return f"semantic.classify({self.expr}, [{labels_str}])"
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters (called after signature validation)."""
-        validate_completion_parameters(self.model_alias, plan.session_state.session_config, self.temperature)
+        validate_completion_parameters(self.model_alias, session_state.session_config, self.temperature)
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
 class AnalyzeSentimentExpr(ValidatedSignature, SemanticExpr):
     function_name = "semantic.analyze_sentiment"
@@ -351,19 +357,19 @@ class AnalyzeSentimentExpr(ValidatedSignature, SemanticExpr):
         """Return the child expressions."""
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
     def __str__(self):
         return f"semantic.analyze_sentiment({self.expr})"
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters (no max_tokens for analyze_sentiment)."""
-        validate_completion_parameters(self.model_alias, plan.session_state.session_config, self.temperature)
+        validate_completion_parameters(self.model_alias, session_state.session_config, self.temperature)
 
 
 class EmbeddingsExpr(ValidatedDynamicSignature, SemanticExpr):
@@ -392,24 +398,32 @@ class EmbeddingsExpr(ValidatedDynamicSignature, SemanticExpr):
         """Return the child expressions."""
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation with dynamic return type
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
     def __str__(self) -> str:
         return f"semantic.embed({self.expr}, {self.model_alias})"
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Return EmbeddingType with specific dimensions based on model."""
-        return_type = self._get_embedding_type_from_config(plan)
+        return_type = self._get_embedding_type_from_config(node, session_state)
         return return_type
 
-    def _get_embedding_type_from_config(self, plan: LogicalPlan) -> EmbeddingType:
+    def _get_embedding_type_from_config(self, node: LogicalPlanNode, session_state: BaseSessionState) -> EmbeddingType:
         """Validate model configuration and return the correct EmbeddingType."""
-        semantic_config = plan.session_state.session_config.semantic
+        return self._validate_model_config(node, session_state)
+
+    def _validate_model_config(self, node: LogicalPlanNode, session_state: BaseSessionState) -> EmbeddingType:
+        """Validate model configuration and return the correct EmbeddingType."""
+        semantic_config = session_state.session_config.semantic
 
         # Check if any embedding models are configured
         if not semantic_config.embedding_models:
@@ -436,7 +450,7 @@ class EmbeddingsExpr(ValidatedDynamicSignature, SemanticExpr):
             dimensions=embedding_params.output_dimensions
         )
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Embeddings don't use completion parameters."""
         pass
 
@@ -468,16 +482,16 @@ class SemanticSummarizeExpr(ValidatedSignature, SemanticExpr):
         """Return the child expressions."""
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         """Handle signature validation and completion parameter validation."""
         # Common validation for all semantic functions
-        self._validate_completion_parameters(plan)
+        self._validate_completion_parameters(node, session_state)
         # Use mixin's implementation
-        return super().to_column_field(plan)
+        return super().to_column_field(node, session_state)
 
-    def _validate_completion_parameters(self, plan: LogicalPlan):
+    def _validate_completion_parameters(self, node: LogicalPlanNode, session_state: BaseSessionState):
         """Validate completion parameters."""
-        validate_completion_parameters(self.model_alias, plan.session_state.session_config, self.temperature)
+        validate_completion_parameters(self.model_alias, session_state.session_config, self.temperature)
 
     def __str__(self) -> str:
         return f"semantic.summarize({self.expr})"

--- a/src/fenic/core/_logical_plan/expressions/text.py
+++ b/src/fenic/core/_logical_plan/expressions/text.py
@@ -10,18 +10,20 @@ from fenic.core._logical_plan.jinja_validation import (
 )
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan.plans.base import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
 import logging
 
 from pydantic import BaseModel, Field
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     LogicalExpr,
     ValidatedDynamicSignature,
     ValidatedSignature,
 )
 from fenic.core._logical_plan.expressions.basic import AliasExpr, ColumnExpr
+from fenic.core._logical_plan.plans.base import LogicalPlanNode
 from fenic.core._logical_plan.signatures.signature_validator import SignatureValidator
 from fenic.core.error import ValidationError
 from fenic.core.types import (
@@ -182,7 +184,11 @@ class TextractExpr(ValidatedDynamicSignature, LogicalExpr):
     def __str__(self):
         return f"{self.function_name}('{self.template}', {self.input_expr})"
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(
+        self,
+        arg_types: List[DataType],
+        node: LogicalPlanNode,
+        session_state: BaseSessionState) -> DataType:
         """Return StructType with fields based on parsed template."""
         return self.parsed_template.to_struct_schema()
 
@@ -899,9 +905,9 @@ class JinjaExpr(LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return self.exprs
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, node: LogicalPlanNode, session_state: Optional[BaseSessionState] = None) -> ColumnField:
         for expr in self.exprs:
-            data_type = expr.to_column_field(plan).data_type
+            data_type = expr.to_column_field(node, session_state).data_type
             self.variable_tree.validate_jinja_variable(expr.name, data_type)
 
         return ColumnField(

--- a/src/fenic/core/_logical_plan/optimizer/base.py
+++ b/src/fenic/core/_logical_plan/optimizer/base.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import List
 
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
 
 @dataclass
@@ -15,6 +16,10 @@ class OptimizationResult:
     plan: LogicalPlan
     was_modified: bool
 
+@dataclass
+class OptimizerNodeResult:
+    node: LogicalPlanNode
+    was_modified: bool
 
 class LogicalPlanOptimizerRule(ABC):
     @abstractmethod

--- a/src/fenic/core/_logical_plan/optimizer/merge_filters_rule.py
+++ b/src/fenic/core/_logical_plan/optimizer/merge_filters_rule.py
@@ -1,13 +1,18 @@
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions import BooleanExpr, Operator
 from fenic.core._logical_plan.optimizer.base import (
     LogicalPlanOptimizerRule,
     OptimizationResult,
+    OptimizerNodeResult,
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._logical_plan.plans.transform import Filter
 
 
 class MergeFiltersRule(LogicalPlanOptimizerRule):
+    session_state: BaseSessionState
+
     """Optimization rule that merges consecutive filter operations into a single filter.
 
     This rule identifies consecutive filter operations and combines their predicates
@@ -15,36 +20,48 @@ class MergeFiltersRule(LogicalPlanOptimizerRule):
     """
 
     def apply(self, logical_plan: LogicalPlan) -> OptimizationResult:
-        result = self.optimize_node(logical_plan)
-        return result
+        self.session_state = logical_plan.session_state
+        return self.optimize_plan(logical_plan)
 
-    def optimize_node(self, node: LogicalPlan) -> OptimizationResult:
+    def optimize_plan(self, plan: LogicalPlan) -> OptimizationResult:
+        optimizer_node_result = self.optimize_node(plan.logical_plan_node)
+        logical_plan = LogicalPlan(plan.session_state)
+        logical_plan.logical_plan_node = optimizer_node_result.node
+        return OptimizationResult(
+            logical_plan,
+            optimizer_node_result.was_modified
+        )
+
+    def optimize_node(self, node: LogicalPlanNode) -> OptimizerNodeResult:
         any_child_modified = False
-        optimized_children = []
+        optimized_children: list[LogicalPlanNode] = []
 
         for child in node.children():
             child_result = self.optimize_node(child)
-            optimized_children.append(child_result.plan)
+            optimized_children.append(child_result.node)
             any_child_modified = any_child_modified or child_result.was_modified
 
         new_node = node.with_children(optimized_children)
+        new_node._schema = node._schema
 
         if isinstance(node, Filter):
             merge_result = self.merge_filter(new_node)
-            return OptimizationResult(
-                merge_result.plan, any_child_modified or merge_result.was_modified
+            return OptimizerNodeResult(
+                merge_result.node, any_child_modified or merge_result.was_modified
             )
 
-        return OptimizationResult(new_node, any_child_modified)
+        return OptimizerNodeResult(new_node, any_child_modified)
 
-    def merge_filter(self, node: LogicalPlan) -> OptimizationResult:
+    def merge_filter(self, node: LogicalPlanNode) -> OptimizerNodeResult:
         if isinstance(node._input, Filter) and node._input.cache_info is None:
             merged_filter = Filter(
-                node._input._input,
                 BooleanExpr(node.predicate(), node._input.predicate(), Operator.AND),
             )
-            merged_filter.cache_info = node.cache_info
-            # Return with was_modified=True since we merged filters
-            return OptimizationResult(merged_filter, True)
+            merged_filter.set_input(node._input._input)
+            merged_filter.set_cache_info(node.cache_info)
+            merged_filter._build_schema_with_validation(self.session_state)
 
-        return OptimizationResult(node, False)
+            # Return with was_modified=True since we merged filters
+            return OptimizerNodeResult(merged_filter, True)
+
+        return OptimizerNodeResult(node, False)

--- a/src/fenic/core/_logical_plan/optimizer/not_filter_pushdown_rule.py
+++ b/src/fenic/core/_logical_plan/optimizer/not_filter_pushdown_rule.py
@@ -7,8 +7,10 @@ from fenic.core._logical_plan.expressions import (
 from fenic.core._logical_plan.optimizer.base import (
     LogicalPlanOptimizerRule,
     OptimizationResult,
+    OptimizerNodeResult,
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._logical_plan.plans.transform import Filter
 
 
@@ -27,31 +29,42 @@ class NotFilterPushdownRule(LogicalPlanOptimizerRule):
     """
 
     def apply(self, logical_plan: LogicalPlan) -> OptimizationResult:
-        return self.optimize_node(logical_plan)
+        return self.optimize_plan(logical_plan)
 
-    def optimize_node(self, node: LogicalPlan) -> OptimizationResult:
+    def optimize_plan(self, plan: LogicalPlan) -> OptimizationResult:
+        # Optimizes the plan by traversing the logical plan node tree.
+        optimizer_node_result = self.optimize_node(plan.logical_plan_node)
+        logical_plan = LogicalPlan(plan.session_state)
+        logical_plan.logical_plan_node = optimizer_node_result.node
+        return OptimizationResult(
+            logical_plan,
+            optimizer_node_result.was_modified,
+        )
+
+
+    def optimize_node(self, node: LogicalPlanNode) -> OptimizerNodeResult:
         any_child_modified = False
-        optimized_children = []
-
-        # First, recursively optimize all children
+        optimized_children: list[LogicalPlanNode] = []
+                # First, recursively optimize all children
         for child in node.children():
             child_result = self.optimize_node(child)
-            optimized_children.append(child_result.plan)
+            optimized_children.append(child_result.node)
             any_child_modified = any_child_modified or child_result.was_modified
 
         # Update node with optimized children
         new_node = node.with_children(optimized_children)
+        new_node._schema = node._schema
 
         # If this is a filter node, apply NOT pushdown to its predicate
         if isinstance(new_node, Filter):
             filter_result = self.optimize_filter(new_node)
-            return OptimizationResult(
-                filter_result.plan, any_child_modified or filter_result.was_modified
+            return OptimizerNodeResult(
+                filter_result.node, any_child_modified or filter_result.was_modified
             )
 
-        return OptimizationResult(new_node, any_child_modified)
+        return OptimizerNodeResult(new_node, any_child_modified)
 
-    def optimize_filter(self, node: Filter) -> OptimizationResult:
+    def optimize_filter(self, node: Filter) -> OptimizerNodeResult:
         predicate = node.predicate()
 
         # Apply selective NOT pushdown transformation to the predicate
@@ -59,12 +72,14 @@ class NotFilterPushdownRule(LogicalPlanOptimizerRule):
 
         # If the predicate was changed, create a new filter with the transformed predicate
         if transformed_predicate != predicate:
-            new_filter = Filter(node._input, transformed_predicate)
+            new_filter = Filter(transformed_predicate)
+            new_filter.set_input(node._input)
+            new_filter._schema = node._schema
             new_filter.cache_info = node.cache_info
-            return OptimizationResult(new_filter, True)
+            return OptimizerNodeResult(new_filter, True)
 
         # No change needed
-        return OptimizationResult(node, False)
+        return OptimizerNodeResult(node, False)
 
     def push_not_inward(self, expr: LogicalExpr) -> LogicalExpr:
         """Recursively push NOT operators inward but only in ways that increase AND expressions.

--- a/src/fenic/core/_logical_plan/optimizer/semantic_filter_rewrite_rule.py
+++ b/src/fenic/core/_logical_plan/optimizer/semantic_filter_rewrite_rule.py
@@ -11,8 +11,10 @@ from fenic.core._logical_plan.expressions import (
 from fenic.core._logical_plan.optimizer.base import (
     LogicalPlanOptimizerRule,
     OptimizationResult,
+    OptimizerNodeResult,
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._logical_plan.plans.transform import Filter
 
 
@@ -41,58 +43,75 @@ class SemanticFilterRewriteRule(LogicalPlanOptimizerRule):
     """
 
     def apply(self, logical_plan: LogicalPlan) -> OptimizationResult:
-        return self.optimize_node(logical_plan)
+        self.session_state = logical_plan.session_state
+        return self.optimize_plan(logical_plan)
 
-    def optimize_node(self, node: LogicalPlan) -> OptimizationResult:
+    def optimize_plan(self, plan: LogicalPlan) -> OptimizationResult:
+        optimizer_node_result = self.optimize_node(plan.logical_plan_node)
+        logical_plan = LogicalPlan(plan.session_state)
+        logical_plan.logical_plan_node = optimizer_node_result.node
+        return OptimizationResult(
+            logical_plan,
+            optimizer_node_result.was_modified
+        )
+
+    def optimize_node(self, node: LogicalPlanNode) -> OptimizerNodeResult:
         any_child_modified = False
-        optimized_children = []
+        optimized_children: list[LogicalPlanNode] = []
 
         for child in node.children():
             child_result = self.optimize_node(child)
-            optimized_children.append(child_result.plan)
+            optimized_children.append(child_result.node)
             any_child_modified = any_child_modified or child_result.was_modified
 
         new_node = node.with_children(optimized_children)
+        new_node._schema = node._schema
 
         if isinstance(new_node, Filter):
             filter_result = self.optimize_filter(new_node)
-            return OptimizationResult(
-                filter_result.plan, any_child_modified or filter_result.was_modified
+            return OptimizerNodeResult(
+                filter_result.node, any_child_modified or filter_result.was_modified
             )
 
-        return OptimizationResult(new_node, any_child_modified)
+        return OptimizerNodeResult(new_node, any_child_modified)
 
-    def optimize_filter(self, node: Filter) -> OptimizationResult:
+    def optimize_filter(self, node: Filter) -> OptimizerNodeResult:
         predicate = node.predicate()
 
         # Skip optimization if not an AND expression or doesn't contain semantic predicates
         if not self.is_and_expr(
             predicate
         ) or not self.count_semantic_predicate_expressions(predicate):
-            return OptimizationResult(node, False)
+            return OptimizerNodeResult(node, False)
 
         standard_predicates, semantic_predicates = self.partition_predicates(predicate)
 
         # Skip optimization if there's only one predicate total
         total_predicates = len(standard_predicates) + len(semantic_predicates)
         if total_predicates <= 1:
-            return OptimizationResult(node, False)
+            return OptimizerNodeResult(node, False)
 
         # Apply predicates in order of increasing cost
-        result = node._input
+        input = node._input
 
         # Apply standard predicates first (if any)
         if standard_predicates:
             standard_predicate_expr = self._make_and_expr(standard_predicates)
-            result = Filter(result, standard_predicate_expr)
+            result = Filter(standard_predicate_expr)
+            result.set_input(input)
+            result._build_schema_with_validation(self.session_state)
+        else:
+            result = input
 
         # Apply semantic predicates last
         for pred in semantic_predicates:
-            result = Filter(result, pred)
+            sem_predicate_result = Filter(pred)
+            sem_predicate_result.set_input(result)
+            sem_predicate_result._build_schema_with_validation(self.session_state)
+            result = sem_predicate_result
 
-        result.cache_info = node.cache_info
-
-        return OptimizationResult(result, True)
+        result.set_cache_info(node.cache_info)
+        return OptimizerNodeResult(result, True)
 
     # Returns a tuple of two lists:
     # - The first list contains all the standard predicates.

--- a/src/fenic/core/_logical_plan/plans/aggregate.py
+++ b/src/fenic/core/_logical_plan/plans/aggregate.py
@@ -1,39 +1,43 @@
 from typing import List
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions import (
     AliasExpr,
     LogicalExpr,
     SortExpr,
 )
 from fenic.core._logical_plan.expressions.base import AggregateExpr
-from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core.types import Schema
 
 
-class Aggregate(LogicalPlan):
+class Aggregate(LogicalPlanNode):
     def __init__(
         self,
-        input: LogicalPlan,
         group_exprs: List[LogicalExpr],
         agg_exprs: List[AliasExpr],
     ):
-        self._input = input
+        super().__init__()
         self._group_exprs = group_exprs
         self._agg_exprs = agg_exprs
-        for expr in agg_exprs:
-            if not isinstance(expr.expr, AggregateExpr):
-                raise ValueError(f"Expression {expr} is not an aggregation")
-            _validate_agg_expr(expr.expr, group_exprs)
-        for expr in group_exprs:
-            _validate_groupby_expr(expr)
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
-        group_fields = [expr.to_column_field(self._input) for expr in self._group_exprs]
-        agg_fields = [expr.to_column_field(self._input) for expr in self._agg_exprs]
+    def _validate_expressions(self):
+        for expr in self._agg_exprs:
+            if not isinstance(expr.expr, AggregateExpr):
+                raise ValueError(f"Expression {expr} is not an aggregation")
+            _validate_agg_expr(expr.expr, self._group_exprs)
+        for expr in self._group_exprs:
+            _validate_groupby_expr(expr)
+
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        self._validate_expressions()
+
+        group_fields = [expr.to_column_field(self._input, session_state) for expr in self._group_exprs]
+        agg_fields = [expr.to_column_field(self._input, session_state) for expr in self._agg_exprs]
         return Schema(column_fields=group_fields + agg_fields)
 
     def _repr(self) -> str:
@@ -45,12 +49,16 @@ class Aggregate(LogicalPlan):
     def agg_exprs(self) -> List[LogicalExpr]:
         return self._agg_exprs
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Aggregate must have exactly one child")
-        result = Aggregate(children[0], self._group_exprs, self._agg_exprs)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Aggregate(node._group_exprs, node._agg_exprs)
+        new_node.set_input(children[0])
+        return new_node
 
 def _validate_agg_expr(
     expr: LogicalExpr,

--- a/src/fenic/core/_logical_plan/plans/base.py
+++ b/src/fenic/core/_logical_plan/plans/base.py
@@ -1,107 +1,35 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import List, Optional
-
-from fenic._constants import PRETTY_PRINT_INDENT
 from fenic.core._interfaces.session_state import BaseSessionState
-from fenic.core.error import PlanError, SessionError
+from fenic.core._logical_plan.plans.node import CacheInfo, LogicalPlanNode
+from fenic.core.error import SessionError
 from fenic.core.types.schema import Schema
 
 
-@dataclass
-class CacheInfo:
-    duckdb_table_name: Optional[str] = None
-
-
-class LogicalPlan(ABC):
+class LogicalPlan:
     def __init__(self, session_state: BaseSessionState):
-        self.cache_info = None
-        self._schema = self._build_schema()
-        self.session_state = session_state
-        column_names = [field.name for field in self._schema.column_fields]
-        seen = set()
-        duplicates = {name for name in column_names if name in seen or seen.add(name)}
-        if duplicates:
-            example_duplicate = next(iter(duplicates))
-            duplicate_list = ", ".join(f"'{name}'" for name in duplicates)
-            raise PlanError(
-                f"Duplicate column names found: {duplicate_list}. "
-                "Column names must be unique. "
-                f"Use aliases to rename columns, e.g., col('{example_duplicate}').alias('{example_duplicate}_2')."
-            )
+        self.logical_plan_node: LogicalPlanNode = None
+        self.session_state: BaseSessionState = session_state
 
-    @abstractmethod
-    def children(self) -> List[LogicalPlan]:
-        """Returns the child nodes of this logical plan operator.
+    def add_node(self, node: LogicalPlanNode) -> LogicalPlan:
+        new_logical_plan = LogicalPlan(self.session_state)
 
-        Returns:
-            List[LogicalPlan]: A list of child logical plan nodes. For leaf nodes
-                like Source, this will be an empty list.
-        """
-        pass
+        if self.logical_plan_node:
+            node.set_input(self.logical_plan_node)
 
-    @abstractmethod
-    def _build_schema(self) -> Schema:
-        """Constructs the output schema for this logical plan operator.
-
-        This method is called during initialization to determine the schema of the
-        data that will be produced by this operator when executed.
-
-        Returns:
-            Schema: The schema describing the structure and types of the output columns
-                that this operator will produce.
-
-        Raises:
-            ValueError: If the operation would produce an invalid schema, for example
-                calling a semantic map on a non-string column.
-        """
-        pass
-
-    @abstractmethod
-    def _repr(self) -> str:
-        """Return the string representation for this logical plan."""
-        pass
-
-    def _repr_with_indent(self, _level: int) -> str:
-        """Default: just call __repr(). Override this method to build an indentation aware string plan representation."""
-        return self._repr()
+        node._build_schema_with_validation(self.session_state)
+        new_logical_plan.logical_plan_node = node
+        return new_logical_plan
 
     def __str__(self) -> str:
-        """Recursively pretty-print with indentation."""
-
-        def pretty_print(plan: LogicalPlan, level: int) -> str:
-            indent = PRETTY_PRINT_INDENT * level
-            cache_info = " (cached=true)" if plan.cache_info is not None else ""
-            result = f"{indent}{plan._repr_with_indent(level)}{cache_info}\n"
-            for child in plan.children():
-                result += pretty_print(child, level + 1)
-            return result
-
-        return pretty_print(self, 0)
+        return str(self.logical_plan_node)
 
     def set_cache_info(self, cache_info: CacheInfo):
         """Set the cache metadata for this plan."""
-        self.cache_info = cache_info
+        self.logical_plan_node.set_cache_info(cache_info)
 
     def schema(self) -> Schema:
-        return self._schema
-
-    @abstractmethod
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
-        """Creates and returns a new instance of the logical plan with the given children.
-
-        This method acts as a factory method that preserves the current node's properties
-        while replacing its child nodes.
-
-        Args:
-            children: The new child nodes to use in the created logical plan
-
-        Returns:
-            A new logical plan instance of the same type with updated children
-        """
-        pass
+        return self.logical_plan_node.schema()
 
 def ensure_same_session(lhs: BaseSessionState, rhs: BaseSessionState):
     """Ensure that two LogicalPlans belong to the same session context.

--- a/src/fenic/core/_logical_plan/plans/join.py
+++ b/src/fenic/core/_logical_plan/plans/join.py
@@ -1,11 +1,15 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions import (
     ColumnExpr,
     LogicalExpr,
 )
-from fenic.core._logical_plan.plans.base import LogicalPlan, ensure_same_session
+from fenic.core._logical_plan.plans.base import ensure_same_session
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
+
+#from fenic.core._logical_plan.plans.base import ensure_same_session
 from fenic.core._logical_plan.utils import validate_completion_parameters
 from fenic.core.error import TypeMismatchError
 from fenic.core.types import (
@@ -21,30 +25,33 @@ from fenic.core.types.enums import SemanticSimilarityMetric
 SIMILARITY_SCORE_COL_NAME = "_similarity_score"
 
 
-class Join(LogicalPlan):
+class Join(LogicalPlanNode):
     def __init__(
         self,
-        left: LogicalPlan,
-        right: LogicalPlan,
+        left: LogicalPlanNode,
+        right: LogicalPlanNode,
         left_on: List[LogicalExpr],
         right_on: List[LogicalExpr],
         how: str,
     ):
+        super().__init__()
         self._left = left
         self._right = right
         self._left_on = left_on
         self._right_on = right_on
         self._how = how
-        ensure_same_session(left.session_state, right.session_state)
-        super().__init__(left.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def set_input(self, input: LogicalPlanNode):
+        # Nothing to do here, as we require 2 inputs (the left and the right)
+        pass
+
+    def children(self) -> List[LogicalPlanNode]:
         return [self._left, self._right]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         for left_on, right_on in zip(self._left_on, self._right_on, strict=False):
-            left_type = left_on.to_column_field(self._left).data_type
-            right_type = right_on.to_column_field(self._right).data_type
+            left_type = left_on.to_column_field(self._left, session_state).data_type
+            right_type = right_on.to_column_field(self._right, session_state).data_type
             if left_type != right_type:
                 raise TypeMismatchError.from_message(
                     f"Join condition: Cannot compare '{left_on.name}' ({left_type}) with "
@@ -102,34 +109,41 @@ class Join(LogicalPlan):
     def how(self) -> str:
         return self._how
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 2:
             raise ValueError("Join must have exactly two children")
-        result = Join(children[0], children[1], self._left_on, self._right_on, self._how)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return Join(children[0], children[1], node._left_on, node._right_on, node._how)
 
-class BaseSemanticJoin(LogicalPlan, ABC):
+    @classmethod
+    def validate_same_session(
+            cls,
+            current_session_state: BaseSessionState,
+            other_session_state: BaseSessionState) -> None:
+        ensure_same_session(current_session_state, other_session_state)
+
+class BaseSemanticJoin(LogicalPlanNode, ABC):
     def __init__(
         self,
-        left: LogicalPlan,
-        right: LogicalPlan,
+        left: LogicalPlanNode,
+        right: LogicalPlanNode,
         left_on: LogicalExpr,
         right_on: LogicalExpr,
     ):
+        super().__init__()
         self._left = left
         self._right = right
         self._left_on = left_on
         self._right_on = right_on
-        ensure_same_session(left.session_state, right.session_state)
-        super().__init__(left.session_state)
 
     @abstractmethod
     def _validate_columns(self) -> None:
         pass
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         self._validate_columns()
         return Schema(
             self._left.schema().column_fields + self._right.schema().column_fields
@@ -141,19 +155,26 @@ class BaseSemanticJoin(LogicalPlan, ABC):
     def right_on(self) -> LogicalExpr:
         return self._right_on
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._left, self._right]
 
     @abstractmethod
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         raise NotImplementedError("Subclasses must implement with_children")
+
+    @classmethod
+    def validate_same_session(
+            cls,
+            current_session_state: BaseSessionState,
+            other_session_state: BaseSessionState) -> None:
+        ensure_same_session(current_session_state, other_session_state)
 
 
 class SemanticJoin(BaseSemanticJoin):
     def __init__(
         self,
-        left: LogicalPlan,
-        right: LogicalPlan,
+        left: LogicalPlanNode,
+        right: LogicalPlanNode,
         left_on: ColumnExpr,
         right_on: ColumnExpr,
         join_instruction: str,
@@ -161,12 +182,15 @@ class SemanticJoin(BaseSemanticJoin):
         model_alias: Optional[str] = None,
         examples: Optional[JoinExampleCollection] = None,
     ):
-        validate_completion_parameters(model_alias, left.session_state.session_config, temperature)
         self._join_instruction = join_instruction
         self._examples = examples
         self.temperature = temperature
         self.model_alias = model_alias
         super().__init__(left, right, left_on, right_on)
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        validate_completion_parameters(self.model_alias, session_state.session_config, self.temperature)
+        return super()._build_schema(session_state)
 
     def _validate_columns(self) -> None:
         left_schema = self._left.schema()
@@ -209,29 +233,30 @@ class SemanticJoin(BaseSemanticJoin):
             f"right_on={self._right_on.name}, join_instruction={self._join_instruction})"
         )
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 2:
             raise ValueError(f"SemanticJoin expects 2 children, got {len(children)}")
+        return self.copy(self, children)
 
-        result = SemanticJoin(
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return SemanticJoin(
             left=children[0],
             right=children[1],
-            left_on=self._left_on,
-            right_on=self._right_on,
-            join_instruction=self._join_instruction,
-            examples=self._examples,
-            temperature=self.temperature,
-            model_alias=self.model_alias,
+            left_on=node._left_on,
+            right_on=node._right_on,
+            join_instruction=node._join_instruction,
+            examples=node._examples,
+            temperature=node.temperature,
+            model_alias=node.model_alias,
         )
-        result.set_cache_info(self.cache_info)
-        return result
 
 
 class SemanticSimilarityJoin(BaseSemanticJoin):
     def __init__(
         self,
-        left: LogicalPlan,
-        right: LogicalPlan,
+        left: LogicalPlanNode,
+        right: LogicalPlanNode,
         left_on: LogicalExpr,
         right_on: LogicalExpr,
         k: int,
@@ -243,13 +268,13 @@ class SemanticSimilarityJoin(BaseSemanticJoin):
         self._similarity_score_column = similarity_score_column
         super().__init__(left, right, left_on, right_on)
 
-    def _validate_columns(self) -> None:
-        left_dtype = self._left_on.to_column_field(self._left).data_type
+    def _validate_columns(self, session_state: BaseSessionState) -> None:
+        left_dtype = self._left_on.to_column_field(self._left, session_state).data_type
         if not isinstance(left_dtype, EmbeddingType):
             raise TypeMismatchError.from_message(
                 f"Cannot apply semantic.sim_join on non embeddings type left join key column '{self._left_on.name}' with type {left_dtype}",
             )
-        right_dtype = self._right_on.to_column_field(self._right).data_type
+        right_dtype = self._right_on.to_column_field(self._right, session_state).data_type
         if not left_dtype == right_dtype:
             raise TypeMismatchError.from_message(
                 f"Cannot apply semantic.sim_join with mismatched types: left column '{self._left_on.name}' has type {left_dtype}, right column '{self._right_on.name}' has type {right_dtype}",
@@ -270,8 +295,8 @@ class SemanticSimilarityJoin(BaseSemanticJoin):
             f"right_on={self._right_on.name}, k={self._k}, "
         )
 
-    def _build_schema(self) -> Schema:
-        self._validate_columns()
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        self._validate_columns(session_state)
         # add scores field if requested by user.
         additional_fields = []
         if self._similarity_score_column:
@@ -287,20 +312,21 @@ class SemanticSimilarityJoin(BaseSemanticJoin):
             + additional_fields
         )
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode :
         if len(children) != 2:
             raise ValueError(
                 f"SemanticSimilarityJoin expects 2 children, got {len(children)}"
             )
+        return self.copy(self, children)
 
-        result = SemanticSimilarityJoin(
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return SemanticSimilarityJoin(
             left=children[0],
             right=children[1],
-            left_on=self._left_on,
-            right_on=self._right_on,
-            k=self._k,
-            similarity_metric=self._similarity_metric,
-            similarity_score_column=self._similarity_score_column,
+            left_on=node._left_on,
+            right_on=node._right_on,
+            k=node._k,
+            similarity_metric=node._similarity_metric,
+            similarity_score_column=node._similarity_score_column,
         )
-        result.set_cache_info(self.cache_info)
-        return result

--- a/src/fenic/core/_logical_plan/plans/node.py
+++ b/src/fenic/core/_logical_plan/plans/node.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional
+
+from fenic._constants import PRETTY_PRINT_INDENT
+from fenic.core._interfaces.session_state import BaseSessionState
+from fenic.core.error import InternalError, PlanError
+from fenic.core.types.schema import Schema
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+@dataclass
+class CacheInfo:
+    duckdb_table_name: Optional[str] = None
+
+class LogicalPlanNode(ABC):
+
+    def __init__(self):
+        self._input: Optional[LogicalPlanNode] = None
+        self._schema: Optional[Schema] = None
+        self.cache_info: Optional[CacheInfo] = None
+
+    def set_input(self, input: LogicalPlanNode):
+        """Sets the default input node, this can be overriden by the subclass if not needed."""
+        self._input = input
+
+    @abstractmethod
+    def children(self) -> List[LogicalPlanNode]:
+        pass
+
+    @abstractmethod
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        pass
+
+    def _build_schema_with_validation(self, session_state: BaseSessionState):
+        self._schema = self._build_schema(session_state)
+        self.validate_schema()
+
+    @abstractmethod
+    def _repr(self) -> str:
+        pass
+
+    def _repr_with_indent(self, _level: int) -> str:
+        """Default: just call __repr(). Override this method to build an indentation aware string plan representation."""
+        return self._repr()
+
+    def __str__(self) -> str:
+        """Recursively pretty-print with indentation."""
+
+        def pretty_print(node: LogicalPlanNode, level: int) -> str:
+            indent = PRETTY_PRINT_INDENT * level
+            cache_info = " (cached=true)" if node.cache_info is not None else ""
+            result = f"{indent}{node._repr_with_indent(level)}{cache_info}\n"
+            for child in node.children():
+                result += pretty_print(child, level + 1)
+            return result
+
+        return pretty_print(self, 0)
+    
+    def schema(self) -> Schema:
+        return self._schema
+    
+    def validate_schema(self) -> None:
+        """Validate the schema for the node."""
+        if not self._schema:
+            raise PlanError("Schema is not set, must call _build_schema before validation")
+        
+        column_names = [field.name for field in self._schema.column_fields]
+        seen = set()
+        duplicates = {name for name in column_names if name in seen or seen.add(name)}
+        if duplicates:
+            example_duplicate = next(iter(duplicates))
+            duplicate_list = ", ".join(f"'{name}'" for name in duplicates)
+            raise PlanError(
+                f"Duplicate column names found: {duplicate_list}. "
+                "Column names must be unique. "
+                f"Use aliases to rename columns, e.g., col('{example_duplicate}').alias('{example_duplicate}_2')."
+            )
+    
+    @abstractmethod
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        """Creates and returns a new instance of the logical node plan with the given children.
+
+        This method acts as a factory method that preserves the current node's properties
+        while replacing its child nodes.
+
+        Args:
+            children: The new child nodes to use in the created logical plan node
+
+        Returns:
+            A new logical plan node instance of the same type with updated children
+        """
+        pass
+
+    def set_cache_info(self, cache_info: CacheInfo):
+        self.cache_info = cache_info
+
+    def set_schema(self, schema: Schema):
+        self._schema = schema
+
+    @classmethod
+    def copy(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        """Creates a copy of the node."""
+        if cls is not type(node):
+            raise InternalError(f"Expected {cls}, got {type(node)}")
+        new_node = cls._create_new_node(node=node, children=children)
+        new_node.set_schema(node.schema())
+        new_node.set_cache_info(node.cache_info)
+        return new_node
+
+    @classmethod
+    @abstractmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        pass

--- a/src/fenic/core/_logical_plan/plans/sink.py
+++ b/src/fenic/core/_logical_plan/plans/sink.py
@@ -1,16 +1,17 @@
 from typing import List, Literal
 
-from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._interfaces.session_state import BaseSessionState
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core.error import InternalError
 from fenic.core.types import Schema
 
 
-class FileSink(LogicalPlan):
+class FileSink(LogicalPlanNode):
     """Logical plan node that represents a file writing operation."""
 
     def __init__(
         self,
-        child: LogicalPlan,
+        child: LogicalPlanNode,
         sink_type: Literal["csv", "parquet"],
         path: str,
         mode: Literal["error", "overwrite", "ignore"] = "error",
@@ -26,17 +27,17 @@ class FileSink(LogicalPlan):
                  - overwrite: Overwrites the file if it exists
                  - ignore: Silently ignores operation if file exists
         """
+        super().__init__()
         self.child = child
         self.sink_type = sink_type
         self.path = path
         self.mode = mode
-        super().__init__(self.child.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         """Returns the child node of this sink operator."""
         return [self.child]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """The schema of a sink node is the same as its child's schema."""
         return self.child.schema()
 
@@ -48,7 +49,7 @@ class FileSink(LogicalPlan):
             f"mode='{self.mode}')"
         )
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         """Create a new file sink with the same properties but different children.
 
         Args:
@@ -64,27 +65,24 @@ class FileSink(LogicalPlan):
             raise InternalError(
                 f"FileSink expects exactly one child but got {len(children)}"
             )
-        return FileSink(
-            child=children[0],
-            sink_type=self.sink_type,
-            path=self.path,
-            mode=self.mode,
-        )
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return FileSink(children[0], node.sink_type, node.path, node.mode)
 
-class TableSink(LogicalPlan):
+class TableSink(LogicalPlanNode):
     """Logical plan node that represents a table writing operation."""
-
     def __init__(
         self,
-        child: LogicalPlan,
+        child: LogicalPlanNode,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"] = "error",
     ):
         """Initialize a table sink node.
 
         Args:
-            child: The logical plan that produces data to be written
+            child: The logical plan node that produces data to be written
             table_name: Name of the table to write to
             mode: Write mode. Default: "error"
                  - error: Raises an error if table exists
@@ -92,16 +90,16 @@ class TableSink(LogicalPlan):
                  - overwrite: Overwrites existing table
                  - ignore: Silently ignores operation if table exists
         """
+        super().__init__()
         self.child = child
         self.table_name = table_name
         self.mode = mode
-        super().__init__(self.child.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         """Returns the child node of this sink operator."""
         return [self.child]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """The schema of a sink node is the same as its child's schema."""
         return self.child.schema()
 
@@ -109,7 +107,7 @@ class TableSink(LogicalPlan):
         """Return the string representation for this table sink plan."""
         return f"TableSink(table_name='{self.table_name}', mode='{self.mode}')"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         """Create a new table sink with the same properties but different children.
 
         Args:
@@ -125,8 +123,12 @@ class TableSink(LogicalPlan):
             raise InternalError(
                 f"TableSink expects exactly one child but got {len(children)}"
             )
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         return TableSink(
             child=children[0],
-            table_name=self.table_name,
-            mode=self.mode,
+            table_name=node.table_name,
+            mode=node.mode,
         )

--- a/src/fenic/core/_logical_plan/plans/source.py
+++ b/src/fenic/core/_logical_plan/plans/source.py
@@ -6,22 +6,24 @@ import polars as pl
 
 from fenic._constants import PRETTY_PRINT_INDENT
 from fenic.core._interfaces.session_state import BaseSessionState
-from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._utils.schema import convert_polars_schema_to_custom_schema
-from fenic.core.error import InternalError, PlanError
+from fenic.core.error import InternalError, PlanError, ValidationError
 from fenic.core.types import Schema
 
 
-class InMemorySource(LogicalPlan):
-    def __init__(self, source: pl.DataFrame, session_state: BaseSessionState):
+class InMemorySource(LogicalPlanNode):
+    def __init__(self, source: pl.DataFrame):
+        super().__init__()
         self._source = source
-        self.session_state = session_state
-        super().__init__(session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def set_input(self, input: LogicalPlanNode):
+        raise ValidationError("InMemorySource cannot have an input")
+
+    def children(self) -> List[LogicalPlanNode]:
         return []
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState):
         return convert_polars_schema_to_custom_schema(self._source.schema)
 
     def _repr(self) -> str:
@@ -32,36 +34,42 @@ class InMemorySource(LogicalPlan):
         inner = self.schema()._str_with_indent(base_indent=level + 1)
         return f"InMemorySource(\n{inner}\n{indent})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 0:
             raise InternalError(
                 f"InMemorySource must have no children, got {len(children)}"
             )
-        result = InMemorySource(self._source, self.session_state)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return InMemorySource(node._source)
 
 
-class FileSource(LogicalPlan):
+class FileSource(LogicalPlanNode):
     def __init__(
         self,
         paths: list[str],
         file_format: Literal["csv", "parquet"],
-        session_state: BaseSessionState,
         options: Optional[dict] = None,
     ):
         """A lazy FileSource that stores the file path, file format, options, and immediately infers the schema using the given session state."""
+        super().__init__()
         self._paths = paths
         self._file_format = file_format
         self._options = options or {}
-        self.session_state = session_state
-        super().__init__(session_state)
 
-    def _build_schema(self) -> Schema:
+    def set_input(self, input: LogicalPlanNode):
+        raise ValidationError("FileSource cannot have an input")
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """Uses DuckDB (via the session state) to perform a minimal read (LIMIT 0) and obtain the schema from the file."""
+        if self._schema:
+            return self._schema
+
         if self._file_format == "csv":
             try:
-                return self.session_state.execution.infer_schema_from_csv(
+                return session_state.execution.infer_schema_from_csv(
                     self._paths, **self._options
                 )
             except Exception as e:
@@ -82,7 +90,7 @@ class FileSource(LogicalPlan):
 
         elif self._file_format == "parquet":
             try:
-                return self.session_state.execution.infer_schema_from_parquet(
+                return session_state.execution.infer_schema_from_parquet(
                     self._paths, **self._options
                 )
             except Exception as e:
@@ -96,45 +104,52 @@ class FileSource(LogicalPlan):
                         "Failed to infer schema from Parquet files"
                     ) from e
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return []
 
     def _repr(self) -> str:
         return f"FileSource(paths={self._paths}, format={self._file_format})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 0:
             raise InternalError(f"FileSource must have no children, got {len(children)}")
-        result = FileSource(
-            self._paths, self._file_format, self.session_state, self._options
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return FileSource(
+            node._paths, node._file_format, node._options
         )
-        result.set_cache_info(self.cache_info)
-        return result
 
-class TableSource(LogicalPlan):
-    def __init__(self, table_name: str, session_state: BaseSessionState):
+
+class TableSource(LogicalPlanNode):
+    def __init__(self, table_name: str):
+        super().__init__()
         self._table_name = table_name
-        self.session_state = session_state
-        super().__init__(session_state)
 
-    def _build_schema(self) -> Schema:
-        if not self.session_state.catalog.does_table_exist(self._table_name):
+    def set_input(self, input: LogicalPlanNode):
+        raise ValidationError("TableSource cannot have an input")
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        if not session_state.catalog.does_table_exist(self._table_name):
             raise PlanError(
                 f"Table '{self._table_name}' does not exist. "
                 f"Use session.catalog.list_tables() to see available tables, "
                 f"or load data using session.csv() or session.parquet()."
             )
-        return self.session_state.catalog.describe_table(self._table_name)
+        return session_state.catalog.describe_table(self._table_name)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return []
 
     def _repr(self) -> str:
         return f"TableSource(table_name={self._table_name})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 0:
             raise InternalError(f"TableSource must have no children, got {len(children)}")
-        result = TableSource(self._table_name, self.session_state)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return TableSource(node._table_name)

--- a/src/fenic/core/_logical_plan/plans/transform.py
+++ b/src/fenic/core/_logical_plan/plans/transform.py
@@ -18,13 +18,19 @@ from fenic.core._logical_plan.expressions import (
     LogicalExpr,
     SortExpr,
 )
-from fenic.core._logical_plan.plans.base import LogicalPlan, ensure_same_session
+from fenic.core._logical_plan.plans.base import ensure_same_session
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 from fenic.core._utils.misc import generate_unique_arrow_view_name
 from fenic.core._utils.schema import (
     convert_custom_schema_to_polars_schema,
     convert_polars_schema_to_custom_schema,
 )
-from fenic.core.error import InternalError, PlanError, TypeMismatchError
+from fenic.core.error import (
+    InternalError,
+    PlanError,
+    TypeMismatchError,
+    ValidationError,
+)
 from fenic.core.types import (
     ArrayType,
     BooleanType,
@@ -37,16 +43,18 @@ from fenic.core.types import (
 
 logger = logging.getLogger(__name__)
 
-class Projection(LogicalPlan):
-    def __init__(self, input: LogicalPlan, exprs: List[LogicalExpr]):
-        self._input = input
+class Projection(LogicalPlanNode):
+    def __init__(self, exprs: List[LogicalExpr]):
+        super().__init__()
         self._exprs = exprs
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        if self._input is None:
+            raise ValidationError("Projection must have an input")
+
         fields = []
         for expr in self._exprs:
             if isinstance(expr, AggregateExpr):
@@ -55,7 +63,7 @@ class Projection(LogicalPlan):
                     "Please use the agg() method instead."
                 )
 
-            fields.append(expr.to_column_field(self._input))
+            fields.append(expr.to_column_field(self._input, session_state))
         return Schema(fields)
 
     def exprs(self) -> List[LogicalExpr]:
@@ -65,18 +73,33 @@ class Projection(LogicalPlan):
         exprs_str = ", ".join(str(expr) for expr in self._exprs)
         return f"Projection(exprs=[{exprs_str}])"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Projection must have exactly one child")
-        result = Projection(children[0], self._exprs)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(
+            cls,
+            node: LogicalPlanNode,
+            children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Projection(node._exprs)
+        new_node.set_input(children[0])
+        return new_node
 
-class Filter(LogicalPlan):
-    def __init__(self, input: LogicalPlan, predicate: LogicalExpr):
+class Filter(LogicalPlanNode):
+    def __init__(self, predicate: LogicalExpr):
+        super().__init__()
+        self._predicate = predicate
+
+    def set_input(self, input: LogicalPlanNode):
         self._input = input
-        actual_type = predicate.to_column_field(input).data_type
+
+    def children(self) -> List[LogicalPlanNode]:
+        return [self._input]
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        actual_type = self._predicate.to_column_field(self._input, session_state).data_type
         if actual_type != BooleanType:
             raise ValueError(
                 f"Filter predicate must return a boolean value, but got {actual_type}. "
@@ -85,23 +108,16 @@ class Filter(LogicalPlan):
                 "- df.filter(col('status') == 'active')\n"
                 "- df.filter(col('is_valid'))"
             )
-        if isinstance(predicate, AggregateExpr):
+        if isinstance(self._predicate, AggregateExpr):
             raise ValueError(
                 "Aggregate expressions are not allowed in projections. "
                 "Please use the agg() method instead."
             )
-        if isinstance(predicate, SortExpr):
+        if isinstance(self._predicate, SortExpr):
             raise ValueError(
                 "Sort expressions are not allowed in projections. "
                 "Please use the sort() method instead."
             )
-        self._predicate = predicate
-        super().__init__(self._input.session_state)
-
-    def children(self) -> List[LogicalPlan]:
-        return [self._input]
-
-    def _build_schema(self) -> Schema:
         return self._input.schema()
 
     def predicate(self) -> LogicalExpr:
@@ -111,26 +127,33 @@ class Filter(LogicalPlan):
         """Return the representation for the Filter node."""
         return f"Filter(predicate={self._predicate})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Filter must have exactly one child")
-        result = Filter(children[0], self._predicate)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(
+            cls,
+            node: LogicalPlanNode,
+            children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Filter(node._predicate)
+        new_node.set_input(children[0])
+        return new_node
 
-class Union(LogicalPlan):
-    def __init__(self, inputs: List[LogicalPlan]):
+class Union(LogicalPlanNode):
+    def __init__(self, inputs: List[LogicalPlanNode]):
+        super().__init__()
         self._inputs = inputs
-        first_input = inputs[0]
-        for input in inputs[1:]:
-            ensure_same_session(input.session_state, first_input.session_state)
-        super().__init__(first_input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def set_input(self, input: LogicalPlanNode):
+        # Skip setting the input as it is a list of LogicalPlanNodes
+        pass
+
+    def children(self) -> List[LogicalPlanNode]:
         return self._inputs
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         schemas = [input_plan.schema() for input_plan in self._inputs]
 
         # Check that all schemas have the same columns and types
@@ -156,45 +179,62 @@ class Union(LogicalPlan):
     def _repr(self) -> str:
         return "Union"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
-        result = Union(children)
-        result.set_cache_info(self.cache_info)
-        return result
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(
+            cls,
+            node: LogicalPlanNode,
+            children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return Union(children)
+
+    @classmethod
+    def validate_same_session(
+            cls,
+            current_session_state: BaseSessionState,
+            input_session_states: list[BaseSessionState]) -> None:
+        for input_session_state in input_session_states:
+            ensure_same_session(input_session_state, current_session_state)
 
 
-class Limit(LogicalPlan):
-    def __init__(self, input: LogicalPlan, n: int):
-        self._input = input
+class Limit(LogicalPlanNode):
+    def __init__(self, n: int):
+        super().__init__()
         self.n = n
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         return self._input.schema()
 
     def _repr(self) -> str:
         return f"Limit(n={self.n})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Limit must have exactly one child")
-        result = Limit(children[0], self.n)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(
+            cls,
+            node: LogicalPlanNode,
+            children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Limit(node.n)
+        new_node.set_input(children[0])
+        return new_node
 
-class Explode(LogicalPlan):
-    def __init__(self, input: LogicalPlan, expr: LogicalExpr):
-        self._input = input
+class Explode(LogicalPlanNode):
+    def __init__(self, expr: LogicalExpr):
+        super().__init__()
         self._expr = expr
-        super().__init__(self._input.session_state)
 
-    def children(self) -> list[LogicalPlan]:
+    def children(self) -> list[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         input_schema = self._input.schema()
         exploded_field = self._expr.to_column_field(self._input)
 
@@ -226,39 +266,38 @@ class Explode(LogicalPlan):
     def _repr(self) -> str:
         return f"Explode({self._expr})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Explode must have exactly one child")
-        result = Explode(children[0], self._expr)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Explode(node._expr)
+        new_node.set_input(children[0])
+        return new_node
 
-class DropDuplicates(LogicalPlan):
+class DropDuplicates(LogicalPlanNode):
     def __init__(
         self,
-        input: LogicalPlan,
         subset: List[ColumnExpr],
     ):
-        self._input = input
+        super().__init__()
         self.subset = subset
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         return self._input.schema()
 
     def _repr(self) -> str:
         return f"DropDuplicates(subset={', '.join(str(expr) for expr in self.subset)})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("DropDuplicates must have exactly one child")
-        result = DropDuplicates(children[0], self.subset)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
     def _subset(self) -> List[str]:
         subset: List[str] = []
@@ -266,21 +305,24 @@ class DropDuplicates(LogicalPlan):
             subset.append(str(col))
         return subset
 
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = DropDuplicates(node.subset)
+        new_node.set_input(children[0])
+        return new_node
 
-class Sort(LogicalPlan):
+class Sort(LogicalPlanNode):
     def __init__(
         self,
-        input: LogicalPlan,
         sort_exprs: List[SortExpr],
     ):
-        self._input = input
+        super().__init__()
         self._sort_exprs = sort_exprs
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         return self._input.schema()
 
     def sort_exprs(self) -> List[LogicalExpr]:
@@ -289,24 +331,27 @@ class Sort(LogicalPlan):
     def _repr(self) -> str:
         return f"Sort(cols={', '.join(str(expr) for expr in self._sort_exprs)})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Sort must have exactly one child")
-        result = Sort(children[0], self._sort_exprs)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Sort(node._sort_exprs)
+        new_node.set_input(children[0])
+        return new_node
 
 
-class Unnest(LogicalPlan):
-    def __init__(self, input: LogicalPlan, exprs: List[ColumnExpr]):
-        self._input = input
+class Unnest(LogicalPlanNode):
+    def __init__(self, exprs: List[ColumnExpr]):
+        super().__init__()
         self._exprs = exprs
-        super().__init__(self._input.session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         column_fields = []
         for field in self._input.schema().column_fields:
             if field.name in {expr.name for expr in self._exprs}:
@@ -330,15 +375,25 @@ class Unnest(LogicalPlan):
     def col_names(self) -> List[str]:
         return [expr.name for expr in self._exprs]
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("Unnest must have exactly one child")
-        result = Unnest(children[0], self._exprs)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
 
-class SQL(LogicalPlan):
-    def __init__(self, inputs: List[LogicalPlan], template_names: List[str], templated_query: str, session_state: BaseSessionState):
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = Unnest(node._exprs)
+        new_node.set_input(children[0])
+        return new_node
+
+class SQL(LogicalPlanNode):
+    def __init__(
+            self,
+            inputs: List[LogicalPlanNode],
+            template_names: List[str],
+            templated_query: str,
+        ):
+        super().__init__()
         # Note: inputs[i] corresponds to template_names[i]
         if len(inputs) != len(template_names):
             raise InternalError("inputs and template_names must have the same length")
@@ -346,11 +401,12 @@ class SQL(LogicalPlan):
         self._template_names = template_names
         self._templated_query = templated_query
         self.resolved_query, self.view_names = self._replace_query_placeholders()
-        for input in inputs:
-            ensure_same_session(input.session_state, session_state)
-        super().__init__(session_state)
 
-    def children(self) -> List[LogicalPlan]:
+    def set_input(self, input: LogicalPlanNode):
+        # Skip setting the input.
+        pass
+
+    def children(self) -> List[LogicalPlanNode]:
         return self._inputs
 
     def _repr(self) -> str:
@@ -370,7 +426,7 @@ class SQL(LogicalPlan):
         view_names = [template_name_to_view_name[name] for name in self._template_names]
         return replaced_sql, view_names
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         self._validate_query()
         db_conn = duckdb.connect()
         for view_name, input in zip(self.view_names, self._inputs, strict=True):
@@ -408,45 +464,54 @@ class SQL(LogicalPlan):
         root_expr = statements[0]
         _validate_select_only_tree(root_expr)
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         """Create and return a new instance of the SQL plan with the given children."""
         if len(children) == 0:
             raise InternalError("SQL node must have at least one child")
-        result = SQL(children, self._template_names, self._templated_query, self.session_state)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.copy(self, children)
+    
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        return SQL(children, node._template_names, node._templated_query)
+
+    @classmethod
+    def validate_same_session(
+            cls,
+            current_session_state: BaseSessionState,
+            input_session_states: list[BaseSessionState]) -> None:
+        for input_session_state in input_session_states:
+            ensure_same_session(input_session_state, current_session_state)
 
 @dataclass
 class CentroidInfo:
     centroid_column: str
     num_dimensions: int
 
-class SemanticCluster(LogicalPlan):
+class SemanticCluster(LogicalPlanNode):
     def __init__(
         self,
-        input: LogicalPlan,
         by_expr: LogicalExpr,
         num_clusters: int,
         max_iter: int,
         num_init: int,
         label_column: str,
         centroid_column: Optional[str],
+        centroid_info: Optional[CentroidInfo] = None,
     ):
-        self._input = input
+        super().__init__()
         self._by_expr = by_expr
         self._num_clusters = num_clusters
         self._max_iter = max_iter
         self._num_init = num_init
         self._label_column = label_column
         self._centroid_column = centroid_column
-        self._centroid_info: Optional[CentroidInfo] = None
-        super().__init__(self._input.session_state)
+        self._centroid_info = centroid_info
 
-    def children(self) -> List[LogicalPlan]:
+    def children(self) -> List[LogicalPlanNode]:
         return [self._input]
 
-    def _build_schema(self) -> Schema:
-        by_expr_type = self._by_expr.to_column_field(self._input).data_type
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        by_expr_type = self._by_expr.to_column_field(self._input, session_state).data_type
         if not isinstance(by_expr_type, EmbeddingType):
             raise TypeMismatchError.from_message(
                 f"semantic.with_cluster_labels by expression must be an embedding column type (EmbeddingType); "
@@ -481,20 +546,24 @@ class SemanticCluster(LogicalPlan):
     def label_column(self) -> str:
         return self._label_column
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlanNode]) -> LogicalPlanNode:
         if len(children) != 1:
             raise ValueError("SemanticCluster must have exactly one child")
-        result = SemanticCluster(
-            children[0],
-            self._by_expr,
-            num_clusters=self._num_clusters,
-            max_iter=self._max_iter,
-            num_init=self._num_init,
-            label_column=self._label_column,
-            centroid_column=self._centroid_column,
+        return self.copy(self, children)
+
+    @classmethod
+    def _create_new_node(cls, node: LogicalPlanNode, children: List[LogicalPlanNode]) -> LogicalPlanNode:
+        new_node = SemanticCluster(
+            node._by_expr,
+            node._num_clusters,
+            node._max_iter,
+            node._num_init,
+            node._label_column,
+            node._centroid_column,
+            node._centroid_info,
         )
-        result.set_cache_info(self.cache_info)
-        return result
+        new_node.set_input(children[0])
+        return new_node
 
 
 DDL_DML_NODES = (

--- a/src/fenic/core/_logical_plan/serde.py
+++ b/src/fenic/core/_logical_plan/serde.py
@@ -2,6 +2,7 @@ import cloudpickle  # nosec: B403
 
 from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.plans.base import LogicalPlan
+from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
 
 class LogicalPlanSerde:
@@ -17,28 +18,28 @@ class LogicalPlanSerde:
         Returns:
             bytes: The serialized plan
         """
-        # For now, we need to copy the plan in a bottom-up manner, and then walk it again top-down to remove the session state.
-        # We can't nullify the session state during the bottom-up traversal because some plan nodes rely on their children's
-        # session state during initialization. Clearing it too early can break this initialization logic.
-        # TODO(rohitrastogi): Decouple plan construction logic from plan validation logic.
-        def copy_plan(plan: LogicalPlan) -> LogicalPlan:
+        # For now, we need to copy the plan in a bottom-up manner.
+        def copy_plan(node: LogicalPlanNode) -> LogicalPlanNode:
             new_children = []
-            for child in plan.children():
+            for child in node.children():
                 new_children.append(copy_plan(child))
-            return plan.with_children(new_children)
+            return node.with_children(new_children)
 
-        def remove_session_state(plan: LogicalPlan) -> LogicalPlan:
-            plan.session_state = None
-            for child in plan.children():
-                remove_session_state(child)
-            return plan
-
-        copied_plan = copy_plan(plan)
-        remove_session_state(copied_plan)
-        return cloudpickle.dumps(copied_plan)
+        # we only want to serialize the logical plan node tree, not the session state.
+        copied_logical_plan_node = copy_plan(plan.logical_plan_node)
+        return cloudpickle.dumps(copied_logical_plan_node)
 
     @staticmethod
-    def deserialize(data: bytes) -> LogicalPlan:
+    def deserialize_into_logical_plan(data: bytes, session_state: BaseSessionState) -> LogicalPlan:
+        print("Deserializing into logical plan.")
+        logical_plan_node = LogicalPlanSerde.deserialize(data)
+        logical_plan = LogicalPlan(session_state)
+        logical_plan.logical_plan_node = logical_plan_node
+        #logical_plan.update_schema()
+        return logical_plan
+
+    @staticmethod
+    def deserialize(data: bytes) -> LogicalPlanNode:
         """Deserialize bytes back into a LogicalPlan using pickle.
 
         Args:
@@ -51,19 +52,14 @@ class LogicalPlanSerde:
 
     @staticmethod
     def build_logical_plan_with_session_state(
-        plan: LogicalPlan, session: BaseSessionState
+        node: LogicalPlanNode, session: BaseSessionState
     ) -> LogicalPlan:
         """Build a LogicalPlan with the session state.
 
         Args:
-            plan: The LogicalPlan to build
+            node: The LogicalPlanNode tree to source the plan
             session: The session state
         """
-        # TODO(DY): replace pickle with substrait so we don't need this step
-        new_children = []
-        for child in plan.children():
-            new_children.append(
-                LogicalPlanSerde.build_logical_plan_with_session_state(child, session)
-            )
-        plan.session_state = session
-        return plan.with_children(new_children)
+        plan = LogicalPlan(session)
+        plan.logical_plan_node = node
+        return plan

--- a/src/fenic/core/_logical_plan/signatures/function_signature.py
+++ b/src/fenic/core/_logical_plan/signatures/function_signature.py
@@ -10,8 +10,9 @@ from enum import Enum, auto
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan.plans.base import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.signatures.type_signature import (
     Exact,
@@ -49,12 +50,13 @@ class FunctionSignature:
     def validate_and_infer_type(
         self,
         args: List[LogicalExpr],
-        plan: LogicalPlan,
-        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlan], DataType]] = None
+        node: LogicalPlanNode,
+        session_state: BaseSessionState,
+        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlanNode], DataType]] = None
     ) -> DataType:
         """Validate arguments and infer return type using the plan's schema."""
         # Get types of all arguments using to_column_field
-        arg_types = [arg.to_column_field(plan).data_type for arg in args]
+        arg_types = [arg.to_column_field(node, session_state).data_type for arg in args]
 
         # Validate against signature (no implicit casting in initial implementation)
         self.type_signature.validate(arg_types, self.function_name)
@@ -63,7 +65,7 @@ class FunctionSignature:
         if self.return_type == ReturnTypeStrategy.DYNAMIC:
             if dynamic_return_type_func is None:
                 raise InternalError(f"DYNAMIC return type requires dynamic_return_type_func for {self.function_name}")
-            return_type = dynamic_return_type_func(arg_types, plan)
+            return_type = dynamic_return_type_func(arg_types, node, session_state)
         else:
             return_type = self.infer_return_type(arg_types)
 

--- a/src/fenic/core/_logical_plan/signatures/signature_validator.py
+++ b/src/fenic/core/_logical_plan/signatures/signature_validator.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, List, Optional
 
 if TYPE_CHECKING:
-    from fenic.core._logical_plan.plans.base import LogicalPlan
+    from fenic.core._logical_plan.plans.node import LogicalPlanNode
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.signatures.function_signature import FunctionSignature
 from fenic.core._logical_plan.signatures.registry import FunctionRegistry
@@ -36,8 +37,9 @@ class SignatureValidator:
     def validate_and_infer_type(
         self,
         args: List[LogicalExpr],
-        plan: LogicalPlan,
-        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlan], DataType]] = None
+        node: LogicalPlanNode,
+        session_state: BaseSessionState,
+        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlanNode], DataType]] = None
     ) -> DataType:
         """Validate arguments and infer return type using the plan's schema.
         
@@ -46,7 +48,8 @@ class SignatureValidator:
         
         Args:
             args: List of LogicalExpr arguments to validate
-            plan: LogicalPlan object for schema context
+            node: LogicalPlanNode object for schema context
+            session_state: BaseSessionState
             dynamic_return_type_func: Optional function for dynamic return type inference
             
         Returns:
@@ -60,4 +63,4 @@ class SignatureValidator:
             self._signature = FunctionRegistry.get_signature(self.function_name)
         
         # Delegate to the signature's validate_and_infer_type method
-        return self._signature.validate_and_infer_type(args, plan, dynamic_return_type_func)
+        return self._signature.validate_and_infer_type(args, node, session_state, dynamic_return_type_func)

--- a/tests/_backends/local/io/test_writer.py
+++ b/tests/_backends/local/io/test_writer.py
@@ -250,7 +250,7 @@ def test_table_writer_ignore_mode(local_session):
     assert count == 3  # Should still have the count from the first dataframe
 
 
-def test_logical_plan_sink_nodes(local_session):
+def test_logical_plan_nodes_sink_nodes(local_session):
     """Test creation of logical plan sink nodes directly."""
     df = local_session.create_dataframe({"a": [1, 2, 3]})
 
@@ -261,11 +261,14 @@ def test_logical_plan_sink_nodes(local_session):
         path="test.csv",
         mode="overwrite",
     )
+    file_sink._build_schema_with_validation(local_session._session_state)
 
     # Create a TableSink node
     table_sink = TableSink(
         child=df._logical_plan, table_name="test_table", mode="overwrite"
     )
+    table_sink._build_schema_with_validation(local_session._session_state)
+
     file_sink_columns = file_sink.schema().column_names()
     table_sink_columns = table_sink.schema().column_names()
 

--- a/tests/_backends/local/test_transpiler.py
+++ b/tests/_backends/local/test_transpiler.py
@@ -25,6 +25,7 @@ from fenic.core._logical_plan.expressions import (
 from fenic.core._logical_plan.plans import (
     Filter,
     InMemorySource,
+    LogicalPlan,
     Projection,
     Union,
 )
@@ -82,7 +83,8 @@ def test_unsupported_expr(local_session):
 
 def test_convert_source_plan(local_session):
     df = pl.DataFrame({"a": [1, 2, 3]})
-    source = InMemorySource(df, local_session._session_state)
+    source = LogicalPlan(local_session._session_state)
+    source = source.add_node(InMemorySource(df))
     plan_converter = PlanConverter(local_session._session_state)
     physical = plan_converter.convert(
         source,
@@ -92,25 +94,29 @@ def test_convert_source_plan(local_session):
 
 def test_convert_projection_plan(local_session):
     df = pl.DataFrame({"a": [1, 2, 3]})
-    source = InMemorySource(df, local_session._session_state)
+    plan = LogicalPlan(local_session._session_state)
+    plan = plan.add_node(InMemorySource(df))
     plan_converter = PlanConverter(local_session._session_state)
-    proj = Projection(source, [ColumnExpr("a")])
+    proj = Projection([ColumnExpr("a")])
+    plan = plan.add_node(proj)
     physical = plan_converter.convert(
-        proj,
+        plan,
     )
     assert isinstance(physical, ProjectionExec)
 
 
 def test_convert_filter_plan(local_session):
     df = pl.DataFrame({"a": [1, 2, 3]})
-    source = InMemorySource(df, local_session._session_state)
+    plan = LogicalPlan(local_session._session_state)
+    plan = plan.add_node(InMemorySource(df))
     plan_converter = PlanConverter(local_session._session_state)
     filter_expr = NumericComparisonExpr(
         ColumnExpr("a"), LiteralExpr(2, IntegerType), Operator.GT
     )
-    filt = Filter(source, filter_expr)
+    filt = Filter(filter_expr)
+    plan = plan.add_node(filt)
     physical = plan_converter.convert(
-        filt,
+        plan,
     )
     assert isinstance(physical, FilterExec)
 
@@ -119,10 +125,18 @@ def test_convert_union_plan(local_session):
     plan_converter = PlanConverter(local_session._session_state)
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"a": [3, 4]})
-    source1 = InMemorySource(df1, local_session._session_state)
-    source2 = InMemorySource(df2, local_session._session_state)
+    plan = LogicalPlan(local_session._session_state)
+
+    source1 = InMemorySource(df1)
+    source1._build_schema_with_validation(local_session._session_state)
+    source2 = InMemorySource(df2)
+    source2._build_schema_with_validation(local_session._session_state)
+
+    # plan = plan.add_node(source1)
+    # plan = plan.add_node(source2)
     union = Union([source1, source2])
+    plan = plan.add_node(union)
     physical = plan_converter.convert(
-        union,
+        plan,
     )
     assert isinstance(physical, UnionExec)

--- a/tests/_logical_plan/signatures/test_aggregate_function.py
+++ b/tests/_logical_plan/signatures/test_aggregate_function.py
@@ -1,7 +1,10 @@
 """Tests for AggregateFunction base class functionality."""
 
+from typing import Optional
+
 import pytest
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.aggregate import AvgExpr, CountExpr, SumExpr
 from fenic.core.error import TypeMismatchError
 from fenic.core.types.datatypes import (
@@ -20,15 +23,15 @@ class MockColumn:
         self.name = name
         self.data_type = data_type
     
-    def to_column_field(self, plan):
+    def to_column_field(self, node, session_state: Optional[BaseSessionState] = None):
         return ColumnField(self.name, self.data_type)
     
     def __str__(self):
         return self.name
 
 
-class MockPlan:
-    """Mock logical plan for testing."""
+class MockPlanNode:
+    """Mock logical plan node for testing."""
     
     def __init__(self, columns=None):
         self.columns = columns or []
@@ -41,10 +44,10 @@ class TestAggregateFunction:
         """Test that AggregateFunction uses function registry for validation."""
         # SumExpr should use the registry system
         int_col = MockColumn("int_col", IntegerType)
-        plan = MockPlan()
+        node = MockPlanNode()
         
         sum_expr = SumExpr(int_col)
-        result = sum_expr.to_column_field(plan)
+        result = sum_expr.to_column_field(node)
         
         # Should validate successfully and return same type for sum
         assert result.data_type == IntegerType
@@ -54,41 +57,41 @@ class TestAggregateFunction:
         """Test that signature validation works for aggregate functions."""
         # Sum should reject string types
         string_col = MockColumn("str_col", StringType) 
-        plan = MockPlan()
+        node = MockPlanNode()
         
         sum_expr = SumExpr(string_col)
         
         # Should fail validation
         with pytest.raises(TypeMismatchError):
-            sum_expr.to_column_field(plan)
+            sum_expr.to_column_field(node)
     
     def test_avg_dynamic_return_type(self):
         """Test that AvgExpr correctly handles dynamic return types."""
-        plan = MockPlan()
+        node = MockPlanNode()
         
         # Test numeric types return DoubleType
         int_col = MockColumn("int_col", IntegerType)
         avg_expr = AvgExpr(int_col)
-        result = avg_expr.to_column_field(plan)
+        result = avg_expr.to_column_field(node)
         assert result.data_type == DoubleType
         
         # Test embedding types return same type
         embedding_col = MockColumn("emb_col", EmbeddingType(dimensions=128, embedding_model="test"))
         avg_expr_emb = AvgExpr(embedding_col)
-        result_emb = avg_expr_emb.to_column_field(plan)
+        result_emb = avg_expr_emb.to_column_field(node)
         assert isinstance(result_emb.data_type, EmbeddingType)
         assert result_emb.data_type.embedding_model == "test"
         assert result_emb.data_type.dimensions == 128
     
     def test_count_accepts_any_type(self):
         """Test that CountExpr accepts any input type."""
-        plan = MockPlan()
+        node = MockPlanNode()
         
         # Test various types
         for data_type in [IntegerType, StringType, DoubleType]:
             col = MockColumn("col", data_type)
             count_expr = CountExpr(col)
-            result = count_expr.to_column_field(plan)
+            result = count_expr.to_column_field(node)
             
             # Count always returns IntegerType
             assert result.data_type == IntegerType

--- a/tests/_logical_plan/signatures/test_function_signatures.py
+++ b/tests/_logical_plan/signatures/test_function_signatures.py
@@ -4,8 +4,11 @@ Test FunctionSignature class and return type inference.
 This tests the complete function signature validation and return type strategies.
 """
 
+from typing import Optional
+
 import pytest
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.expressions.basic import ArrayLengthExpr, ColumnExpr
 from fenic.core._logical_plan.signatures.function_signature import (
@@ -23,7 +26,7 @@ from fenic.core.types.schema import ColumnField, Schema
 
 
 # Mock classes for testing
-class MockPlan:
+class MockPlanNode:
     def __init__(self, column_fields=None):
         if column_fields is None:
             column_fields = []
@@ -38,7 +41,7 @@ class MockColumn(LogicalExpr):
         self.name = name
         self.data_type = data_type
 
-    def to_column_field(self, plan):
+    def to_column_field(self, node, session_state: Optional[BaseSessionState] = None):
         return ColumnField(self.name, self.data_type)
 
     def children(self):
@@ -99,30 +102,30 @@ class TestFunctionSignature:
 
         # Create mock arguments
         string_col = MockColumn("text_col", StringType)
-        plan = MockPlan()
+        node = MockPlanNode()
 
         # Should validate and return correct type
-        return_type = sig.validate_and_infer_type([string_col], plan)
+        return_type = sig.validate_and_infer_type([string_col], node, None)
         assert return_type == StringType
 
         # Should fail validation with wrong type
         int_col = MockColumn("int_col", IntegerType)
         with pytest.raises(TypeMismatchError, match="upper Argument 0: expected StringType, got IntegerType"):
-            sig.validate_and_infer_type([int_col], plan)
+            sig.validate_and_infer_type([int_col], node, None)
 
     def test_dynamic_return_type_with_function(self):
         """Test DYNAMIC return type with custom function."""
         sig = FunctionSignature(function_name="array_constructor", type_signature=VariadicUniform(expected_min_args=1),
                                 return_type=ReturnTypeStrategy.DYNAMIC)
 
-        def dynamic_return_func(arg_types, logical_plan):
+        def dynamic_return_func(arg_types, logical_node, session_state):
             return ArrayType(arg_types[0])
 
         string_col = MockColumn("text_col", StringType)
-        plan = MockPlan()
+        node = MockPlanNode()
 
         # Should use dynamic function for return type
-        return_type = sig.validate_and_infer_type([string_col], plan, dynamic_return_func)
+        return_type = sig.validate_and_infer_type([string_col], node, None, dynamic_return_func)
         assert return_type == ArrayType(StringType)
 
 
@@ -155,19 +158,19 @@ class TestScalarFunctionIntegration:
     def test_validated_signatures_with_mock_plan(self):
         """Test that ValidatedSignature expressions work correctly with MockPlan."""
         # Create a plan with a string column
-        plan = MockPlan([ColumnField("text_col", ArrayType(StringType))])
+        node = MockPlanNode([ColumnField("text_col", ArrayType(StringType))])
 
         # Create a StrLengthExpr and test it
         col_expr = ColumnExpr("text_col")
         array_length_expr = ArrayLengthExpr(col_expr)
 
-        result = array_length_expr.to_column_field(plan)
+        result = array_length_expr.to_column_field(node)
         assert result.data_type == IntegerType
 
         # Test that type validation works (should fail for wrong type)
-        plan_wrong_type = MockPlan([ColumnField("int_col", IntegerType)])
+        node_wrong_type = MockPlanNode([ColumnField("int_col", IntegerType)])
         col_expr_wrong = ColumnExpr("int_col")
         array_length_expr_wrong = ArrayLengthExpr(col_expr_wrong)
 
         with pytest.raises(TypeMismatchError, match="array_size expects argument 0 to be an array type, got IntegerType"):
-            array_length_expr_wrong.to_column_field(plan_wrong_type)
+            array_length_expr_wrong.to_column_field(node_wrong_type)

--- a/tests/_logical_plan/test_optimizer.py
+++ b/tests/_logical_plan/test_optimizer.py
@@ -92,6 +92,7 @@ def test_semantic_predicate_rewrite_basic(local_session):
         & (col("a_numeric_column") > 0)
         & semantic.predicate("something that references {blurb2}")
     )
+
     plan = (
         LogicalPlanOptimizer([MergeFiltersRule(), SemanticFilterRewriteRule()])
         .optimize(df._logical_plan)

--- a/tests/_logical_plan/test_serde.py
+++ b/tests/_logical_plan/test_serde.py
@@ -33,23 +33,21 @@ def _test_plan_serialization(
     # Serialize and deserialize
     serialized = LogicalPlanSerde.serialize(plan)
     deserialized = LogicalPlanSerde.deserialize(serialized)
+
     deserialized_with_session_state = (
         LogicalPlanSerde.build_logical_plan_with_session_state(deserialized, session)
     )
     deserialized_df = DataFrame._from_logical_plan(
-        deserialized_with_session_state
-    )
-    deserialized_with_session_state._build_schema()
-    plan._build_schema()
+        LogicalPlan(session),
+        deserialized_with_session_state.logical_plan_node)
 
     # Test equivalence
     assert isinstance(deserialized_with_session_state, type(plan))
-    assert plan._repr() == deserialized_with_session_state._repr()
-    assert str(plan._build_schema()) == str(deserialized_with_session_state._build_schema())
+    assert str(plan) == str(deserialized_with_session_state)
 
     # Test children if any
-    assert len(plan.children()) == len(deserialized_with_session_state.children())
-    for orig_child, deser_child in zip(plan.children(), deserialized.children(), strict=False):
+    assert len(plan.logical_plan_node.children()) == len(deserialized_with_session_state.logical_plan_node.children())
+    for orig_child, deser_child in zip(plan.logical_plan_node.children(), deserialized_with_session_state.logical_plan_node.children(), strict=False):
         assert orig_child._repr() == deser_child._repr()
 
     return deserialized_df

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -16,6 +16,7 @@ from fenic import (
 )
 from fenic.api.session.config import OpenAIModelConfig
 from fenic.core._logical_plan.plans import InMemorySource
+from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core.error import ConfigurationError
 from fenic.core.error import ValidationError as FenicValidationError
 
@@ -198,11 +199,16 @@ def test_inmemory_source(local_session):
 
     # Check that the logical plan is an InMemorySource.
     assert isinstance(
-        df._logical_plan, InMemorySource
+        df._logical_plan, LogicalPlan
+    ), "Expected a LogicalPlan."
+
+    assert isinstance(
+        df._logical_plan.logical_plan_node, InMemorySource
     ), "Expected an InMemorySource logical node."
 
     # Verify the schema.
     schema = df.schema
+
     expected_columns = {"col1", "col2"}
     actual_columns = {field.name for field in schema.column_fields}
     assert (


### PR DESCRIPTION
### TL;DR

Refactored the logical plan architecture to separate the logical plan node tree from the session state, improving serialization and plan manipulation.

### What changed?

- Created a new `LogicalPlanNode` class hierarchy that's independent of session state
- Modified `LogicalPlan` to be a container that holds both a `LogicalPlanNode` tree and session state
- Updated all plan operations to work with the new node-based architecture
- Refactored expression evaluation to take an optional session state parameter
- Modified plan serialization to only serialize the node tree, not the session state

