### PR TITLE
feat: support logical types in cloud catalog 

### DIFF
--- a/src/fenic/_backends/cloud/cloud_catalog_utils.py
+++ b/src/fenic/_backends/cloud/cloud_catalog_utils.py
@@ -1,0 +1,83 @@
+from typing import Union
+
+import pyarrow as pa
+
+from fenic.core.types.datatypes import (
+    ArrayType,
+    BooleanType,
+    DocumentPathType,
+    DoubleType,
+    EmbeddingType,
+    FloatType,
+    IntegerType,
+    StringType,
+    StructType,
+    TranscriptType,
+    _HtmlType,
+    _JsonType,
+    _MarkdownType,
+    _PrimitiveType,
+)
+from fenic.core.types.schema import Schema
+
+
+def convert_custom_dtype_to_pyarrow(
+    custom_dtype: Union[
+        _PrimitiveType,
+        ArrayType,
+        StructType,
+        _JsonType,
+        _MarkdownType,
+        _HtmlType,
+        TranscriptType,
+        DocumentPathType,
+    ]
+) -> object:
+    """Convert a custom data type to the corresponding PyArrow data type.
+
+    Importing PyArrow inside the function avoids a hard dependency unless used.
+    """
+
+    if isinstance(custom_dtype, _PrimitiveType):
+        if custom_dtype == IntegerType:
+            return pa.int64()
+        elif custom_dtype == FloatType:
+            return pa.float32()
+        elif custom_dtype == DoubleType:
+            return pa.float64()
+        elif custom_dtype == StringType:
+            return pa.string()
+        elif custom_dtype == BooleanType:
+            return pa.bool_()
+    elif isinstance(custom_dtype, ArrayType):
+        return pa.list(convert_custom_dtype_to_pyarrow(custom_dtype.element_type))
+    elif isinstance(custom_dtype, StructType):
+        return pa.struct(
+            [
+                pa.field(field.name, convert_custom_dtype_to_pyarrow(field.data_type))
+                for field in custom_dtype.struct_fields
+            ]
+        )
+    elif isinstance(custom_dtype, EmbeddingType):
+        return pa.list_(pa.float32(), custom_dtype.dimensions)
+    elif isinstance(
+        custom_dtype, (_JsonType, _MarkdownType, _HtmlType, TranscriptType, DocumentPathType)
+    ):
+        return pa.string()
+    else:
+        raise ValueError(f"Unsupported custom data type: {custom_dtype}")
+
+
+
+def convert_custom_schema_to_pyarrow_schema(custom_schema: Schema) -> object:
+    """Convert a fenic Schema to a PyArrow schema.
+
+    Returns a ``pyarrow.Schema`` with fields mapped from the custom schema
+    using ``convert_custom_dtype_to_pyarrow``.
+    """
+    return pa.schema(
+        [
+            pa.field(field.name, convert_custom_dtype_to_pyarrow(field.data_type))
+            for field in custom_schema.column_fields
+        ]
+    )


### PR DESCRIPTION
### TL;DR

Replaced Polars-based schema serialization with Protocol Buffers for cloud catalog schema handling.

### What changed?

- Added a new `cloud_catalog_utils.py` file with PyArrow conversion utilities
- Serialize `fenic` DataType objects as base64 encoded binary strings
- Deserialize `fenic` DataType objects upon reading from cloud catalog table. 
- Updated schema handling in `CloudCatalog` to use the new serialization approach
- Added additional string backed types (Transcript, Embedding, Markdown, HTML, etc.) to conversion functions for polars and pyarrow. 
- Enhanced tests to verify proper serialization/deserialization of complex data types

### How to test?

1. Run the updated tests in `test_cloud_catalog.py`
2. Verify schema conversion works for all data types including complex ones
3. Test creating tables with various data types in the cloud catalog
4. Confirm that schema information is properly preserved when retrieving table schemas

### Why make this change?

The previous implementation could not support saving tables with Logical Types to the Cloud Catalog, as it relied on the `pyarrow` types being converted to `polars` types, then back into `fenic` types, which loses all of our data type metadata. This new approach serializes the entire `fenic` `DataType` object when the schema for the table is saved, so we can recreate our Logical Types faithfully when loading the table. 

### Notes/Questions

1. Do we still need some human-readable version of the fenic datatype available in the DB? That would require changes on the `fenic_cloud` side to add a new field to store that information. 

2. We should probably develop some kind of documentation about all of the places that need to be adjusted when a new DataType is added (new serde, new conversions to polars dtype, new conversions to pyarrow dtype), or we can add back that `_StringBackedType` marker class and add a catch all rule that all of these types should be `pl.String/pa.string()` 