### PR TITLE
fix: split plan creation from validation

### DIFF
--- a/src/fenic/_backends/local/transpiler/plan_converter.py
+++ b/src/fenic/_backends/local/transpiler/plan_converter.py
@@ -79,6 +79,7 @@ class PlanConverter:
         # for SemanticFilterRewriteRule() to produce optimal plans.
         logical = (
             LogicalPlanOptimizer(
+                self.session_state,
                 [NotFilterPushdownRule(), MergeFiltersRule(), SemanticFilterRewriteRule()]
             )
             .optimize(logical)
@@ -281,7 +282,7 @@ class PlanConverter:
             child_physical = self.convert(
                 child_logical
             )
-            target_field = logical._expr.to_column_field(child_logical)
+            target_field = logical._expr.to_column_field(child_logical, self.session_state)
             return ExplodeExec(
                 child_physical,
                 physical_expr,

--- a/src/fenic/api/dataframe/grouped_data.py
+++ b/src/fenic/api/dataframe/grouped_data.py
@@ -89,5 +89,6 @@ class GroupedData(BaseGroupedData):
 
         agg_exprs = self._process_agg_exprs(exprs)
         return self._df._from_logical_plan(
-            Aggregate(self._df._logical_plan, self._by_exprs, agg_exprs),
+            Aggregate.from_session_state(self._df._logical_plan, self._by_exprs, agg_exprs, self._df._session_state),
+            self._df._session_state,
         )

--- a/src/fenic/api/dataframe/semantic_extensions.py
+++ b/src/fenic/api/dataframe/semantic_extensions.py
@@ -125,7 +125,7 @@ class SemanticExtensions:
             )
 
         return self._df._from_logical_plan(
-            SemanticCluster(
+            SemanticCluster.from_session_state(
                 self._df._logical_plan,
                 by_expr,
                 num_clusters=num_clusters,
@@ -133,7 +133,9 @@ class SemanticExtensions:
                 num_init=num_init,
                 label_column=label_column,
                 centroid_column=centroid_column,
-            )
+                session_state=self._df._session_state,
+            ),
+            self._df._session_state,
         )
 
     def join(
@@ -242,16 +244,19 @@ class SemanticExtensions:
                 "join_instruction must contain exactly one :left and one :right column"
             )
 
+        DataFrame._ensure_same_session(self._df._session_state, [other._session_state])
         return self._df._from_logical_plan(
-            SemanticJoin(
+            SemanticJoin.from_session_state(
                 left=self._df._logical_plan,
                 right=other._logical_plan,
                 left_on=left_on._logical_expr,
                 right_on=right_on._logical_expr,
                 join_instruction=join_instruction,
-                examples=examples,
                 model_alias=model_alias,
+                examples=examples,
+                session_state=self._df._session_state,
             ),
+            self._df._session_state,
         )
 
     def sim_join(
@@ -353,8 +358,9 @@ class SemanticExtensions:
         _validate_column(left_on, "left_on")
         _validate_column(right_on, "right_on")
 
+        DataFrame._ensure_same_session(self._df._session_state, [other._session_state])
         return self._df._from_logical_plan(
-            SemanticSimilarityJoin(
+            SemanticSimilarityJoin.from_session_state(
                 self._df._logical_plan,
                 other._logical_plan,
                 Column._from_col_or_name(left_on)._logical_expr,
@@ -362,7 +368,9 @@ class SemanticExtensions:
                 k,
                 similarity_metric,
                 similarity_score_column,
+                self._df._session_state,
             ),
+            self._df._session_state,
         )
 
     # Spark aliases

--- a/src/fenic/api/io/reader.py
+++ b/src/fenic/api/io/reader.py
@@ -217,12 +217,12 @@ class DataFrameReader:
         # Convert all paths to strings
         paths_str = [str(p) for p in paths_list]
 
-        logical_node = FileSource(
+        logical_node = FileSource.from_session_state(
             paths=paths_str,
             file_format=file_format,
-            session_state=self._session_state,
             options=options,
+            session_state=self._session_state,
         )
         from fenic.api.dataframe import DataFrame
 
-        return DataFrame._from_logical_plan(logical_node)
+        return DataFrame._from_logical_plan(logical_node, self._session_state)

--- a/src/fenic/api/io/writer.py
+++ b/src/fenic/api/io/writer.py
@@ -65,11 +65,11 @@ class DataFrameWriter:
             df.write.save_as_table("my_table", mode="overwrite")  # Replaces existing table
             ```
         """
-        sink_plan = TableSink(
-            child=self._dataframe._logical_plan, table_name=table_name, mode=mode
+        sink_plan = TableSink.from_session_state(
+            child=self._dataframe._logical_plan, table_name=table_name, mode=mode, session_state=self._dataframe._session_state
         )
 
-        metrics = self._dataframe._logical_plan.session_state.execution.save_as_table(
+        metrics = self._dataframe._session_state.execution.save_as_table(
             sink_plan, table_name=table_name, mode=mode
         )
         logger.info(metrics.get_summary())
@@ -114,14 +114,15 @@ class DataFrameWriter:
                 f"Your path '{file_path}' is missing the extension."
             )
 
-        sink_plan = FileSink(
+        sink_plan = FileSink.from_session_state(
             child=self._dataframe._logical_plan,
             sink_type="csv",
             path=file_path,
             mode=mode,
+            session_state=self._dataframe._session_state,
         )
 
-        metrics = self._dataframe._logical_plan.session_state.execution.save_to_file(
+        metrics = self._dataframe._session_state.execution.save_to_file(
             sink_plan, file_path=file_path, mode=mode
         )
         logger.info(metrics.get_summary())
@@ -166,14 +167,15 @@ class DataFrameWriter:
                 f"Your path '{file_path}' is missing the extension."
             )
 
-        sink_plan = FileSink(
+        sink_plan = FileSink.from_session_state(
             child=self._dataframe._logical_plan,
             sink_type="parquet",
             path=file_path,
             mode=mode,
+            session_state=self._dataframe._session_state,
         )
 
-        metrics = self._dataframe._logical_plan.session_state.execution.save_to_file(
+        metrics = self._dataframe._session_state.execution.save_to_file(
             sink_plan, file_path=file_path, mode=mode
         )
         logger.info(metrics.get_summary())

--- a/src/fenic/core/_logical_plan/expressions/aggregate.py
+++ b/src/fenic/core/_logical_plan/expressions/aggregate.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List
 if TYPE_CHECKING:
     from fenic.core._logical_plan import LogicalPlan
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     AggregateExpr,
     LogicalExpr,
@@ -52,15 +53,15 @@ class AvgExpr(ValidatedDynamicSignature, AggregateExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr]
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
         """Use signature to validate and get return type, storing input type for transpiler."""
         # Get the input type first
-        self.input_type = self.expr.to_column_field(plan).data_type
+        self.input_type = self.expr.to_column_field(plan, session_state).data_type
 
         # Now use the mixin implementation to validate and get return type
-        return super().to_column_field(plan)
+        return super().to_column_field(plan, session_state)
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan, session_state: BaseSessionState) -> DataType:
         """Return EmbeddingType for embeddings, DoubleType for numeric types."""
         input_type = arg_types[0]
         if isinstance(input_type, EmbeddingType):
@@ -135,7 +136,7 @@ class ListExpr(ValidatedDynamicSignature, AggregateExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr]
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan, session_state: BaseSessionState) -> DataType:
         """Return ArrayType with element type matching the input type."""
         return ArrayType(arg_types[0])
 

--- a/src/fenic/core/_logical_plan/expressions/arithmetic.py
+++ b/src/fenic/core/_logical_plan/expressions/arithmetic.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from fenic.core._logical_plan import LogicalPlan
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import BinaryExpr
 from fenic.core.types.datatypes import (
     DataType,
@@ -41,9 +42,9 @@ class ArithmeticExpr(BinaryExpr):
         else:
             return IntegerType
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        left_field = self.left.to_column_field(plan)
-        right_field = self.right.to_column_field(plan)
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        left_field = self.left.to_column_field(plan, session_state)
+        right_field = self.right.to_column_field(plan, session_state)
         self._validate_types(left_field.data_type, right_field.data_type)
         result_type = self._promote_type(left_field.data_type, right_field.data_type)
         return ColumnField(str(self), result_type)

--- a/src/fenic/core/_logical_plan/expressions/case.py
+++ b/src/fenic/core/_logical_plan/expressions/case.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List, Optional
 if TYPE_CHECKING:
     from fenic.core._logical_plan import LogicalPlan
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core.types import BooleanType, ColumnField
 
@@ -18,14 +19,14 @@ class WhenExpr(LogicalExpr):
     def __str__(self):
         return f"{'CASE' if self.expr is None else self.expr} WHEN ({self.condition}) THEN ({self.value})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        if self.condition.to_column_field(plan).data_type != BooleanType:
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        if self.condition.to_column_field(plan, session_state).data_type != BooleanType:
             raise TypeError(
                 "when() condition must be a boolean expression.  Got type: "
-                f"{self.condition.to_column_field(plan).data_type}"
+                f"{self.condition.to_column_field(plan, session_state).data_type}"
             )
 
-        return self.value.to_column_field(plan)
+        return self.value.to_column_field(plan, session_state)
 
     def children(self) -> List[LogicalExpr]:
         children = []
@@ -45,8 +46,8 @@ class OtherwiseExpr(LogicalExpr):
     def __str__(self):
         return f"{self.expr} ELSE ({self.value})"
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        return self.value.to_column_field(plan)
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        return self.value.to_column_field(plan, session_state)
 
     def children(self) -> List[LogicalExpr]:
         return [self.expr, self.value]

--- a/src/fenic/core/_logical_plan/expressions/comparison.py
+++ b/src/fenic/core/_logical_plan/expressions/comparison.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fenic.core._logical_plan import LogicalPlan
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import BinaryExpr
 from fenic.core.types import (
     BooleanType,
@@ -14,9 +15,9 @@ from fenic.core.types.datatypes import is_dtype_numeric
 
 
 class EqualityComparisonExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, plan: LogicalPlan, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(plan, session_state).data_type
+        right_type = self.right.to_column_field(plan, session_state).data_type
 
         if left_type != right_type:
             raise TypeError(
@@ -26,15 +27,15 @@ class EqualityComparisonExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        self._validate_types(plan, session_state)
         return ColumnField(str(self), BooleanType)
 
 
 class NumericComparisonExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, plan: LogicalPlan, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(plan, session_state).data_type
+        right_type = self.right.to_column_field(plan, session_state).data_type
 
         if not is_dtype_numeric(left_type) or not is_dtype_numeric(right_type):
             raise TypeError(
@@ -44,15 +45,15 @@ class NumericComparisonExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        self._validate_types(plan, session_state)
         return ColumnField(str(self), BooleanType)
 
 
 class BooleanExpr(BinaryExpr):
-    def _validate_types(self, plan: LogicalPlan):
-        left_type = self.left.to_column_field(plan).data_type
-        right_type = self.right.to_column_field(plan).data_type
+    def _validate_types(self, plan: LogicalPlan, session_state: BaseSessionState):
+        left_type = self.left.to_column_field(plan, session_state).data_type
+        right_type = self.right.to_column_field(plan, session_state).data_type
 
         if left_type != BooleanType or right_type != BooleanType:
             raise TypeError(
@@ -62,6 +63,6 @@ class BooleanExpr(BinaryExpr):
             )
         return
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
-        self._validate_types(plan)
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        self._validate_types(plan, session_state)
         return ColumnField(str(self), BooleanType)

--- a/src/fenic/core/_logical_plan/expressions/text.py
+++ b/src/fenic/core/_logical_plan/expressions/text.py
@@ -16,6 +16,7 @@ import logging
 
 from pydantic import BaseModel, Field
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import (
     LogicalExpr,
     ValidatedDynamicSignature,
@@ -182,7 +183,7 @@ class TextractExpr(ValidatedDynamicSignature, LogicalExpr):
     def __str__(self):
         return f"{self.function_name}('{self.template}', {self.input_expr})"
 
-    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan) -> DataType:
+    def _infer_dynamic_return_type(self, arg_types: List[DataType], plan: LogicalPlan, session_state: BaseSessionState) -> DataType:
         """Return StructType with fields based on parsed template."""
         return self.parsed_template.to_struct_schema()
 
@@ -899,9 +900,9 @@ class JinjaExpr(LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return self.exprs
 
-    def to_column_field(self, plan: LogicalPlan) -> ColumnField:
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
         for expr in self.exprs:
-            data_type = expr.to_column_field(plan).data_type
+            data_type = expr.to_column_field(plan, session_state).data_type
             self.variable_tree.validate_jinja_variable(expr.name, data_type)
 
         return ColumnField(

--- a/src/fenic/core/_logical_plan/optimizer/base.py
+++ b/src/fenic/core/_logical_plan/optimizer/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.plans.base import LogicalPlan
 
 
@@ -18,11 +19,12 @@ class OptimizationResult:
 
 class LogicalPlanOptimizerRule(ABC):
     @abstractmethod
-    def apply(self, logical_plan: LogicalPlan) -> OptimizationResult:
+    def apply(self, logical_plan: LogicalPlan, session_state: BaseSessionState) -> OptimizationResult:
         """Apply the optimization rule to the logical plan.
 
         Args:
             logical_plan: The logical plan to optimize
+            session_state: The session state to use for the optimization
 
         Returns:
             OptimizationResult: The optimized plan and whether any changes were made
@@ -31,7 +33,8 @@ class LogicalPlanOptimizerRule(ABC):
 
 
 class LogicalPlanOptimizer:
-    def __init__(self, rules: List[LogicalPlanOptimizerRule] = None):
+    def __init__(self, session_state: BaseSessionState, rules: List[LogicalPlanOptimizerRule] = None):
+        self.session_state = session_state
         self.rules = rules
 
     def optimize(self, logical_plan: LogicalPlan) -> OptimizationResult:
@@ -39,6 +42,7 @@ class LogicalPlanOptimizer:
 
         Args:
             logical_plan: The logical plan to optimize
+            session_state: The session state to use for the optimization
 
         Returns:
             OptimizationResult: The optimized plan and whether any changes were made
@@ -47,7 +51,7 @@ class LogicalPlanOptimizer:
         optimized_plan = logical_plan
 
         for rule in self.rules:
-            result = rule.apply(optimized_plan)
+            result = rule.apply(optimized_plan, self.session_state)
             optimized_plan = result.plan
             any_changes = any_changes or result.was_modified
 

--- a/src/fenic/core/_logical_plan/optimizer/merge_filters_rule.py
+++ b/src/fenic/core/_logical_plan/optimizer/merge_filters_rule.py
@@ -1,3 +1,4 @@
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions import BooleanExpr, Operator
 from fenic.core._logical_plan.optimizer.base import (
     LogicalPlanOptimizerRule,
@@ -14,34 +15,35 @@ class MergeFiltersRule(LogicalPlanOptimizerRule):
     into a single filter operation so the combined predicates can be better optimized by SemanticPredicateReorderRule.
     """
 
-    def apply(self, logical_plan: LogicalPlan) -> OptimizationResult:
-        result = self.optimize_node(logical_plan)
+    def apply(self, logical_plan: LogicalPlan, session_state: BaseSessionState) -> OptimizationResult:
+        result = self.optimize_node(logical_plan, session_state)
         return result
 
-    def optimize_node(self, node: LogicalPlan) -> OptimizationResult:
+    def optimize_node(self, node: LogicalPlan, session_state: BaseSessionState) -> OptimizationResult:
         any_child_modified = False
         optimized_children = []
 
         for child in node.children():
-            child_result = self.optimize_node(child)
+            child_result = self.optimize_node(child, session_state)
             optimized_children.append(child_result.plan)
             any_child_modified = any_child_modified or child_result.was_modified
 
-        new_node = node.with_children(optimized_children)
+        new_node = node.with_children(optimized_children, session_state)
 
         if isinstance(node, Filter):
-            merge_result = self.merge_filter(new_node)
+            merge_result = self.merge_filter(new_node, session_state)
             return OptimizationResult(
                 merge_result.plan, any_child_modified or merge_result.was_modified
             )
 
         return OptimizationResult(new_node, any_child_modified)
 
-    def merge_filter(self, node: LogicalPlan) -> OptimizationResult:
+    def merge_filter(self, node: LogicalPlan, session_state: BaseSessionState) -> OptimizationResult:
         if isinstance(node._input, Filter) and node._input.cache_info is None:
-            merged_filter = Filter(
+            merged_filter = Filter.from_session_state(
                 node._input._input,
                 BooleanExpr(node.predicate(), node._input.predicate(), Operator.AND),
+                session_state
             )
             merged_filter.cache_info = node.cache_info
             # Return with was_modified=True since we merged filters

--- a/src/fenic/core/_logical_plan/plans/sink.py
+++ b/src/fenic/core/_logical_plan/plans/sink.py
@@ -1,5 +1,8 @@
-from typing import List, Literal
+from __future__ import annotations
 
+from typing import List, Literal, Optional
+
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core.error import InternalError
 from fenic.core.types import Schema
@@ -9,12 +12,13 @@ class FileSink(LogicalPlan):
     """Logical plan node that represents a file writing operation."""
 
     def __init__(
-        self,
-        child: LogicalPlan,
-        sink_type: Literal["csv", "parquet"],
-        path: str,
-        mode: Literal["error", "overwrite", "ignore"] = "error",
-    ):
+            self,
+            child: LogicalPlan,
+            sink_type: Literal["csv", "parquet"],
+            path: str,
+            mode: Literal["error", "overwrite", "ignore"] = "error",
+            session_state: Optional[BaseSessionState] = None,
+            schema: Optional[Schema] = None):
         """Initialize a file sink node.
 
         Args:
@@ -25,34 +29,61 @@ class FileSink(LogicalPlan):
                  - error: Raises an error if file exists
                  - overwrite: Overwrites the file if it exists
                  - ignore: Silently ignores operation if file exists
+            session_state: The session state to use for the new node.
+            schema: The schema to use for the new node.
         """
         self.child = child
         self.sink_type = sink_type
         self.path = path
         self.mode = mode
-        super().__init__(self.child.session_state)
+        super().__init__(session_state, schema)
+
+    @classmethod
+    def from_session_state(
+        cls,
+        child: LogicalPlan,
+        sink_type: Literal["csv", "parquet"],
+        path: str,
+        mode: Literal["error", "overwrite", "ignore"] = "error",
+        session_state: Optional[BaseSessionState] = None,
+    ) -> FileSink:
+        return FileSink(child, sink_type, path, mode, session_state, None)
+
+    @classmethod
+    def from_schema(
+        cls,
+        child: LogicalPlan,
+        sink_type: Literal["csv", "parquet"],
+        path: str,
+        mode: Literal["error", "overwrite", "ignore"] = "error",
+        schema: Optional[Schema] = None,
+    ) -> FileSink:
+        return FileSink(child, sink_type, path, mode, None, schema)
 
     def children(self) -> List[LogicalPlan]:
         """Returns the child node of this sink operator."""
         return [self.child]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """The schema of a sink node is the same as its child's schema."""
         return self.child.schema()
 
     def _repr(self) -> str:
         """Return the string representation for this file sink plan."""
         return (
-            f"FileSink(type={self.sink_type}, "
-            f"path='{self.path}', "
-            f"mode='{self.mode}')"
+            f"FileSink(type={self.sink_type}, path='{self.path}', mode='{self.mode}')"
         )
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(
+        self,
+        children: List[LogicalPlan],
+        session_state: Optional[BaseSessionState] = None,
+    ) -> LogicalPlan:
         """Create a new file sink with the same properties but different children.
 
         Args:
             children: The new children for this node. Must contain exactly one child.
+            session_state: The session state to use for the new node.
 
         Returns:
             A new FileSink instance with the updated child.
@@ -64,11 +95,12 @@ class FileSink(LogicalPlan):
             raise InternalError(
                 f"FileSink expects exactly one child but got {len(children)}"
             )
-        return FileSink(
+        return FileSink.from_session_state(
             child=children[0],
             sink_type=self.sink_type,
             path=self.path,
             mode=self.mode,
+            session_state=session_state,
         )
 
 
@@ -76,11 +108,12 @@ class TableSink(LogicalPlan):
     """Logical plan node that represents a table writing operation."""
 
     def __init__(
-        self,
-        child: LogicalPlan,
-        table_name: str,
-        mode: Literal["error", "append", "overwrite", "ignore"] = "error",
-    ):
+            self,
+            child: LogicalPlan,
+            table_name: str,
+            mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+            session_state: Optional[BaseSessionState] = None,
+            schema: Optional[Schema] = None):
         """Initialize a table sink node.
 
         Args:
@@ -91,17 +124,39 @@ class TableSink(LogicalPlan):
                  - append: Appends data to table if it exists
                  - overwrite: Overwrites existing table
                  - ignore: Silently ignores operation if table exists
+            session_state: The session state to use for the new node.
+            schema: The schema to use for the new node.
         """
         self.child = child
         self.table_name = table_name
         self.mode = mode
-        super().__init__(self.child.session_state)
+        super().__init__(session_state, schema)
+
+    @classmethod
+    def from_session_state(
+        cls,
+        child: LogicalPlan,
+        table_name: str,
+        mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+        session_state: Optional[BaseSessionState] = None,
+    ) -> TableSink:
+        return TableSink(child, table_name, mode, session_state, None)
+
+    @classmethod
+    def from_schema(
+        cls,
+        child: LogicalPlan,
+        table_name: str,
+        mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+        schema: Optional[Schema] = None,
+    ) -> TableSink:
+        return TableSink(child, table_name, mode, None, schema)
 
     def children(self) -> List[LogicalPlan]:
         """Returns the child node of this sink operator."""
         return [self.child]
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """The schema of a sink node is the same as its child's schema."""
         return self.child.schema()
 
@@ -109,11 +164,16 @@ class TableSink(LogicalPlan):
         """Return the string representation for this table sink plan."""
         return f"TableSink(table_name='{self.table_name}', mode='{self.mode}')"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(
+        self,
+        children: List[LogicalPlan],
+        session_state: Optional[BaseSessionState] = None,
+    ) -> LogicalPlan:
         """Create a new table sink with the same properties but different children.
 
         Args:
             children: The new children for this node. Must contain exactly one child.
+            session_state: The session state to use for the new node.
 
         Returns:
             A new TableSink instance with the updated child.
@@ -125,8 +185,9 @@ class TableSink(LogicalPlan):
             raise InternalError(
                 f"TableSink expects exactly one child but got {len(children)}"
             )
-        return TableSink(
+        return TableSink.from_session_state(
             child=children[0],
             table_name=self.table_name,
             mode=self.mode,
+            session_state=session_state,
         )

--- a/src/fenic/core/_logical_plan/plans/source.py
+++ b/src/fenic/core/_logical_plan/plans/source.py
@@ -13,15 +13,26 @@ from fenic.core.types import Schema
 
 
 class InMemorySource(LogicalPlan):
-    def __init__(self, source: pl.DataFrame, session_state: BaseSessionState):
+    def __init__(
+            self,
+            source: pl.DataFrame,
+            session_state: Optional[BaseSessionState] = None,
+            schema: Optional[Schema] = None):
         self._source = source
-        self.session_state = session_state
-        super().__init__(session_state)
+        super().__init__(session_state, schema)
+
+    @classmethod
+    def from_schema(cls, source: pl.DataFrame, schema: Schema) -> InMemorySource:
+        return InMemorySource(source=source, schema=schema)
+
+    @classmethod
+    def from_session_state(cls, source: pl.DataFrame, session_state: BaseSessionState) -> InMemorySource:
+        return InMemorySource(source=source, session_state=session_state)
 
     def children(self) -> List[LogicalPlan]:
         return []
 
-    def _build_schema(self) -> Schema:
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         return convert_polars_schema_to_custom_schema(self._source.schema)
 
     def _repr(self) -> str:
@@ -32,36 +43,43 @@ class InMemorySource(LogicalPlan):
         inner = self.schema()._str_with_indent(base_indent=level + 1)
         return f"InMemorySource(\n{inner}\n{indent})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self,
+        children: List[LogicalPlan],
+        session_state: Optional[BaseSessionState] = None) -> LogicalPlan:
         if len(children) != 0:
             raise InternalError(
                 f"InMemorySource must have no children, got {len(children)}"
             )
-        result = InMemorySource(self._source, self.session_state)
-        result.set_cache_info(self.cache_info)
-        return result
+        return self.from_schema(self._source, self._schema)
 
 
 class FileSource(LogicalPlan):
     def __init__(
-        self,
-        paths: list[str],
-        file_format: Literal["csv", "parquet"],
-        session_state: BaseSessionState,
-        options: Optional[dict] = None,
-    ):
+            self,
+            paths: list[str],
+            file_format: Literal["csv", "parquet"],
+            options: Optional[dict] = None,
+            session_state: Optional[BaseSessionState] = None,
+            schema: Optional[Schema] = None):
         """A lazy FileSource that stores the file path, file format, options, and immediately infers the schema using the given session state."""
         self._paths = paths
         self._file_format = file_format
         self._options = options or {}
-        self.session_state = session_state
-        super().__init__(session_state)
+        super().__init__(session_state, schema)
 
-    def _build_schema(self) -> Schema:
+    @classmethod
+    def from_session_state(cls, paths: list[str], file_format: Literal["csv", "parquet"], options: Optional[dict] = None, session_state: Optional[BaseSessionState] = None) -> FileSource:
+        return FileSource(paths, file_format, options, session_state, None)
+
+    @classmethod
+    def from_schema(cls, paths: list[str], file_format: Literal["csv", "parquet"], options: Optional[dict] = None, schema: Optional[Schema] = None) -> FileSource:
+        return FileSource(paths, file_format, options, None, schema)
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
         """Uses DuckDB (via the session state) to perform a minimal read (LIMIT 0) and obtain the schema from the file."""
         if self._file_format == "csv":
             try:
-                return self.session_state.execution.infer_schema_from_csv(
+                return session_state.execution.infer_schema_from_csv(
                     self._paths, **self._options
                 )
             except Exception as e:
@@ -82,7 +100,7 @@ class FileSource(LogicalPlan):
 
         elif self._file_format == "parquet":
             try:
-                return self.session_state.execution.infer_schema_from_parquet(
+                return session_state.execution.infer_schema_from_parquet(
                     self._paths, **self._options
                 )
             except Exception as e:
@@ -102,29 +120,40 @@ class FileSource(LogicalPlan):
     def _repr(self) -> str:
         return f"FileSource(paths={self._paths}, format={self._file_format})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlan], session_state: Optional[BaseSessionState] = None) -> LogicalPlan:
         if len(children) != 0:
             raise InternalError(f"FileSource must have no children, got {len(children)}")
-        result = FileSource(
-            self._paths, self._file_format, self.session_state, self._options
+        result = FileSource.from_schema(
+            self._paths, self._file_format, self._options, self._schema
         )
         result.set_cache_info(self.cache_info)
         return result
 
 class TableSource(LogicalPlan):
-    def __init__(self, table_name: str, session_state: BaseSessionState):
+    def __init__(
+            self,
+            table_name: str,
+            session_state: Optional[BaseSessionState],
+            schema: Optional[Schema]):
         self._table_name = table_name
-        self.session_state = session_state
-        super().__init__(session_state)
+        super().__init__(session_state, schema)
 
-    def _build_schema(self) -> Schema:
-        if not self.session_state.catalog.does_table_exist(self._table_name):
+    @classmethod
+    def from_session_state(cls, table_name: str, session_state: BaseSessionState) -> TableSource:
+        return TableSource(table_name, session_state, None)
+
+    @classmethod
+    def from_schema(cls, table_name: str, schema: Schema) -> TableSource:
+        return TableSource(table_name, None, schema)
+
+    def _build_schema(self, session_state: BaseSessionState) -> Schema:
+        if not session_state.catalog.does_table_exist(self._table_name):
             raise PlanError(
                 f"Table '{self._table_name}' does not exist. "
                 f"Use session.catalog.list_tables() to see available tables, "
                 f"or load data using session.csv() or session.parquet()."
             )
-        return self.session_state.catalog.describe_table(self._table_name)
+        return session_state.catalog.describe_table(self._table_name)
 
     def children(self) -> List[LogicalPlan]:
         return []
@@ -132,9 +161,9 @@ class TableSource(LogicalPlan):
     def _repr(self) -> str:
         return f"TableSource(table_name={self._table_name})"
 
-    def with_children(self, children: List[LogicalPlan]) -> LogicalPlan:
+    def with_children(self, children: List[LogicalPlan], session_state: Optional[BaseSessionState] = None) -> LogicalPlan:
         if len(children) != 0:
             raise InternalError(f"TableSource must have no children, got {len(children)}")
-        result = TableSource(self._table_name, self.session_state)
+        result = TableSource.from_schema(self._table_name, self._schema)
         result.set_cache_info(self.cache_info)
         return result

--- a/src/fenic/core/_logical_plan/signatures/signature_validator.py
+++ b/src/fenic/core/_logical_plan/signatures/signature_validator.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional
 if TYPE_CHECKING:
     from fenic.core._logical_plan.plans.base import LogicalPlan
 
+from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr
 from fenic.core._logical_plan.signatures.function_signature import FunctionSignature
 from fenic.core._logical_plan.signatures.registry import FunctionRegistry
@@ -37,7 +38,8 @@ class SignatureValidator:
         self,
         args: List[LogicalExpr],
         plan: LogicalPlan,
-        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlan], DataType]] = None
+        session_state: BaseSessionState,
+        dynamic_return_type_func: Optional[Callable[[List[DataType], LogicalPlan, BaseSessionState], DataType]] = None
     ) -> DataType:
         """Validate arguments and infer return type using the plan's schema.
         
@@ -47,6 +49,7 @@ class SignatureValidator:
         Args:
             args: List of LogicalExpr arguments to validate
             plan: LogicalPlan object for schema context
+            session_state: The session state to use for the new node
             dynamic_return_type_func: Optional function for dynamic return type inference
             
         Returns:
@@ -60,4 +63,4 @@ class SignatureValidator:
             self._signature = FunctionRegistry.get_signature(self.function_name)
         
         # Delegate to the signature's validate_and_infer_type method
-        return self._signature.validate_and_infer_type(args, plan, dynamic_return_type_func)
+        return self._signature.validate_and_infer_type(args, plan, session_state, dynamic_return_type_func)

--- a/tests/_backends/local/io/test_writer.py
+++ b/tests/_backends/local/io/test_writer.py
@@ -255,16 +255,20 @@ def test_logical_plan_sink_nodes(local_session):
     df = local_session.create_dataframe({"a": [1, 2, 3]})
 
     # Create a FileSink node
-    file_sink = FileSink(
+    file_sink = FileSink.from_session_state(
         child=df._logical_plan,
         sink_type="csv",
         path="test.csv",
         mode="overwrite",
+        session_state=df._session_state,
     )
 
     # Create a TableSink node
-    table_sink = TableSink(
-        child=df._logical_plan, table_name="test_table", mode="overwrite"
+    table_sink = TableSink.from_session_state(
+        child=df._logical_plan,
+        table_name="test_table",
+        mode="overwrite",
+        session_state=df._session_state
     )
     file_sink_columns = file_sink.schema().column_names()
     table_sink_columns = table_sink.schema().column_names()

--- a/tests/_backends/local/test_transpiler.py
+++ b/tests/_backends/local/test_transpiler.py
@@ -92,9 +92,9 @@ def test_convert_source_plan(local_session):
 
 def test_convert_projection_plan(local_session):
     df = pl.DataFrame({"a": [1, 2, 3]})
-    source = InMemorySource(df, local_session._session_state)
+    source = InMemorySource.from_session_state(df, local_session._session_state)
     plan_converter = PlanConverter(local_session._session_state)
-    proj = Projection(source, [ColumnExpr("a")])
+    proj = Projection.from_session_state(source, [ColumnExpr("a")], local_session._session_state)
     physical = plan_converter.convert(
         proj,
     )
@@ -103,12 +103,12 @@ def test_convert_projection_plan(local_session):
 
 def test_convert_filter_plan(local_session):
     df = pl.DataFrame({"a": [1, 2, 3]})
-    source = InMemorySource(df, local_session._session_state)
+    source = InMemorySource.from_session_state(df, local_session._session_state)
     plan_converter = PlanConverter(local_session._session_state)
     filter_expr = NumericComparisonExpr(
         ColumnExpr("a"), LiteralExpr(2, IntegerType), Operator.GT
     )
-    filt = Filter(source, filter_expr)
+    filt = Filter.from_session_state(source, filter_expr, local_session._session_state)
     physical = plan_converter.convert(
         filt,
     )
@@ -119,9 +119,9 @@ def test_convert_union_plan(local_session):
     plan_converter = PlanConverter(local_session._session_state)
     df1 = pl.DataFrame({"a": [1, 2]})
     df2 = pl.DataFrame({"a": [3, 4]})
-    source1 = InMemorySource(df1, local_session._session_state)
-    source2 = InMemorySource(df2, local_session._session_state)
-    union = Union([source1, source2])
+    source1 = InMemorySource.from_session_state(df1, local_session._session_state)
+    source2 = InMemorySource.from_session_state(df2, local_session._session_state)
+    union = Union.from_session_state([source1, source2], local_session._session_state)
     physical = plan_converter.convert(
         union,
     )


### PR DESCRIPTION
### TL;DR

Refactored logical plan nodes to decouple session state from schema construction, improving serialization and plan manipulation.

### What changed?

This PR refactors the logical plan architecture to properly separate session state from schema construction:

- Modified `LogicalPlan` base class to accept either a session state or a pre-built schema
- Added factory methods (`from_session_state` and `from_schema`) to all plan nodes
- Updated expression evaluation to explicitly pass session state to `to_column_field` methods
- Refactored DataFrame to store session state as a separate field rather than accessing it through the logical plan
- Updated optimizer rules to accept session state as a parameter
- Simplified plan serialization by removing session state cleanup steps
