### PR TITLE
feat: Add verbosity and minimal reasoning params for gpt5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "polars>=1.20.0,<=1.30.0",
   "tiktoken>=0.9.0",
   "lancedb>=0.22.0",
-  "openai>=1.82.0",
+  "openai>=1.101.0",
   "sqlglot>=26.25.3",
   "pandas>=2.2.2",
   "cloudpickle>=3.1.1",

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -79,7 +79,7 @@ class OpenAIChatCompletionsCore:
 
         Args:
             request: The messages to send
-            profile_configuration: The optional profile configuration for the request (for passing reasoning_effort)
+            profile_configuration: The optional profile configuration for the request (for passing reasoning_effort and verbosity)
         Returns:
             The response text or an exception
         """

--- a/src/fenic/_inference/language_model.py
+++ b/src/fenic/_inference/language_model.py
@@ -54,7 +54,7 @@ class LanguageModel:
 
         # Check model specific requirements for request params.
         temperature_param = temperature if self.model_parameters.supports_custom_temperature else None
-        if not temperature_param:
+        if temperature and not temperature_param:
             logger.warning(f"Model {self.model} does not support custom temperature.  Ignoring temperature parameter.")
 
         for message_list in messages:

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -554,6 +554,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         except Exception as e:
             logger.error(f"Error in worker for model {self.model}: {e}", exc_info=True)
 
+
     async def _process_single_request(self, queue_item: QueueItem[RequestT]):
         """Process a single request from the queues.
 

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -38,8 +38,11 @@ class CompletionModelParameters:
         context_window_length: Maximum number of tokens in the context window
         max_output_tokens: Maximum number of tokens the model can generate in a single request.
         max_temperature: Maximum temperature for the model.
+        supports_profiles: Whether the model supports parameter profiles.
         supports_reasoning: Whether the model supports reasoning parameter.
+        supports_minimal_reasoning: Whether the model supports minimal reasoning parameter. (Introduced with OpenAI gpt5 models)
         supports_custom_temperature: Whether the model supports custom temperature.
