### PR TITLE
feat: add support for greatest/least column functions

### DIFF
--- a/src/fenic/__init__.py
+++ b/src/fenic/__init__.py
@@ -39,7 +39,9 @@ from fenic.api import (
     desc_nulls_last,
     embedding,
     first,
+    greatest,
     json,
+    least,
     lit,
     markdown,
     max,
@@ -186,6 +188,8 @@ __all__ = [
     "when",
     "col",
     "lit",
+    "greatest",
+    "least",
     # Lineage
     "Lineage",
     # Metrics

--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -57,6 +57,7 @@ from fenic.core._logical_plan.expressions import (
     FuzzyRatioExpr,
     FuzzyTokenSetRatioExpr,
     FuzzyTokenSortRatioExpr,
+    GreatestExpr,
     ILikeExpr,
     IndexExpr,
     InExpr,
@@ -65,6 +66,7 @@ from fenic.core._logical_plan.expressions import (
     JqExpr,
     JsonContainsExpr,
     JsonTypeExpr,
+    LeastExpr,
     LikeExpr,
     ListExpr,
     LiteralExpr,
@@ -1145,6 +1147,14 @@ class ExprConverter:
 
         # Return the maximum
         return pl.max_horizontal([ratio1, ratio2, ratio3])
+
+    @_convert_expr.register(GreatestExpr)
+    def _convert_greatest_expr(self, logical: GreatestExpr) -> pl.Expr:
+        return pl.max_horizontal([self._convert_expr(expr) for expr in logical.exprs])
+
+    @_convert_expr.register(LeastExpr)
+    def _convert_least_expr(self, logical: LeastExpr) -> pl.Expr:
+        return pl.min_horizontal([self._convert_expr(expr) for expr in logical.exprs])
 
 def _convert_fuzzy_similarity_method_to_expr(expr: pl.Expr, other: pl.Expr, method: FuzzySimilarityMethod) -> pl.Expr:
     if method == "indel":

--- a/src/fenic/api/__init__.py
+++ b/src/fenic/api/__init__.py
@@ -21,7 +21,9 @@ from fenic.api.functions import (
     desc_nulls_last,
     embedding,
     first,
+    greatest,
     json,
+    least,
     lit,
     markdown,
     max,
@@ -109,6 +111,8 @@ __all__ = [
     "when",
     "col",
     "lit",
+    "greatest",
+    "least",
     # Lineage
     "Lineage",
 ]

--- a/src/fenic/api/functions/__init__.py
+++ b/src/fenic/api/functions/__init__.py
@@ -17,6 +17,8 @@ from fenic.api.functions.builtin import (
     desc_nulls_first,
     desc_nulls_last,
     first,
+    greatest,
+    least,
     max,
     mean,
     min,
@@ -65,4 +67,6 @@ __all__ = [
     "when",
     "first",
     "stddev",
+    "greatest",
+    "least",
 ]

--- a/src/fenic/api/functions/builtin.py
+++ b/src/fenic/api/functions/builtin.py
@@ -15,6 +15,8 @@ from fenic.core._logical_plan.expressions import (
     CoalesceExpr,
     CountExpr,
     FirstExpr,
+    GreatestExpr,
+    LeastExpr,
     ListExpr,
     MaxExpr,
     MinExpr,
@@ -505,25 +507,18 @@ def coalesce(*cols: ColumnOrName) -> Column:
     in order and returns the first non-null value encountered. If all values are null, returns null.
 
     Args:
-        *cols: Column expressions or column names to evaluate. Can be:
-
-            - Individual arguments
-            - Lists of columns/column names
-            - Tuples of columns/column names
+        *cols: Column expressions or column names to evaluate. Each argument should be a single
+            column expression or column name string.
 
     Returns:
         A Column expression containing the first non-null value from the input columns.
 
     Raises:
-        ValueError: If no columns are provided.
+        ValidationError: If no columns are provided.
 
-    Example: Basic coalesce usage
+    Example: coalesce usage
         ```python
-        # Basic usage
         df.select(coalesce("col1", "col2", "col3"))
-
-        # With nested collections
-        df.select(coalesce(["col1", "col2"], "col3"))
         ```
     """
     if not cols:
@@ -540,3 +535,78 @@ def coalesce(*cols: ColumnOrName) -> Column:
         Column._from_col_or_name(c)._logical_expr for c in flattened_args
     ]
     return Column._from_logical_expr(CoalesceExpr(flattened_exprs))
+
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
+def greatest(*cols: ColumnOrName) -> Column:
+    """Returns the greatest value from the given columns for each row.
+
+    This function mimics the behavior of SQL's GREATEST function. It evaluates the input columns
+    in order and returns the greatest value encountered. If all values are null, returns null.
+
+    Args:
+        *cols: Column expressions or column names to evaluate. Each argument should be a single
+            column expression or column name string.
+
+    Returns:
+        A Column expression containing the greatest value from the input columns.
+
+    Raises:
+        ValidationError: If fewer than two columns are provided.
+
+    Example: greatest usage
+        ```python
+        df.select(fc.greatest("col1", "col2", "col3"))
+        ```
+    """
+    if len(cols) < 2:
+        raise ValidationError(f"greatest() requires at least 2 columns, got {len(cols)}")
+
+    flattened_args = []
+    for arg in cols:
+        if isinstance(arg, (list, tuple)):
+            flattened_args.extend(arg)
+        else:
+            flattened_args.append(arg)
+
+    flattened_exprs = [
+        Column._from_col_or_name(c)._logical_expr for c in flattened_args
+    ]
+    return Column._from_logical_expr(GreatestExpr(flattened_exprs))
+
+
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
+def least(*cols: ColumnOrName) -> Column:
+    """Returns the least value from the given columns for each row.
+
+    This function mimics the behavior of SQL's LEAST function. It evaluates the input columns
+    in order and returns the least value encountered. If all values are null, returns null.
+
+    Args:
+        *cols: Column expressions or column names to evaluate. Each argument should be a single
+            column expression or column name string.
+
+    Returns:
+        A Column expression containing the least value from the input columns.
+
+    Raises:
+        ValidationError: If fewer than two columns are provided.
+
+    Example: least usage
+        ```python
+        df.select(fc.least("col1", "col2", "col3"))
+        ```
+    """
+    if len(cols) < 2:
+        raise ValidationError(f"least() requires at least 2 columns, got {len(cols)}")
+
+    flattened_args = []
+    for arg in cols:
+        if isinstance(arg, (list, tuple)):
+            flattened_args.extend(arg)
+        else:
+            flattened_args.append(arg)
+
+    flattened_exprs = [
+        Column._from_col_or_name(c)._logical_expr for c in flattened_args
+    ]
+    return Column._from_logical_expr(LeastExpr(flattened_exprs))

--- a/src/fenic/api/functions/builtin.py
+++ b/src/fenic/api/functions/builtin.py
@@ -524,17 +524,10 @@ def coalesce(*cols: ColumnOrName) -> Column:
     if not cols:
         raise ValidationError("No columns were provided. Please specify at least one column to use with the coalesce method.")
 
-    flattened_args = []
-    for arg in cols:
-        if isinstance(arg, (list, tuple)):
-            flattened_args.extend(arg)
-        else:
-            flattened_args.append(arg)
-
-    flattened_exprs = [
-        Column._from_col_or_name(c)._logical_expr for c in flattened_args
+    exprs = [
+        Column._from_col_or_name(c)._logical_expr for c in cols
     ]
-    return Column._from_logical_expr(CoalesceExpr(flattened_exprs))
+    return Column._from_logical_expr(CoalesceExpr(exprs))
 
 @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
 def greatest(*cols: ColumnOrName) -> Column:
@@ -561,17 +554,10 @@ def greatest(*cols: ColumnOrName) -> Column:
     if len(cols) < 2:
         raise ValidationError(f"greatest() requires at least 2 columns, got {len(cols)}")
 
-    flattened_args = []
-    for arg in cols:
-        if isinstance(arg, (list, tuple)):
-            flattened_args.extend(arg)
-        else:
-            flattened_args.append(arg)
-
-    flattened_exprs = [
-        Column._from_col_or_name(c)._logical_expr for c in flattened_args
+    exprs = [
+        Column._from_col_or_name(c)._logical_expr for c in cols
     ]
-    return Column._from_logical_expr(GreatestExpr(flattened_exprs))
+    return Column._from_logical_expr(GreatestExpr(exprs))
 
 
 @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
@@ -599,14 +585,7 @@ def least(*cols: ColumnOrName) -> Column:
     if len(cols) < 2:
         raise ValidationError(f"least() requires at least 2 columns, got {len(cols)}")
 
-    flattened_args = []
-    for arg in cols:
-        if isinstance(arg, (list, tuple)):
-            flattened_args.extend(arg)
-        else:
-            flattened_args.append(arg)
-
-    flattened_exprs = [
-        Column._from_col_or_name(c)._logical_expr for c in flattened_args
+    exprs = [
+        Column._from_col_or_name(c)._logical_expr for c in cols
     ]
-    return Column._from_logical_expr(LeastExpr(flattened_exprs))
+    return Column._from_logical_expr(LeastExpr(exprs))

--- a/src/fenic/api/functions/builtin.py
+++ b/src/fenic/api/functions/builtin.py
@@ -536,8 +536,7 @@ def greatest(*cols: ColumnOrName) -> Column:
     This function mimics the behavior of SQL's GREATEST function. It evaluates the input columns
     in order and returns the greatest value encountered. If all values are null, returns null.
 
-    Each argument should have the same type and be of a primitive type (StringType, BooleanType,
-    FloatType, IntegerType, etc).
+    All arguments must be of the same primitive type (e.g., StringType, BooleanType, FloatType, IntegerType, etc).
 
     Args:
         *cols: Column expressions or column names to evaluate. Each argument should be a single

--- a/src/fenic/api/functions/builtin.py
+++ b/src/fenic/api/functions/builtin.py
@@ -536,6 +536,9 @@ def greatest(*cols: ColumnOrName) -> Column:
     This function mimics the behavior of SQL's GREATEST function. It evaluates the input columns
     in order and returns the greatest value encountered. If all values are null, returns null.
 
+    Each argument should have the same type and be of a primitive type (StringType, BooleanType,
+    FloatType, IntegerType, etc).
+
     Args:
         *cols: Column expressions or column names to evaluate. Each argument should be a single
             column expression or column name string.
@@ -566,6 +569,8 @@ def least(*cols: ColumnOrName) -> Column:
 
     This function mimics the behavior of SQL's LEAST function. It evaluates the input columns
     in order and returns the least value encountered. If all values are null, returns null.
+
+    All arguments must be of the same primitive type (e.g., StringType, BooleanType, FloatType, IntegerType, etc).
 
     Args:
         *cols: Column expressions or column names to evaluate. Each argument should be a single

--- a/src/fenic/core/_logical_plan/expressions/__init__.py
+++ b/src/fenic/core/_logical_plan/expressions/__init__.py
@@ -27,9 +27,11 @@ from fenic.core._logical_plan.expressions.basic import (
 from fenic.core._logical_plan.expressions.basic import CastExpr as CastExpr
 from fenic.core._logical_plan.expressions.basic import CoalesceExpr as CoalesceExpr
 from fenic.core._logical_plan.expressions.basic import ColumnExpr as ColumnExpr
+from fenic.core._logical_plan.expressions.basic import GreatestExpr as GreatestExpr
 from fenic.core._logical_plan.expressions.basic import IndexExpr as IndexExpr
 from fenic.core._logical_plan.expressions.basic import InExpr as InExpr
 from fenic.core._logical_plan.expressions.basic import IsNullExpr as IsNullExpr
+from fenic.core._logical_plan.expressions.basic import LeastExpr as LeastExpr
 from fenic.core._logical_plan.expressions.basic import LiteralExpr as LiteralExpr
 from fenic.core._logical_plan.expressions.basic import NotExpr as NotExpr
 from fenic.core._logical_plan.expressions.basic import SortExpr as SortExpr

--- a/src/fenic/core/_logical_plan/expressions/basic.py
+++ b/src/fenic/core/_logical_plan/expressions/basic.py
@@ -396,6 +396,56 @@ class InExpr(UnparameterizedExpr, LogicalExpr):
     def children(self) -> List[LogicalExpr]:
         return [self.expr, self.other]
 
+class GreatestExpr(ValidatedSignature, UnparameterizedExpr, LogicalExpr):
+    """Expression representing the greatest value of a list of expressions."""
+
+    function_name = "greatest"
+    def __init__(self, exprs: List[LogicalExpr]):
+        self.exprs = exprs
+        self._validator = SignatureValidator(self.function_name)
+
+    @property
+    def validator(self) -> SignatureValidator:
+        return self._validator
+
+    def children(self) -> List[LogicalExpr]:
+        return self.exprs
+
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        column_field = super().to_column_field(plan, session_state)
+        first_expr_type = self.exprs[0].to_column_field(plan, session_state).data_type
+        if not isinstance(first_expr_type, _PrimitiveType):
+            raise TypeMismatchError.from_message(
+                f"fc.greatest() only supports primitive types (StringType, BooleanType, "
+                f"FloatType, IntegerType, etc). Got: {first_expr_type} instead. "
+            )
+        return column_field
+
+class LeastExpr(ValidatedSignature, UnparameterizedExpr, LogicalExpr):
+    """Expression representing the least value of a list of expressions."""
+
+    function_name = "least"
+    def __init__(self, exprs: List[LogicalExpr]):
+        self.exprs = exprs
+        self._validator = SignatureValidator(self.function_name)
+
+    @property
+    def validator(self) -> SignatureValidator:
+        return self._validator
+
+    def children(self) -> List[LogicalExpr]:
+        return self.exprs
+
+    def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        column_field = super().to_column_field(plan, session_state)
+        first_expr_type = self.exprs[0].to_column_field(plan, session_state).data_type
+        if not isinstance(first_expr_type, _PrimitiveType):
+            raise TypeMismatchError.from_message(
+                f"fc.least() only supports primitive types (StringType, BooleanType, "
+                f"FloatType, IntegerType, etc). Got: {first_expr_type} instead. "
+            )
+
+        return column_field
 
 UNIMPLEMENTED_TYPES = (_HtmlType, TranscriptType, DocumentPathType)
 def _can_cast(src: DataType, dst: DataType) -> bool:

--- a/src/fenic/core/_logical_plan/signatures/basic.py
+++ b/src/fenic/core/_logical_plan/signatures/basic.py
@@ -44,4 +44,14 @@ def register_basic_signatures():
                                                                   type_signature=ArrayWithMatchingElement(),
                                                                   return_type=BooleanType))
 
+    # Greatest - all arguments must be same type as first
+    FunctionRegistry.register("greatest", FunctionSignature(function_name="greatest",
+                                                            type_signature=VariadicUniform(expected_min_args=2),
+                                                            return_type=ReturnTypeStrategy.SAME_AS_INPUT))
+
+    # Least - all arguments must be same type as first
+    FunctionRegistry.register("least", FunctionSignature(function_name="least",
+                                                            type_signature=VariadicUniform(expected_min_args=2),
+                                                            return_type=ReturnTypeStrategy.SAME_AS_INPUT))
+
 register_basic_signatures()

--- a/tests/_backends/local/functions/test_greatest_least.py
+++ b/tests/_backends/local/functions/test_greatest_least.py
@@ -1,0 +1,129 @@
+import re
+
+import pytest
+
+from fenic import ColumnField, col, greatest, least
+from fenic.core.error import TypeMismatchError, ValidationError
+from fenic.core.types.datatypes import BooleanType, DoubleType, IntegerType, StringType
+
+
+@pytest.fixture
+def greatest_least_source(local_session):
+    """Create a test dataframe source with various data types."""
+    return local_session.create_dataframe(
+        {
+            "int": [1, 3, None],
+            "int2": [2, 4, None],
+            "int3": [3, None, None],
+            "list": [["any"], ["string"], ["list"]],
+            "list2": [["other"], ["string"], ["list"]],
+            "bool": [True, False, None],
+            "bool2": [False, True, None],
+            "float": [1.0, 2.0, None],
+            "float2": [2.0, 1.0, None],
+            "float3": [1.0, 1.0, None],
+            "float4": [2.0, 2.0, None],
+            "str": ["a", "b", None],
+            "str2": ["c", "d", None],
+            "struct": [{"a": 1, "b": 2}, {"a": 3, "b": 4}, None],
+            "struct2": [{"a": 5, "b": 6}, {"a": 7, "b": 8}, None]
+        }
+    )
+
+def test_greatest(greatest_least_source):
+    df = greatest_least_source.select(greatest(col("int"), col("int2"), col("int3")).alias("greatest"))
+    assert df.schema.column_fields == [
+        ColumnField(name="greatest", data_type=IntegerType)
+    ]
+    result = df.to_polars()["greatest"]
+    assert result[0] == 3
+    assert result[1] == 4
+    assert result[2] is None
+
+    df = greatest_least_source.select(greatest(col("bool"), col("bool2")).alias("greatest"))
+    assert df.schema.column_fields == [
+        ColumnField(name="greatest", data_type=BooleanType)
+    ]
+    result = df.to_polars()["greatest"]
+    assert result[0]
+    assert result[1]
+    assert result[2] is None
+
+    df = greatest_least_source.select(greatest(col("float"), col("float2"), col("float3"), col("float4")).alias("greatest"))
+    assert df.schema.column_fields == [
+        ColumnField(name="greatest", data_type=DoubleType)
+    ]
+    result = df.to_polars()["greatest"]
+    assert result[0] == 2.0
+    assert result[1] == 2.0
+    assert result[2] is None
+
+    df = greatest_least_source.select(greatest(col("str"), col("str2")).alias("greatest"))
+    assert df.schema.column_fields == [
+        ColumnField(name="greatest", data_type=StringType)
+    ]
+    result = df.to_polars()["greatest"]
+    assert result[0] == "c"
+    assert result[1] == "d"
+    assert result[2] is None
+
+    with pytest.raises(TypeMismatchError):
+        df = greatest_least_source.select(greatest(col("list"), col("list2")).alias("greatest"))
+
+    with pytest.raises(TypeMismatchError):
+        df = greatest_least_source.select(greatest(col("struct"), col("struct2")).alias("greatest"))
+
+    with pytest.raises(ValidationError, match=re.escape("greatest() requires at least 2 columns, got 1")):
+        df = greatest_least_source.select(greatest(col("int")).alias("greatest"))
+
+    with pytest.raises(TypeMismatchError, match="greatest expects all arguments to have the same type"):
+        df = greatest_least_source.select(greatest(col("int"), col("str")).alias("greatest"))
+
+def test_least(greatest_least_source):
+    df = greatest_least_source.select(least(col("int"), col("int2"), col("int3")).alias("least"))
+    assert df.schema.column_fields == [
+        ColumnField(name="least", data_type=IntegerType)
+    ]
+    result = df.to_polars()["least"]
+    assert result[0] == 1
+    assert result[1] == 3
+    assert result[2] is None
+
+    df = greatest_least_source.select(least(col("bool"), col("bool2")).alias("least"))
+    assert df.schema.column_fields == [
+        ColumnField(name="least", data_type=BooleanType)
+    ]
+    result = df.to_polars()["least"]
+    assert not result[0]
+    assert not result[1]
+    assert result[2] is None
+
+    df = greatest_least_source.select(least(col("float"), col("float2"), col("float3"), col("float4")).alias("least"))
+    assert df.schema.column_fields == [
+        ColumnField(name="least", data_type=DoubleType)
+    ]
+    result = df.to_polars()["least"]
+    assert result[0] == 1.0
+    assert result[1] == 1.0
+    assert result[2] is None
+
+    df = greatest_least_source.select(least(col("str"), col("str2")).alias("least"))
+    assert df.schema.column_fields == [
+        ColumnField(name="least", data_type=StringType)
+    ]
+    result = df.to_polars()["least"]
+    assert result[0] == "a"
+    assert result[1] == "b"
+    assert result[2] is None
+
+    with pytest.raises(TypeMismatchError):
+        df = greatest_least_source.select(least(col("struct"), col("struct2")).alias("least"))
+
+    with pytest.raises(TypeMismatchError):
+        df = greatest_least_source.select(least(col("list"), col("list2")).alias("least"))
+
+    with pytest.raises(ValidationError, match=re.escape("least() requires at least 2 columns, got 1")):
+        df = greatest_least_source.select(least(col("int")).alias("least"))
+
+    with pytest.raises(TypeMismatchError, match="least expects all arguments to have the same type"):
+        df = greatest_least_source.select(least(col("int"), col("str")).alias("least"))


### PR DESCRIPTION
## Add `greatest()` and `least()` functions for horizontal min/max operations

### Summary
This PR adds SQL-compatible `greatest()` and `least()` functions to find the maximum and minimum values across multiple columns within each row. These functions mirror the behavior of SQL's `GREATEST` and `LEAST` operations.

### What's New
- **`greatest(*cols)`** - Returns the maximum value among the provided columns for each row
- **`least(*cols)`** - Returns the minimum value among the provided columns for each row

### Example Usage
```python
# Find the maximum value across multiple columns
df.select(greatest(col("score1"), col("score2"), col("score3")).alias("best_score"))

# Find the minimum value across multiple columns  
df.select(least(col("price1"), col("price2"), col("price3")).alias("lowest_price"))
```

### Implementation Details
- Functions require at least 2 arguments
- All arguments must be of the same primitive type (IntegerType, FloatType, StringType, BooleanType, etc.)
- Complex types (lists, structs) are not supported and will raise `TypeMismatchError`
- Null handling follows SQL semantics - returns NULL if all values are NULL
- Transpiles to Polars' `max_horizontal()`/`min_horizontal()` for efficient execution