### PR TITLE
fix: Check UDF return value and validate its not a logical type

### DIFF
--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -105,7 +105,8 @@ from fenic.core._utils.schema import (
     convert_custom_dtype_to_polars,
     convert_pydantic_type_to_custom_struct_type,
 )
-from fenic.core.error import InternalError
+from fenic.core._utils.type_inference import can_cast, infer_dtype_from_pyobj
+from fenic.core.error import ExecutionError, InternalError
 from fenic.core.types.datatypes import (
     ArrayType,
     BooleanType,
@@ -339,8 +340,9 @@ class ExprConverter:
         struct = pl.struct(
             [self._convert_expr(arg) for arg in logical.args]
         )
-        converted_udf = _convert_udf_to_map_elements(
-            logical.func
+        converted_udf = _convert_udf_to_map_elements_and_validate_return_type(
+            logical.func,
+            logical.return_type,
         )
         return struct.map_elements(
             converted_udf,
@@ -1162,7 +1164,7 @@ def _calculate_similarity_numpy(
 
     raise InternalError(f"Unknown similarity metric: {metric}. Invalid state.")
 
-def _convert_udf_to_map_elements(udf: Callable) -> Callable:
+def _convert_udf_to_map_elements_and_validate_return_type(udf: Callable, return_type: DataType) -> Callable:
     """Converts a scalar-based UDF into one that works with `map_elements` in Polars.
 
     Args:
@@ -1171,11 +1173,20 @@ def _convert_udf_to_map_elements(udf: Callable) -> Callable:
 
     Returns:
         A function that operates on a row (Struct) and applies the UDF to the unwrapped values.
+    
+    Raises:
+        ExecutionError: If the type of the UDF's return value does not match the expected return type.
     """
 
     def adapted_udf(row):
+        def udf_with_validate_return_type(udf: Callable, return_type: DataType, *args, **kwargs) -> DataType:
+            result = udf(*args, **kwargs)
+            dtype = infer_dtype_from_pyobj(result)
+            if not can_cast(dtype, return_type):
+                raise ExecutionError(f"The type of UDF's return value ({dtype}) does not match expected return type ({return_type})")
+            return result
         column_values = list(row.values())
         # Unpack the row (Struct) by its column names
-        return udf(*column_values)
+        return udf_with_validate_return_type(udf, return_type, *column_values)
 
     return adapted_udf

--- a/src/fenic/api/functions/builtin.py
+++ b/src/fenic/api/functions/builtin.py
@@ -24,6 +24,7 @@ from fenic.core._logical_plan.expressions import (
     UDFExpr,
     WhenExpr,
 )
+from fenic.core._utils.type_inference import is_logical_type
 from fenic.core.error import ValidationError
 from fenic.core.types import DataType
 
@@ -270,7 +271,7 @@ def udf(f: Optional[Callable] = None, *, return_type: DataType):
     Args:
         f: Python function to convert to UDF
 
-        return_type: Expected return type of the UDF. Required parameter.
+        return_type: Expected return type of the UDF. Can only be Required parameter.
 
     Example: UDF with primitive types
         ```python
@@ -302,6 +303,9 @@ def udf(f: Optional[Callable] = None, *, return_type: DataType):
             return Column._from_logical_expr(UDFExpr(func, col_exprs, return_type))
 
         return _udf_wrapper
+
+    if is_logical_type(return_type):
+        raise ValidationError("Logical types are not supported as return_type for udfs.")
 
     if f is not None:
         return _create_udf(f)

--- a/src/fenic/core/_logical_plan/expressions/basic.py
+++ b/src/fenic/core/_logical_plan/expressions/basic.py
@@ -11,27 +11,17 @@ from fenic.core._logical_plan.expressions.base import (
     ValidatedSignature,
 )
 from fenic.core._logical_plan.signatures.signature_validator import SignatureValidator
+from fenic.core._utils.type_inference import can_cast
 from fenic.core.error import PlanError, TypeMismatchError, ValidationError
 from fenic.core.types import (
     ArrayType,
     BooleanType,
     ColumnField,
     DataType,
-    DocumentPathType,
-    DoubleType,
-    EmbeddingType,
-    FloatType,
     IntegerType,
-    JsonType,
-    MarkdownType,
     StringType,
     StructField,
     StructType,
-    TranscriptType,
-)
-from fenic.core.types.datatypes import (
-    _HtmlType,
-    _PrimitiveType,
 )
 
 
@@ -302,7 +292,7 @@ class CastExpr(LogicalExpr):
         self.source_type = self.expr.to_column_field(plan).data_type
         src = self.source_type
         dst = self.dest_type
-        if not _can_cast(src, dst):
+        if not can_cast(src, dst):
             raise PlanError(f"Unsupported cast: {src} → {dst}")
         return ColumnField(str(self), dst)
 
@@ -374,44 +364,3 @@ class InExpr(LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr, self.other]
 
-UNIMPLEMENTED_TYPES = (_HtmlType, TranscriptType, DocumentPathType)
-def _can_cast(src: DataType, dst: DataType) -> bool:
-    if type(src) in UNIMPLEMENTED_TYPES or type(dst) in UNIMPLEMENTED_TYPES:
-        raise NotImplementedError(f"Unimplemented type: Cannot cast {src} → {dst}")
-
-    if isinstance(src, EmbeddingType):
-        return NotImplementedError(f"Unimplemented type: Cannot cast {src} → {dst}")
-
-    if (src == ArrayType(element_type=FloatType) or src == ArrayType(element_type=DoubleType)) and isinstance(dst, EmbeddingType):
-        return True
-
-    if src == dst:
-        return True
-
-    if dst == MarkdownType:
-        return _can_cast(src, StringType)
-
-    if src == MarkdownType:
-        return _can_cast(StringType, dst)
-
-    if dst == JsonType or src == JsonType:
-        return True
-
-    if isinstance(src, _PrimitiveType) and isinstance(dst, _PrimitiveType):
-        # Disallow string → bool
-        if src == StringType and dst == BooleanType:
-            return False
-        return True
-
-    if isinstance(src, ArrayType) and isinstance(dst, ArrayType):
-        return _can_cast(src.element_type, dst.element_type)
-
-    if isinstance(src, StructType) and isinstance(dst, StructType):
-        src_fields = {f.name: f.data_type for f in src.struct_fields}
-        dst_fields = {f.name: f.data_type for f in dst.struct_fields}
-        for name, dst_type in dst_fields.items():
-            if name in src_fields and not _can_cast(src_fields[name], dst_type):
-                return False
-        return True
-
-    return False

--- a/src/fenic/core/_utils/misc.py
+++ b/src/fenic/core/_utils/misc.py
@@ -57,3 +57,4 @@ def generate_unique_arrow_view_name() -> str:
         'temp_arrow_view_1a2b3c4d5e6f...'
     """
     return f"temp_arrow_view_{uuid.uuid4().hex}"
+

--- a/src/fenic/core/_utils/type_inference.py
+++ b/src/fenic/core/_utils/type_inference.py
@@ -4,12 +4,20 @@ from fenic.core.types.datatypes import (
     ArrayType,
     BooleanType,
     DataType,
+    DocumentPathType,
     DoubleType,
+    EmbeddingType,
     FloatType,
     IntegerType,
+    JsonType,
+    MarkdownType,
     StringType,
     StructField,
     StructType,
+    TranscriptType,
+    _HtmlType,
+    _PrimitiveType,
+    _StringBackedType,
 )
 
 
@@ -96,3 +104,63 @@ def _find_common_supertype(type1: DataType, type2: DataType, path="") -> DataTyp
         return StructType(merged_fields)
 
     raise TypeInferenceError(f"Incompatible types: {type1} vs {type2}", path)
+
+def is_logical_type(type: DataType) -> bool:
+    """Check if a type is a logical type.  If it is a _StringBackedType, or a struct or array that contains a _StringBackedType, it is logical type.
+
+    Args:
+        type: The type to check.
+
+    Returns:
+        True if the type is a logical type, False otherwise.
+    """
+    if isinstance(type, _StringBackedType):
+        return True
+    elif isinstance(type, StructType):
+        return any(is_logical_type(field.data_type) for field in type.struct_fields)
+    elif isinstance(type, ArrayType):
+        return is_logical_type(type.element_type)
+    return False
+
+UNIMPLEMENTED_TYPES = (_HtmlType, TranscriptType, DocumentPathType)
+def can_cast(src: DataType, dst: DataType) -> bool:
+    if type(src) in UNIMPLEMENTED_TYPES or type(dst) in UNIMPLEMENTED_TYPES:
+        raise NotImplementedError(f"Unimplemented type: Cannot cast {src} → {dst}")
+
+    if isinstance(src, EmbeddingType):
+        return NotImplementedError(f"Unimplemented type: Cannot cast {src} → {dst}")
+
+    if (src == ArrayType(element_type=FloatType) or src == ArrayType(element_type=DoubleType)) and isinstance(dst, EmbeddingType):
+        return True
+
+    if src == dst:
+        return True
+
+    if dst == MarkdownType:
+        return can_cast(src, StringType)
+
+    if src == MarkdownType:
+        return can_cast(StringType, dst)
+
+    if dst == JsonType or src == JsonType:
+        return True
+
+    if isinstance(src, _PrimitiveType) and isinstance(dst, _PrimitiveType):
+        # Disallow string → bool
+        if src == StringType and dst == BooleanType:
+            return False
+        return True
+
+    if isinstance(src, ArrayType) and isinstance(dst, ArrayType):
+        return can_cast(src.element_type, dst.element_type)
+
+    if isinstance(src, StructType) and isinstance(dst, StructType):
+        src_fields = {f.name: f.data_type for f in src.struct_fields}
+        dst_fields = {f.name: f.data_type for f in dst.struct_fields}
+        for name, dst_type in dst_fields.items():
+            if name in src_fields and not can_cast(src_fields[name], dst_type):
+                return False
+        return True
+
+    return False
+

--- a/tests/_backends/local/functions/test_udf.py
+++ b/tests/_backends/local/functions/test_udf.py
@@ -1,4 +1,15 @@
-from fenic import ArrayType, IntegerType, StructField, StructType, col, udf
+import pytest
+
+from fenic import (
+    ArrayType,
+    IntegerType,
+    MarkdownType,
+    StructField,
+    StructType,
+    col,
+    udf,
+)
+from fenic.core.error import ExecutionError, ValidationError
 
 
 def test_with_column_udf(sample_df):
@@ -19,7 +30,6 @@ def test_with_column_udf_expr_input(sample_df):
     result = sample_df.with_column("age_plus_1", add_one(col("age") + 1)).to_polars()
     assert "age_plus_1" in result.columns
     assert result["age_plus_1"][0] == 27
-
 
 def test_with_column_udf_multiple_args(local_session):
     @udf(return_type=IntegerType)
@@ -100,3 +110,31 @@ def test_udf_with_nested_types(local_session):
         special_sum3(col("struct_col"), col("array_col")).alias("result")
     ).to_polars()
     assert struct_result["result"].to_list() == [[20, 1, 2, 3], [40, 4, 5, 6]]
+
+
+def test_udf_with_logical_return_type(local_session):
+    # basic logical types
+    with pytest.raises(ValidationError):
+        @udf(return_type=MarkdownType)
+        def markdown_udf(x: str):
+            return f"# hello\n\n {x} \n\n# goodbye"
+
+    # array with logical type
+    with pytest.raises(ValidationError):
+        @udf(return_type=ArrayType(element_type=MarkdownType))
+        def markdown_array_udf(x: str):
+            return [f"# hello\n\n {x} \n\n# hello", f"# goodbye\n\n {x} \n\n# goodbye"]
+
+    # struct with logical type
+    with pytest.raises(ValidationError):
+        @udf(return_type=StructType([StructField("value1", IntegerType), StructField("value2", MarkdownType)]))
+        def markdown_struct_udf(x: str):
+            return {"value1": len(x), "value2": f"# hello\n\n {x} \n\n# goodbye"}
+
+def test_udf_with_mismatching_return_type(sample_df):
+    @udf(return_type=ArrayType(element_type=IntegerType))
+    def add_one(x):
+        return x + 1
+
+    with pytest.raises(ExecutionError):
+        sample_df.select(add_one("age")).to_polars()


### PR DESCRIPTION
# Summary

Imporve UDF type checking - check UDF return type before mapping the result to the polars series/column output, and validate that the UDF is not returning a logical type since that's currently unsupported.

# What Changed

* UDF polars wrapper also checks the return type to see if we can cast it to one of our DTypes
* udf() will validate that the return type is not a logical type
* Moved can_cast and added is_logical_type to utils type_inference
* Added unit tests for logical type validation and for checking a mismatching return type

# Out of scope
Add support for returned LogicalTypes in UDFs (see [issue #114](https://github.com/typedef-ai/fenic/issues/114))