+        supports_verbosity: Whether the model supports verbosity. (Introduced with OpenAI gpt5 models)
     """
 
     def __init__(
@@ -52,8 +55,11 @@ class CompletionModelParameters:
         cached_input_token_write_cost: float = 0.0,
         cached_input_token_read_cost: float = 0.0,
         tiered_token_costs: Optional[Dict[int, TieredTokenCost]] = None,
+        supports_profiles = True,
         supports_reasoning = False,
+        supports_minimal_reasoning = False,
         supports_custom_temperature = True,
+        supports_verbosity = False,
     ):
         self.input_token_cost = input_token_cost
         self.cached_input_token_read_cost = cached_input_token_read_cost
@@ -64,8 +70,11 @@ class CompletionModelParameters:
         self.tiered_input_token_costs = tiered_token_costs
         self.max_output_tokens = max_output_tokens
         self.max_temperature = max_temperature
+        self.supports_profiles = supports_profiles
         self.supports_reasoning = supports_reasoning
+        self.supports_minimal_reasoning = supports_minimal_reasoning
         self.supports_custom_temperature = supports_custom_temperature
+        self.supports_verbosity = supports_verbosity
 
 
 class EmbeddingModelParameters:
@@ -355,6 +364,7 @@ class ModelCatalog:
                 output_token_cost=15.00 / 1_000_000,  # $15 per 1M tokens
                 context_window_length=200_000,
                 max_output_tokens=8_192,
+                supports_profiles=False,
             ),
             snapshots=["claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620"],
         )
@@ -369,6 +379,7 @@ class ModelCatalog:
                 output_token_cost=4.00 / 1_000_000,  # $4 per 1M tokens
                 context_window_length=200_000,
                 max_output_tokens=8_000,
+                supports_profiles=False,
             ),
             snapshots=["claude-3-5-haiku-20241022"],
         )
@@ -383,6 +394,7 @@ class ModelCatalog:
                 output_token_cost=75.00 / 1_000_000,  # $75 per 1M tokens
                 context_window_length=200_000,
                 max_output_tokens=4_096,
+                supports_profiles=False,
             ),
             snapshots=["claude-3-opus-20240229"],
         )
@@ -397,6 +409,7 @@ class ModelCatalog:
                 output_token_cost=1.25 / 1_000_000,  # $1.25 per 1M tokens
                 context_window_length=200_000,
                 max_output_tokens=4_096,
+                supports_profiles=False,
             ),
         )
 
@@ -412,6 +425,7 @@ class ModelCatalog:
                 context_window_length=8_192,
                 max_output_tokens=8_192,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4-0314", "gpt-4-0613"],
         )
@@ -426,6 +440,7 @@ class ModelCatalog:
                 context_window_length=128_000,
                 max_output_tokens=4_096,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4-turbo-2024-04-09"],
         )
@@ -440,6 +455,7 @@ class ModelCatalog:
                 context_window_length=128_000,
                 max_output_tokens=16_384,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4o-mini-2024-07-18"],
         )
@@ -454,6 +470,7 @@ class ModelCatalog:
                 context_window_length=128_000,
                 max_output_tokens=16_384,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20"],
         )
@@ -468,6 +485,7 @@ class ModelCatalog:
                 context_window_length=1_000_000,
                 max_output_tokens=32_768,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4.1-nano-2025-04-14"],
         )
@@ -482,6 +500,7 @@ class ModelCatalog:
                 context_window_length=1_000_000,
                 max_output_tokens=32_768,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4.1-mini-2025-04-14"],
         )
@@ -496,6 +515,7 @@ class ModelCatalog:
                 context_window_length=1_000_000,
                 max_output_tokens=32_768,
                 max_temperature=2,
+                supports_profiles=False,
             ),
             snapshots=["gpt-4.1-2025-04-14"],
         )
@@ -583,7 +603,9 @@ class ModelCatalog:
                 context_window_length=400_000,
                 max_output_tokens=128_000,
                 supports_reasoning=True,
+                supports_minimal_reasoning=True,
                 supports_custom_temperature=False,
+                supports_verbosity=True,
             ),
             snapshots=["gpt-5-2025-08-07"],
         )
@@ -598,7 +620,9 @@ class ModelCatalog:
                 context_window_length=400_000,
                 max_output_tokens=128_000,
                 supports_reasoning=True,
+                supports_minimal_reasoning=True,
                 supports_custom_temperature=False,
+                supports_verbosity=True,
             ),
             snapshots=["gpt-5-mini-2025-08-07"],
         )
@@ -613,6 +637,8 @@ class ModelCatalog:
                 context_window_length=400_000,
                 max_output_tokens=128_000,
                 supports_reasoning=True,
+                supports_minimal_reasoning=True,
+                supports_verbosity=True,
                 supports_custom_temperature=False,
             ),
             snapshots=["gpt-5-nano-2025-08-07"],
@@ -817,6 +843,7 @@ class ModelCatalog:
                 context_window_length=1_048_576,
                 max_output_tokens=8_192,
                 max_temperature=2.0,
+                supports_profiles=False,
             ),
             snapshots=["gemini-2.0-flash-lite-001"],
         )
@@ -832,6 +859,7 @@ class ModelCatalog:
                 context_window_length=1_048_576,
                 max_output_tokens=8_192,
                 max_temperature=2.0,
+                supports_profiles=False,
             ),
             snapshots=["gemini-2.0-flash-001", "gemini-2.0-flash-exp"],
         )

--- a/src/fenic/core/_resolved_session_config.py
+++ b/src/fenic/core/_resolved_session_config.py
@@ -14,7 +14,8 @@ from typing import Literal, Optional, Union
 
 from fenic.core._inference.model_catalog import ModelProvider
 
-ReasoningEffort = Literal["low", "medium", "high"]
+ReasoningEffort = Literal["minimal", "low", "medium", "high"]
+Verbosity = Literal["low", "medium", "high"]
 
 # --- Enums ---
 
@@ -42,6 +43,7 @@ class ResolvedGoogleModelProfile:
 @dataclass
 class ResolvedOpenAIModelProfile:
     reasoning_effort: Optional[ReasoningEffort] = None
+    verbosity: Optional[Verbosity] = None
 
 @dataclass
 class ResolvedCohereModelProfile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,20 @@ def configure_language_model(model_provider: ModelProvider, model_name: str) -> 
     )
     # these limits are purposely low so we don't consume our entire project limit while running multiple tests in multiple branches
     if model_provider == ModelProvider.OPENAI:
-        if model_parameters.supports_reasoning:
+        if model_parameters.supports_reasoning and model_parameters.supports_verbosity:
+            language_model = OpenAILanguageModel(
+                model_name=model_name,
+                rpm=500,
+                tpm=100_000,
+                profiles={
+                    "minimal": OpenAILanguageModel.Profile(reasoning_effort="minimal", verbosity="low"),
+                    "low": OpenAILanguageModel.Profile(reasoning_effort="low", verbosity="low"),
+                    "medium": OpenAILanguageModel.Profile(reasoning_effort="medium", verbosity="low"),
+                    "high": OpenAILanguageModel.Profile(reasoning_effort="high", verbosity="low"),
+                },
+                default_profile="minimal",
+            )
+        elif model_parameters.supports_reasoning:
             language_model = OpenAILanguageModel(
                 model_name=model_name,
                 rpm=500,
@@ -269,7 +282,7 @@ def configure_language_model(model_provider: ModelProvider, model_name: str) -> 
                     "medium": OpenAILanguageModel.Profile(reasoning_effort="medium"),
                     "high": OpenAILanguageModel.Profile(reasoning_effort="high"),
                 },
-                default_profile="medium",
+                default_profile="low",
             )
         else:
             language_model = OpenAILanguageModel(

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "lancedb", specifier = ">=0.22.0" },
     { name = "numpy", specifier = ">=2.0.0" },
-    { name = "openai", specifier = ">=1.82.0" },
+    { name = "openai", specifier = ">=1.101.0" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "polars", specifier = ">=1.20.0,<=1.30.0" },
     { name = "pyarrow", marker = "extra == 'cloud'", specifier = ">=19.0.0,<20.0.0" },
@@ -1374,7 +1374,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.88.0"
+version = "1.101.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1386,9 +1386,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/ea/bbeef604d1fe0f7e9111745bb8a81362973a95713b28855beb9a9832ab12/openai-1.88.0.tar.gz", hash = "sha256:122d35e42998255cf1fc84560f6ee49a844e65c054cd05d3e42fda506b832bb1", size = 470963 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/7c/eaf06b62281f5ca4f774c4cff066e6ddfd6a027e0ac791be16acec3a95e3/openai-1.101.0.tar.gz", hash = "sha256:29f56df2236069686e64aca0e13c24a4ec310545afb25ef7da2ab1a18523f22d", size = 518415 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/03/ef68d77a38dd383cbed7fc898857d394d5a8b0520a35f054e7fe05dc3ac1/openai-1.88.0-py3-none-any.whl", hash = "sha256:7edd7826b3b83f5846562a6f310f040c79576278bf8e3687b30ba05bb5dff978", size = 734293 },
+    { url = "https://files.pythonhosted.org/packages/c8/a6/0e39baa335bbd1c66c7e0a41dbbec10c5a15ab95c1344e7f7beb28eee65a/openai-1.101.0-py3-none-any.whl", hash = "sha256:6539a446cce154f8d9fb42757acdfd3ed9357ab0d34fcac11096c461da87133b", size = 810772 },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Added support for GPT-5 models with new verbosity parameter and minimal reasoning effort option.  Added Profile validation to ensure users can only use Profiles and params that apply to a given model.

### What changed?

- Added strict profile param checking to the runtime validation step depending on the model
- Added unit tests for the above
- Updated OpenAI dependency from 1.82.0 to 1.99.0 (included a bug fix, and supports new gpt5 params)
- Added support for `verbosity` parameter in OpenAI profiles (low/medium/high)
- Added support for `minimal` reasoning effort level for GPT-5 models
- Updated documentation and examples to reference GPT-5 models as well as O-series models
- Modified profile configuration to handle verbosity and reasoning effort appropriately based on model capabilities

### How to test?

1. Create a configuration with GPT-5 models using the new parameters:
```python
config = SemanticConfig(
    language_models={
        "gpt5": OpenAILanguageModel(
            model_name="gpt-5-mini",
            rpm=1_000,
            tpm=1_000_000,
            profiles={
                "fast": OpenAILanguageModel.Profile(reasoning_effort="minimal", verbosity="low"),
                "thorough": OpenAILanguageModel.Profile(reasoning_effort="high", verbosity="high")
            },
            default_profile="fast"
        )
    },
    default_language_model="gpt5"
)
```
Make sure the requests include the new params

2. Create profile with non GPT-5 model and add the reasoning_effort "minimal" and verbosity. Make sure the requests have reasoning_effort low and remove verbosity

