### PR TITLE
fix: only use regex search for the mcp server example

### DIFF
--- a/examples/mcp/docs-server/README.md
+++ b/examples/mcp/docs-server/README.md
@@ -31,6 +31,7 @@ General models are great at Typescript and Python, not your private APIs. This s
 1. **(Optional) Set environment variables:**
 
 ```bash
+  export GOOGLE_API_KEY="your-google-developer-api-key"
   # Optional: Set custom data directory (defaults to ~/.fenic)
   export FENIC_WORK_DIR="/path/to/custom/directory"
 ```
@@ -49,7 +50,10 @@ General models are great at Typescript and Python, not your private APIs. This s
      "mcpServers": {
        "fenic-docs": {
          "command": "/path/to/fenic/examples/mcp/docs-server/.venv/bin/python",
-         "args": ["/path/to/fenic/examples/mcp/docs-server/server.py"]
+         "args": ["/path/to/fenic/examples/mcp/docs-server/server.py"],
+         "env": {
+           "GOOGLE_API_KEY":"your-google-developer-api-key",
+         }
        }
      }
    }

--- a/examples/mcp/docs-server/pyproject.toml
+++ b/examples/mcp/docs-server/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "fastmcp>=0.1.0",
   "griffe>=0.42.0",
   "fenic[anthropic,google]>=0.3.0",
+  "structlog>=25.4.0",
 ]
 
 [project.scripts]

