### PR TITLE
fix: model_registry now uses the new ResolvedModelAlias for embedding model lookup properly

### DIFF
--- a/src/fenic/_backends/local/model_registry.py
+++ b/src/fenic/_backends/local/model_registry.py
@@ -136,7 +136,7 @@ class SessionModelRegistry:
             raise InternalError(f"Language Model with alias '{alias.name}' not found in configured models: {sorted(list(self.language_model_registry.models.keys()))}")
         return language_model_for_alias
 
-    def get_embedding_model(self, alias: Optional[str] = None) -> EmbeddingModel:
+    def get_embedding_model(self, alias: Optional[ResolvedModelAlias] = None) -> EmbeddingModel:
         """Get an embedding model by alias or return the default model.
 
         Args:
@@ -152,9 +152,9 @@ class SessionModelRegistry:
             raise InternalError("Requested embedding model, but no embedding models are configured.")
         if alias is None:
             return self.embedding_model_registry.default_model
-        embedding_model_for_model_alias = self.embedding_model_registry.models.get(alias)
+        embedding_model_for_model_alias = self.embedding_model_registry.models.get(alias.name)
         if embedding_model_for_model_alias is None:
-            raise InternalError(f"Embedding Model with model name '{alias}' not found in configured models: {sorted(list(self.embedding_model_registry.models.keys()))}")
+            raise InternalError(f"Embedding Model with model name '{alias.name}' not found in configured models: {sorted(list(self.embedding_model_registry.models.keys()))}")
         return embedding_model_for_model_alias
 
     def shutdown_models(self):

--- a/src/fenic/_backends/local/session_state.py
+++ b/src/fenic/_backends/local/session_state.py
@@ -63,7 +63,7 @@ class LocalSessionState(BaseSessionState):
     def get_language_model(self, alias: Optional[ResolvedModelAlias] = None) -> LanguageModel:
         return self._model_registry.get_language_model(alias)
 
-    def get_embedding_model(self, alias: Optional[str] = None) -> EmbeddingModel:
+    def get_embedding_model(self, alias: Optional[ResolvedModelAlias] = None) -> EmbeddingModel:
         return self._model_registry.get_embedding_model(alias)
 
     def get_model_metrics(self) -> tuple[LMMetrics, RMMetrics]:

--- a/tests/_backends/local/functions/test_embed.py
+++ b/tests/_backends/local/functions/test_embed.py
@@ -15,6 +15,7 @@ from fenic import (
     semantic,
     text,
 )
+from fenic._backends.local.session_state import LocalSessionState
 from fenic.api.session import (
     OpenAILanguageModel,
     SemanticConfig,
@@ -22,6 +23,7 @@ from fenic.api.session import (
     SessionConfig,
 )
 from fenic.core._inference.model_catalog import ModelProvider
+from fenic.core._logical_plan.resolved_types import ResolvedModelAlias
 from fenic.core.error import TypeMismatchError, ValidationError
 
 
@@ -332,3 +334,8 @@ def test_cosine_similarity_special_cases(local_session):
     similarities = result["cosine_sim"].to_list()
 
     assert all(np.isnan(sim) for sim in similarities)
+
+def test_fetch_embedding_model_by_alias(local_session):
+    session_state: LocalSessionState = local_session._session_state
+    embedding_model = session_state.get_embedding_model(alias=ResolvedModelAlias(name="embedding"))
+    assert embedding_model


### PR DESCRIPTION
This part of the `session_state` interaction with `model_registry` was not updated when we added profile support to embedding models. 