### PR TITLE
docs: fix group by docstring to use count() within agg()

### DIFF
--- a/src/fenic/api/dataframe/dataframe.py
+++ b/src/fenic/api/dataframe/dataframe.py
@@ -1164,6 +1164,19 @@ class DataFrame:
             # |        HR|    NYC|    72500.0|
             # +----------+--------+-----------+
             ```
+
+        Example: Group by expression
+            ```python
+            # Group by expression
+            df.group_by(lower(col("department")).alias("department")).agg(count("*")).show()
+            # Output:
+            # +---------+-----+
+            # |department|count|
+            # +----------+-----+
+            # |        it|    3|
+            # |        hr|    2|
+            # +---------+-----+
+            ```
         """
         return GroupedData(self, list(cols) if cols else None)
 

--- a/src/fenic/api/dataframe/dataframe.py
+++ b/src/fenic/api/dataframe/dataframe.py
@@ -1142,7 +1142,7 @@ class DataFrame:
             })
 
             # Group by single column
-            df.group_by(col("department")).count().show()
+            df.group_by(col("department")).agg(count("*")).show()
             # Output:
             # +----------+-----+
             # |department|count|
@@ -1163,20 +1163,6 @@ class DataFrame:
             # |        IT|    NYC|    85000.0|
             # |        HR|    NYC|    72500.0|
             # +----------+--------+-----------+
-            ```
-
-        Example: Group by expression
-            ```python
-            # Group by expression
-            df.group_by(col("age").cast("int").alias("age_group")).count().show()
-            # Output:
-            # +---------+-----+
-            # |age_group|count|
-            # +---------+-----+
-            # |       20|    2|
-            # |       30|    3|
-            # |       40|    1|
-            # +---------+-----+
             ```
         """
         return GroupedData(self, list(cols) if cols else None)


### PR DESCRIPTION
We don't yet support aggregate expression syntactic sugar directly on the GroupedData object and we require aggregate expressions inside the agg() function. This confused the MCP docs server.Aggregate expression syntactic sugar is not yet supported directly on the GroupedData object. Instead, aggregate expressions must be passed inside the agg() function. The example has been updated to use agg() instead of calling count() directly, since this caused confusion in the MCP docs server.