--- a/examples/mcp/docs-server/search.py
+++ b/examples/mcp/docs-server/search.py
@@ -1,0 +1,175 @@
+import logging
+import re
+from typing import Callable
+
+import fenic as fc
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class FenicAPIDocQuerySearch:
+    """Search for queries to the Fenic API.
+    Supports both keyword and regex search.
+    """
+
+    @classmethod
+    def _is_valid_regex(cls, query: str) -> bool:
+        """Heuristic check to see if the query is a regex."""
+        try:
+            re.compile(query)
+            return True
+        except re.error:
+            return False
+
+    @classmethod
+    def _search_api_docs_regex(cls, df: fc.DataFrame, query: str) -> fc.DataFrame:
+        """Search API documentation using regex."""
+        return df.filter(
+            fc.col("name").rlike(f"(?i){query}")
+            | fc.col("qualified_name").rlike(f"(?i){query}")
+            | (
+                fc.col("docstring").is_not_null()
+                & fc.col("docstring").rlike(f"(?i){query}")
+            )
+            | (
+                fc.col("annotation").is_not_null()
+                & fc.col("annotation").rlike(f"(?i){query}")
+            )
+            | (
+                fc.col("returns").is_not_null()
+                & fc.col("returns").rlike(f"(?i){query}")
+            )
+        )
+
+    @classmethod
+    def _search_learnings_regex(cls, df: fc.DataFrame, query: str) -> fc.DataFrame:
+        """Search learnings using regex."""
+        return df.filter(
+            fc.col("question").rlike(f"(?i){query}")
+            | fc.col("answer").rlike(f"(?i){query}")
+            | fc.array_contains(fc.col("keywords"), query)
+        )
+
+    @classmethod
+    def _search_learnings_keyword(cls, df: fc.DataFrame, term: str) -> fc.DataFrame:
+        """Search learnings using keyword."""
+        return df.filter(
+            fc.col("question").contains(term)
+            | fc.col("answer").contains(term)
+            | fc.array_contains(fc.col("keywords"), term)
+        )
+
+    @classmethod
+    def _search_terms(
+        cls,
+        df: fc.DataFrame,
+        query: str,
+        search_func: Callable[[fc.DataFrame, str], fc.DataFrame],
+    ) -> fc.DataFrame:
+        """Search using multiple terms."""
+        # First search the query as a whole.
+        result_df = search_func(df, query)
+        logger.debug(f"result_df - {query}: {result_df.count()}")
+
+        # look for each individual term as well.
+        terms = query.lower().split()
+        terms_data_frames = []
+        for term in terms:
+            terms_data_frames.append(search_func(df, term))
+        result_df = result_df.union(terms_data_frames[0])
+        for df in terms_data_frames[1:]:
+            result_df = result_df.union(df)
+
+        logger.debug(f"learnings results: {result_df.to_pydict()}")
+
+        return result_df
+
+    @classmethod
+    def search_learnings(cls, session: fc.Session, query: str) -> fc.DataFrame:
+        """Search learnings using keyword."""
+        if session.catalog.does_table_exist("learnings"):
+            try:
+                learnings_df = session.table("learnings")
+
+                logger.debug(f"Searching learnings with regex: {query}")
+                learnings_search = cls._search_terms(
+                    learnings_df, query, cls._search_learnings_regex
+                )
+
+                # Add relevance scoring for learnings
+                learnings_scored = learnings_search.select(
+                    "question",
+                    "answer",
+                    "learning_type",
+                    "keywords",
+                    "related_functions",
+                    fc.when(fc.col("question").rlike(f"(?i){query}"), fc.lit(10))
+                    .otherwise(fc.lit(0))
+                    .alias("question_score"),
+                    fc.when(fc.col("answer").rlike(f"(?i){query}"), fc.lit(5))
+                    .otherwise(fc.lit(0))
+                    .alias("answer_score"),
+                    fc.when(fc.array_contains(fc.col("keywords"), query), fc.lit(3))
+                    .otherwise(fc.lit(0))
+                    .alias("keywords_score"),
+                )
+
+                # Calculate total score with correction boost
+                learnings_scored = learnings_scored.select(
+                    "*",
+                    (
+                        fc.col("question_score")
+                        + fc.col("answer_score")
+                        + fc.col("keywords_score")
+                    ).alias("base_score"),
+                ).select(
+                    "*",
+                    fc.when(
+                        fc.col("learning_type") == "correction",
+                        fc.col("base_score") * 1.5,
+                    )
+                    .otherwise(fc.col("base_score"))
+                    .alias("score"),
+                )
+
+                # Sort and limit learnings (max 7 results)
+                return learnings_scored.order_by(fc.col("score").desc()).limit(7)
+            except Exception as e:
+                logger.error(f"Warning: Learnings search failed: {e}")
+                return None
+
+    @classmethod
+    def search_api_docs(cls, session: fc.Session, query: str) -> fc.DataFrame:
+        # Search API documentation
+        df = session.table("api_df")
+
+        # Filter only public API elements
+        df = df.filter(
+            (fc.col("is_public")) & (~fc.col("qualified_name").contains("._"))
+        )
+
+        if not cls._is_valid_regex(query):
+            raise ValueError("Invalid regex query")
+        logger.debug(f"Searching API docs with regex: {query}")
+        search_df = cls._search_api_docs_regex(df, query)
+
+        # Add relevance scoring
+        search_df = search_df.select(
+            "type",
+            "name",
+            "qualified_name",
+            "docstring",
+            fc.when(fc.col("name").rlike(f"(?i){query}"), fc.lit(10))
+            .otherwise(fc.lit(0))
+            .alias("name_score"),
+            fc.when(fc.col("qualified_name").rlike(f"(?i){query}"), fc.lit(5))
+            .otherwise(fc.lit(0))
+            .alias("path_score"),
+        )
+
+        # Calculate total score and sort
+        search_df = search_df.select(
+            "*", (fc.col("name_score") + fc.col("path_score")).alias("score")
+        )
+
+        return search_df

--- a/examples/mcp/docs-server/tests/test_search.py
+++ b/examples/mcp/docs-server/tests/test_search.py
@@ -18,15 +18,19 @@ def test_search_regex(session):
     assert search_df.count() > 0 # nosec: B101
     
     search_dict = search_df.to_pydict()
-    print(search_dict["qualified_name"])
     assert "fenic.api.functions.semantic.extract" in search_dict["qualified_name"] # nosec: B101
 
-def test_search_keyword(session):
-    """When searching for keywords, we should get a union of results from the different terms."""
-    search_df = FenicAPIDocQuerySearch.search_api_docs(session, "semantic extract")
+    search_df = FenicAPIDocQuerySearch.search_api_docs(session, "(semantic|extract)")
     assert search_df is not None # nosec: B101
     assert search_df.count() > 0 # nosec: B101
