### PR TITLE
feat: Add metrics trace callback to execution api

### DIFF
--- a/src/fenic/_backends/cloud/execution.py
+++ b/src/fenic/_backends/cloud/execution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 import grpc
@@ -74,7 +74,7 @@ class CloudExecution(BaseExecution):
         )
 
     def collect(
-        self, plan: LogicalPlan, n: Optional[int] = None
+        self, plan: LogicalPlan, n: Optional[int] = None, trace_callback: Optional[Callable[[...], Any]] = None
     ) -> Tuple[pl.DataFrame, QueryMetrics]:
         """Execute a logical plan and return a Polars DataFrame and query metrics."""
         request = StartExecutionRequest(
@@ -94,7 +94,7 @@ class CloudExecution(BaseExecution):
 
         return df, self._get_query_execution_metrics(execution_id)
 
-    def show(self, plan: LogicalPlan, n: int = 10) -> Tuple[str, QueryMetrics]:
+    def show(self, plan: LogicalPlan, n: int = 10, trace_callback: Optional[Callable[[...], Any]] = None) -> Tuple[str, QueryMetrics]:
         """Execute a logical plan and return a string representation of the sample rows."""
         logger.debug(f"Sending show request: {plan}")
         request = StartExecutionRequest(
@@ -122,7 +122,7 @@ class CloudExecution(BaseExecution):
 
         return result_response.show_result, self._get_query_execution_metrics(execution_id)
 
-    def count(self, plan: LogicalPlan) -> Tuple[int, QueryMetrics]:
+    def count(self, plan: LogicalPlan, trace_callback: Optional[Callable[[...], Any]] = None) -> Tuple[int, QueryMetrics]:
         """Execute a logical plan and return the number of rows."""
         request = StartExecutionRequest(
             count=CountExecutionRequest(
@@ -161,6 +161,7 @@ class CloudExecution(BaseExecution):
         logical_plan: LogicalPlan,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"],
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result as a table."""
         logger.debug(f"Saving plan {logical_plan} as table: {table_name}")
@@ -197,6 +198,7 @@ class CloudExecution(BaseExecution):
         self,
         logical_plan: LogicalPlan,
         view_name: str,
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> None:
         """Save the dataframe as a view."""
         # TODO: Implement saving dataframe view
@@ -207,6 +209,7 @@ class CloudExecution(BaseExecution):
         logical_plan: LogicalPlan,
         file_path: str,
         mode: Literal["error", "overwrite", "ignore"] = "error",
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result as a CSV or parquet file."""
         if urlparse(file_path).scheme not in CLOUD_SUPPORTED_SCHEMES:

--- a/src/fenic/_backends/local/execution.py
+++ b/src/fenic/_backends/local/execution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, Tuple
 
 import polars as pl
 
@@ -43,25 +43,25 @@ class LocalExecution(BaseExecution):
         self.transpiler = LocalTranspiler(session_state)
 
     def collect(
-        self, plan: LogicalPlan, n: Optional[int] = None
+        self, plan: LogicalPlan, n: Optional[int] = None, trace_callback: Optional[Callable[[QueryMetrics], None]] = None
     ) -> Tuple[pl.DataFrame, QueryMetrics]:
         """Execute a logical plan and return a Polars DataFrame and query metrics."""
         self.session_state._check_active()
         physical_plan = self.transpiler.transpile(plan)
         try:
-            df, metrics = physical_plan.execute()
+            df, metrics = physical_plan.execute(trace_callback)
         except Exception as e:
             raise ExecutionError(f"Failed to execute query: {e}") from e
         if n is not None:
             df = df.limit(n)
         return df, metrics
 
-    def show(self, plan: LogicalPlan, n: int = 10) -> Tuple[str, QueryMetrics]:
+    def show(self, plan: LogicalPlan, n: int = 10, trace_callback: Optional[Callable[[QueryMetrics], None]] = None) -> Tuple[str, QueryMetrics]:
         """Execute a logical plan and return a string representation of the sample rows of the DataFrame and query metrics."""
         self.session_state._check_active()
         physical_plan = self.transpiler.transpile(plan)
         try:
-            df, metrics = physical_plan.execute()
+            df, metrics = physical_plan.execute(trace_callback)
         except Exception as e:
             raise ExecutionError(f"Failed to execute query: {e}") from e
         with pl.Config(
@@ -73,12 +73,12 @@ class LocalExecution(BaseExecution):
             output = str(df)
         return output, metrics
 
-    def count(self, plan: LogicalPlan) -> Tuple[int, QueryMetrics]:
+    def count(self, plan: LogicalPlan, trace_callback: Optional[Callable[[QueryMetrics], None]] = None) -> Tuple[int, QueryMetrics]:
         """Execute a logical plan and return the number of rows in the DataFrame and query metrics."""
         self.session_state._check_active()
         physical_plan = self.transpiler.transpile(plan)
         try:
-            df, metrics = physical_plan.execute()
+            df, metrics = physical_plan.execute(trace_callback)
         except Exception as e:
             raise ExecutionError(f"Failed to execute query: {e}") from e
         return df.shape[0], metrics
@@ -98,6 +98,7 @@ class LocalExecution(BaseExecution):
         logical_plan: LogicalPlan,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"],
+        trace_callback: Optional[Callable[[QueryMetrics], None]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result as a table in the current database."""
         self.session_state._check_active()
@@ -132,7 +133,7 @@ class LocalExecution(BaseExecution):
                     )
         physical_plan = self.transpiler.transpile(logical_plan)
         try:
-            _, metrics = physical_plan.execute()
+            _, metrics = physical_plan.execute(trace_callback)
         except Exception as e:
             raise ExecutionError(f"Failed to execute query: {e}") from e
         return metrics
@@ -141,6 +142,7 @@ class LocalExecution(BaseExecution):
         self,
         logical_plan: LogicalPlan,
         view_name: str,
+        trace_callback: Optional[Callable[[QueryMetrics], None]] = None,
     ) -> None:
         """Save the table as a view in the current database."""
         self.session_state._check_active()
@@ -156,6 +158,7 @@ class LocalExecution(BaseExecution):
         logical_plan: LogicalPlan,
         file_path: str,
         mode: Literal["error", "overwrite", "ignore"] = "error",
+        trace_callback: Optional[Callable[[QueryMetrics], None]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result to a file."""
         self.session_state._check_active()
@@ -175,7 +178,7 @@ class LocalExecution(BaseExecution):
 
         physical_plan = self.transpiler.transpile(logical_plan)
         try:
-            _, metrics = physical_plan.execute()
+            _, metrics = physical_plan.execute(trace_callback)
         except Exception as e:
             raise ExecutionError(f"Failed to execute query: {e}") from e
         return metrics

--- a/src/fenic/_backends/local/physical_plan/base.py
+++ b/src/fenic/_backends/local/physical_plan/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import polars as pl
 
@@ -36,7 +36,7 @@ class PhysicalPlan:
         short_uuid = str(uuid.uuid4().hex)[:8]
         self.operator_id = f"{self.__class__.__name__}_{short_uuid}"
 
-    def execute(self) -> Tuple[pl.DataFrame, QueryMetrics]:
+    def execute(self, trace_callback: Optional[Callable[[...], Any]] = None) -> Tuple[pl.DataFrame, QueryMetrics]:
         """Execute the physical plan and return the result DataFrame along with execution metrics.
 
         This method handles:
@@ -75,7 +75,7 @@ class PhysicalPlan:
                 curr_operator_metrics.execution_time_ms = (
                     time.time() - start_time
                 ) * 1000
-                return df, QueryMetrics(
+                query_metrics = QueryMetrics(
                     execution_time_ms=curr_operator_metrics.execution_time_ms,
                     num_output_rows=curr_operator_metrics.num_output_rows,
                     total_lm_metrics=total_lm_metrics,
@@ -83,12 +83,15 @@ class PhysicalPlan:
                     _plan_repr=plan_repr,
                     _operator_metrics=all_operator_metrics,
                 )
+                if trace_callback:
+                    trace_callback(query_metrics)
+                return df, query_metrics
 
         # Step 3: Execute child operators and collect their metrics
         child_dfs = []
         child_execution_time = 0
         for child in self.children:
-            child_df, child_metrics = child.execute()
+            child_df, child_metrics = child.execute(trace_callback)
             child_dfs.append(child_df)
             plan_repr.children.append(child_metrics._plan_repr)
             all_operator_metrics.update(child_metrics._operator_metrics)
@@ -126,6 +129,10 @@ class PhysicalPlan:
             _plan_repr=plan_repr,
             _operator_metrics=all_operator_metrics,
         )
+
+        if trace_callback:
+            trace_callback(query_metrics)
+
         return result_df, query_metrics
 
     def _execute(self, child_dfs: List[pl.DataFrame]) -> pl.DataFrame:

--- a/src/fenic/core/_interfaces/execution.py
+++ b/src/fenic/core/_interfaces/execution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, Tuple
 
 import polars as pl
 
@@ -15,18 +15,22 @@ if TYPE_CHECKING:
 class BaseExecution(ABC):
     @abstractmethod
     def collect(
-        self, plan: LogicalPlan, n: Optional[int] = None
+        self, plan: LogicalPlan, n: Optional[int] = None, trace_callback: Optional[Callable[[...], Any]] = None
     ) -> Tuple[pl.DataFrame, QueryMetrics]:
         """Execute a logical plan and return a Polars DataFrame and query metrics."""
         pass
 
     @abstractmethod
-    def show(self, plan: LogicalPlan, n: int = 10) -> Tuple[str, QueryMetrics]:
+    def show(
+        self, plan: LogicalPlan, n: int = 10, trace_callback: Optional[Callable[[...], Any]] = None
+    ) -> Tuple[str, QueryMetrics]:
         """Execute a logical plan and return a string representation of the sample rows of the DataFrame and query metrics."""
         pass
 
     @abstractmethod
-    def count(self, plan: LogicalPlan) -> Tuple[int, QueryMetrics]:
+    def count(
+        self, plan: LogicalPlan, trace_callback: Optional[Callable[[...], Any]] = None
+    ) -> Tuple[int, QueryMetrics]:
         """Execute a logical plan and return the number of rows in the DataFrame and query metrics."""
         pass
 
@@ -41,6 +45,7 @@ class BaseExecution(ABC):
         logical_plan: LogicalPlan,
         table_name: str,
         mode: Literal["error", "append", "overwrite", "ignore"],
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result as a table in the current database."""
         pass
@@ -50,6 +55,7 @@ class BaseExecution(ABC):
         self,
         logical_plan: LogicalPlan,
         view_name: str,
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> None:
         """Save the dataframe as a view in the current database."""
         pass
@@ -60,6 +66,7 @@ class BaseExecution(ABC):
         logical_plan: LogicalPlan,
         file_path: str,
         mode: Literal["error", "overwrite", "ignore"] = "error",
+        trace_callback: Optional[Callable[[...], Any]] = None,
     ) -> QueryMetrics:
         """Execute the logical plan and save the result to a file."""
         pass

--- a/tests/_backends/local/test_metrics.py
+++ b/tests/_backends/local/test_metrics.py
@@ -49,29 +49,48 @@ def customer_data():
         "segment": ["Premium", "Standard", "Premium", "Standard", "Premium"],
     }
 
-def test_simple_metrics(local_session, sales_data, product_data, customer_data):
-    sales_df = local_session.create_dataframe(pl.DataFrame(sales_data))
-    product_df = local_session.create_dataframe(pl.DataFrame(product_data))
-    customer_df = local_session.create_dataframe(pl.DataFrame(customer_data))
+@pytest.fixture(params=["simple_dataframe", "semantic_dataframe"])
+def dataframe(request, local_session, sales_data, product_data, customer_data):
+    if request.param == "simple_dataframe":
+        sales_df = local_session.create_dataframe(pl.DataFrame(sales_data))
+        product_df = local_session.create_dataframe(pl.DataFrame(product_data))
+        customer_df = local_session.create_dataframe(pl.DataFrame(customer_data))
 
-    # First query - premium electronics sales
-    premium_electronics = (
-        sales_df.join(product_df, "product_id")
-        .join(customer_df, "customer_id")
-        .filter((col("segment") == "Premium") & (col("category") == "Electronics"))
-        .select("product_name", "customer_name", "amount", "quantity")
-        .group_by("product_name")
-        .agg(
-            sum("amount").alias("total_sales"),
-            avg("amount").alias("avg_sale"),
-            count("customer_name").alias("num_transactions"),
+        # First query - premium electronics sales
+        premium_electronics = (
+            sales_df.join(product_df, "product_id")
+            .join(customer_df, "customer_id")
+            .filter((col("segment") == "Premium") & (col("category") == "Electronics"))
+            .select("product_name", "customer_name", "amount", "quantity")
+            .group_by("product_name")
+            .agg(
+                sum("amount").alias("total_sales"),
+                avg("amount").alias("avg_sale"),
+                count("customer_name").alias("num_transactions"),
+            )
+        ).cache()
+        # Union the queries and limit results
+        final_result = premium_electronics.union(premium_electronics).limit(5)
+        return final_result
+    elif request.param == "semantic_dataframe":
+        df = local_session.create_dataframe(pl.DataFrame({"name": ["Alice", "Bob"]}))
+        df = df.select(
+            semantic.map("What is a longer name for {{name}}?", name=col("name")).alias("longer_name"),
+            semantic.embed(col("name")).alias("embedding"),
         )
-    ).cache()
-    # Union the queries and limit results
-    final_result = premium_electronics.union(premium_electronics).limit(5)
+        df = df.filter(
+            semantic.predicate(
+                "This name: '{{longer_name}}' is used as a placeholder in discussions about cryptographic systems.",
+                longer_name=col("longer_name"),
+            )
+        )
+        return df
 
+
+@pytest.mark.parametrize("dataframe", ["simple_dataframe"], indirect=True)
+def test_simple_metrics(dataframe):
     # Execute and collect metrics
-    result = final_result.collect("polars")
+    result = dataframe.collect("polars")
     metrics = result.metrics
 
     # Verify basic metrics
@@ -120,21 +139,10 @@ def test_simple_metrics(local_session, sales_data, product_data, customer_data):
     assert limit_op.num_output_rows == metrics.num_output_rows
     assert limit_op.execution_time_ms > 0
 
-
-def test_semantic_metrics(local_session):
+@pytest.mark.parametrize("dataframe", ["semantic_dataframe"], indirect=True)
+def test_semantic_metrics(dataframe):
     """Test that the semantic API works at all without using the fixture, given that the fixture sets lm."""
-    df = local_session.create_dataframe(pl.DataFrame({"name": ["Alice", "Bob"]}))
-    df = df.select(
-        semantic.map("What is a longer name for {{name}}?", name=col("name")).alias("longer_name"),
-        semantic.embed(col("name")).alias("embedding"),
-    )
-    df = df.filter(
-        semantic.predicate(
-            "This name: '{{longer_name}}' is used as a placeholder in discussions about cryptographic systems.",
-            longer_name=col("longer_name"),
-        )
-    )
-    result = df.collect("polars")
+    result = dataframe.collect("polars")
     metrics = result.metrics
     assert metrics.total_lm_metrics.num_uncached_input_tokens > 0
     assert metrics.total_lm_metrics.num_output_tokens > 0
@@ -156,6 +164,50 @@ def test_semantic_metrics(local_session):
             assert operator_metrics.lm_metrics.cost > 0
             assert operator_metrics.rm_metrics.num_input_tokens == 0
             assert operator_metrics.rm_metrics.cost == 0
+
+
+@pytest.mark.parametrize("dataframe", ["simple_dataframe", "semantic_dataframe"], indirect=True)
+def test_metrics_trace_callback(dataframe):
+    # Choose dataframe to test
+    test_plan = dataframe._logical_plan
+
+    # Define our callback
+    cur_callback_count = 0
+    final_callback_metrics = None
+
+    # Make sure the callback is called each step of the way
+    def trace_callback(query_metrics):
+        nonlocal cur_callback_count, final_callback_metrics
+        cur_callback_count += 1
+        final_callback_metrics = query_metrics
+
+    # Execute and collect metrics
+    _, metrics = dataframe._session_state.execution.collect(test_plan, trace_callback=trace_callback)
+    assert cur_callback_count == len(metrics._operator_metrics)
+
+    # Verify the callback received the correct metrics
+    assert metrics == final_callback_metrics
+
+    # Verify callback metrics for each type of execution
+    cur_callback_count = 0
+    _, metrics = dataframe._session_state.execution.show(test_plan, trace_callback=trace_callback)
+    assert cur_callback_count == len(metrics._operator_metrics)
+    assert metrics == final_callback_metrics
+
+    cur_callback_count = 0
+    _, metrics = dataframe._session_state.execution.count(test_plan, trace_callback=trace_callback)
+    assert cur_callback_count == len(metrics._operator_metrics)
+    assert metrics == final_callback_metrics
+
+    cur_callback_count = 0
+    metrics = dataframe._session_state.execution.save_as_table(test_plan, "test_metrics_table", mode="overwrite", trace_callback=trace_callback)
+    assert cur_callback_count == len(metrics._operator_metrics)
+    assert metrics == final_callback_metrics
+
+    cur_callback_count = 0
+    metrics = dataframe._session_state.execution.save_to_file(test_plan, "test_metrics_file", mode="overwrite", trace_callback=trace_callback)
+    assert cur_callback_count == len(metrics._operator_metrics)
+    assert metrics == final_callback_metrics
 
 
 def test_metrics_from_view(local_session, sales_data, product_data, customer_data):


### PR DESCRIPTION
### TL;DR

Added trace callback functionality to execution methods to enable real-time monitoring of query execution metrics.

### What changed?

- Added an optional `trace_callback` parameter to all execution methods in both local and cloud backends:
  - `collect()`
  - `show()`
  - `count()`
  - `save_as_table()`
  - `save_as_view()`
  - `save_to_file()`
- Modified the `execute()` method in the physical plan base class to invoke the callback with query metrics
- The callback is called at each step of the execution process, providing real-time metrics
- Added comprehensive tests to verify the callback functionality works correctly with different types of dataframes and execution methods

### How to test?

Run the new test cases in `tests/_backends/local/test_metrics.py`:

```python
pytest tests/_backends/local/test_metrics.py::test_metrics_trace_callback
```

The tests verify that:
- The callback is called the expected number of times
- The metrics passed to the callback match the final metrics
- The callback works with different types of dataframes (simple and semantic)
- The callback works with all execution methods (collect, show, count, save_as_table, save_to_file)

### Why make this change?

This enhancement enables real-time monitoring of query execution, allowing users to track the progress and performance of their queries as they execute. This is particularly valuable for:

- Debugging complex queries
- Performance monitoring and optimization
- Building progress indicators for long-running queries
- Collecting telemetry data during query execution
- Enabling custom logging or alerting based on query metrics