### PR TITLE
fix: rogue replacement of `name` with `model_name`

### DIFF
--- a/src/fenic/_backends/cloud/catalog.py
+++ b/src/fenic/_backends/cloud/catalog.py
@@ -445,7 +445,7 @@ class CloudCatalog(BaseCatalog):
         filtered_catalogs = [
             catalog for catalog in result.catalogs if not catalog.ephemeral
         ]
-        return {catalog.model_name.casefold(): catalog for catalog in filtered_catalogs}
+        return {catalog.name.casefold(): catalog for catalog in filtered_catalogs}
 
     def _does_database_exist(self, catalog_name: str, database_name: str) -> bool:
         """Checks if a database with the specified name exists in the specified catalog."""
@@ -496,7 +496,7 @@ class CloudCatalog(BaseCatalog):
             )
         )
         databases = [
-            namespace.model_name for namespace in result.simple_catalog.list_namespaces
+            namespace.name for namespace in result.simple_catalog.list_namespaces
         ]
 
         # in case we are in the current catalog, always return the default database.
@@ -518,7 +518,7 @@ class CloudCatalog(BaseCatalog):
                 dataset_type=CatalogDatasetTypeReferenceEnum.TABLE,
             )
         )
-        return [dataset.model_name for dataset in result.catalog_dataset]
+        return [dataset.name for dataset in result.catalog_dataset]
 
     def _get_table(
             self,

--- a/src/fenic/_backends/cloud/session_state.py
+++ b/src/fenic/_backends/cloud/session_state.py
@@ -238,7 +238,7 @@ class CloudSessionState(BaseSessionState):
         existing = response.existing
 
         self.session_uuid = response.uuid
-        self.session_name = response.model_name
+        self.session_name = response.name
         self.session_canonical_name = response.canonical_name
         self.engine_uri = response.uris.remote_actions_uri
         self.arrow_ipc_uri = response.uris.remote_results_uri_prefix

--- a/tests/_backends/cloud/test_cloud_execution.py
+++ b/tests/_backends/cloud/test_cloud_execution.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import polars as pl
 import pytest
 
-from fenic.api.session.config import OpenAILanguageModel
+from fenic.api.session.config import OpenAIEmbeddingModel, OpenAILanguageModel
 
 pytest.importorskip("grpc")
 pytest.importorskip("fenic_cloud.hasura_client")
@@ -196,7 +196,7 @@ def cloud_session_config(cloud_app_name):
         app_name=cloud_app_name,
         semantic=SemanticConfig(
             language_models={"nano" : OpenAILanguageModel(model_name="gpt-4.1-nano", rpm=500, tpm=200_000)},
-            embedding_models={"oai-small": OpenAILanguageModel(model_name="text-embedding-3-small", rpm=3000, tpm=1_000_000)}
+            embedding_models={"oai-small": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=3000, tpm=1_000_000)}
         ),
         cloud=CloudConfig(
             size=CloudExecutorSize.SMALL,


### PR DESCRIPTION
Fix replacement that wasn't meant to apply to the cloud files. 