-    
+
     search_dict = search_df.to_pydict()
-    assert "fenic.core.types.enums.SemanticSimilarityMetric" in search_dict["qualified_name"] # nosec: B101
-    assert "fenic.api.functions.semantic.extract" in search_dict["qualified_name"] # nosec: B101
+    assert "fenic.api.dataframe.semantic_extensions.SemanticExtensions.join" in search_dict["qualified_name"] # nosec: B101
+    assert "fenic.core.types.semantic" in search_dict["qualified_name"] # nosec: B101
+    assert "fenic.api.functions.text.extract" in search_dict["qualified_name"] # nosec: B101
+
+    search_df = FenicAPIDocQuerySearch.search_api_docs(session, "semantic.join")
+    assert search_df is not None # nosec: B101
+    assert search_df.count() > 0 # nosec: B101
+    search_dict = search_df.to_pydict()
+    assert "fenic.api.dataframe.semantic_extensions.SemanticExtensions.join" in search_dict["qualified_name"] # nosec: B101

--- a/examples/mcp/docs-server/utils/schemas.py
+++ b/examples/mcp/docs-server/utils/schemas.py
@@ -26,7 +26,7 @@ def get_learnings_schema(include_embeddings: bool = True) -> fc.Schema:
         # Using text-embedding-3-large with 3072 dimensions
         embedding_type = fc.EmbeddingType(
             dimensions=3072, 
-            embedding_model="openai/text-embedding-3-large"
+            embedding_model="google-developer/gemini-embedding-001"
         )
         schema_fields.extend([
             fc.ColumnField('question_embedding', embedding_type),

--- a/examples/mcp/docs-server/utils/validation.py
+++ b/examples/mcp/docs-server/utils/validation.py
@@ -1,0 +1,118 @@
+import re
+
+from fastmcp.exceptions import ValidationError
+
+MAX_REGEX_LENGTH = 256
+MAX_ALTERNATIONS = 20
+MAX_QUANTIFIER_VALUE = 1000
+
+
+def _is_balanced(s: str, open_char: str, close_char: str) -> bool:
+    depth = 0
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == open_char:
+            depth += 1
+        elif c == close_char:
+            depth -= 1
+            if depth < 0:
+                return False
+        i += 1
+    return depth == 0
+
+
+def _strip_slash_delimiters(pattern: str) -> tuple[str, set[str]]:
+    """Support /pattern/flags syntax; return (pattern, flags).
+    Only recognize i,m,s,x flags; others are rejected later.
+    """
+    if len(pattern) >= 2 and pattern.startswith("/") and pattern.rfind("/") > 0:
+        last = pattern.rfind("/")
+        core = pattern[1:last]
+        flags = set(pattern[last + 1 :].lower())
+        return core, flags
+    return pattern, set()
+
+
+def validate_and_sanitize_regex(user_query: str) -> str:
+    r"""Validate user regex and return a sanitized pattern suitable for rlike.
+
+    Rules:
+    - Non-empty, max length
+    - Balanced (), [], {}
+    - Quantifiers {m,n} limited to reasonable bounds
+    - Limit number of alternations '|'
+    - Disallow backreferences (\\1, \\2, ...)
+    - Disallow lookbehind and exotic inline constructs except non-capturing (?:)
+    - Strip /pattern/flags form and ignore unsupported flags; case-insensitive handled upstream
+    - Strip leading inline flags like (?i) to avoid duplication
+    """
+    if user_query is None:
+        raise ValidationError("Query must not be null")
+
+    query = user_query.strip()
+    if not query:
+        raise ValidationError("Query must not be empty")
+
+    if len(query) > MAX_REGEX_LENGTH:
+        raise ValidationError(f"Regex too long (>{MAX_REGEX_LENGTH} characters)")
+
+    # Support /pattern/flags and capture flags
+    query, flags = _strip_slash_delimiters(query)
+    unsupported_flags = {f for f in flags if f not in {"i", "m", "s", "x"}}
+    if unsupported_flags:
+        raise ValidationError(
+            f"Unsupported regex flags: {''.join(sorted(unsupported_flags))}"
+        )
+
+    # Strip inline flags at start like (?i), (?m), combined, to avoid duplication
+    query = re.sub(r"^\(\?[aiLmsux]+\)", "", query)
+
+    # Basic balance checks
+    if not _is_balanced(query, "(", ")"):
+        raise ValidationError("Unbalanced parentheses")
+    if not _is_balanced(query, "[", "]"):
+        raise ValidationError("Unbalanced character class brackets")
+    if not _is_balanced(query, "{", "}"):
+        raise ValidationError("Unbalanced curly braces")
+
+    # Validate quantifiers {m} or {m,n}
+    for m, n in re.findall(r"\{\s*(\d+)\s*(?:,\s*(\d*)\s*)?\}", query):
+        try:
+            m_val = int(m)
+            n_val = int(n) if n else m_val
+        except ValueError:
+            raise ValidationError("Invalid quantifier bounds") from None
+        if m_val > MAX_QUANTIFIER_VALUE or n_val > MAX_QUANTIFIER_VALUE:
+            raise ValidationError("Quantifier bounds too large")
+        if n and n_val < m_val:
+            raise ValidationError("Quantifier upper bound less than lower bound")
+
+    # Limit alternations
+    if query.count("|") > MAX_ALTERNATIONS:
+        raise ValidationError("Too many alternations in regex")
+
+    # Disallow backreferences
+    if re.search(r"\\[1-9]\\d*", query):
+        raise ValidationError("Backreferences are not supported")
+
+    # Disallow lookbehind and other exotic constructs; allow only non-capturing (?:)
+    if re.search(r"\(\?(?!(?:[:]))", query):
+        raise ValidationError("Unsupported inline regex construct")
+
+    # Heuristic ReDoS guard: forbid nested quantifiers like (.+)+, (.*)+, (?:.+){2,}
+    if re.search(r"\((?:[^()]*[+*])[^()]*\)\s*[+*]", query):
+        raise ValidationError("Nested quantifiers are not allowed")
+    if re.search(r"(\.\*){2,}|(\.\+){2,}", query):
+        raise ValidationError("Excessive greedy wildcards are not allowed")
+
+    # Ensure it compiles in Python as a basic sanity check
+    try:
+        re.compile(query)
+    except re.error as err:
+        raise ValidationError(f"Invalid regex syntax: {err}") from None
+
+    return query

--- a/examples/mcp/docs-server/uv.lock
+++ b/examples/mcp/docs-server/uv.lock
@@ -349,6 +349,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "fenic", extra = ["anthropic", "google"] },
     { name = "griffe" },
+    { name = "structlog" },
 ]
 
 [package.metadata]
@@ -356,6 +357,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "fenic", extras = ["anthropic", "google"], specifier = ">=0.3.0" },
     { name = "griffe", specifier = ">=0.42.0" },
+    { name = "structlog", specifier = ">=25.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1835,6 +1837,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload-time = "2025-06-21T04:03:17.337Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload-time = "2025-06-21T04:03:15.705Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/b9/6e672db4fec07349e7a8a8172c1a6ae235c58679ca29c3f86a61b5e59ff3/structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4", size = 1369138, upload-time = "2025-06-02T08:21:12.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/4a/97ee6973e3a73c74c8120d59829c3861ea52210667ec3e7a16045c62b64d/structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c", size = 68720, upload-time = "2025-06-02T08:21:11.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Improved search functionality in the docs-server with better regex handling, structured logging, and enhanced error handling.

### What changed?

This uses the changes proposed by Brandon for our own MCP server. We'll use just the regex.

Also, I incorrectly assumed we didn't need the models for the server, that is not correct as store_learnings requires the models. I've added them back to the configuration and README.md.

I've tested also retrieving the information from the learnings (using the full string as well as the terms), this wasn't working properly as store_learnings was failing due to the lack of model configuration.