### PR TITLE
ci(build): build linux/x86_64 on pr publish

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -68,7 +68,7 @@ jobs:
         platform:
           ## linux
           - target: x86_64
-            builds: on_release
+            builds: on_all
             manylinux: auto
             python_arch: x64
             ## linux cross


### PR DESCRIPTION
# what

updates the build & release workflow to always build linux/x86_64 along with
apple/aarch64 when PR calls for it
