### PR TITLE
feat: Add connector for reading huggingface scheme

### DIFF
--- a/src/fenic/api/io/reader.py
+++ b/src/fenic/api/io/reader.py
@@ -20,6 +20,39 @@ class DataFrameReader:
     """Interface used to load a DataFrame from external storage systems.
     
     Similar to PySpark's DataFrameReader.
+
+    Supported External Storage Schemes:
+    - Amazon S3 (s3://)
+        - Format: s3://{bucket_name}/{path_to_file}
+
+        - Notes:
+            - Uses boto3 to aquire AWS credentials.
+
+        - Examples:
+            - s3://my-bucket/data.csv
+            - s3://my-bucket/data/*.parquet
+
+    - Hugging Face Datasets (hf://)
+        - Format: hf://{repo_type}/{repo_id}/{path_to_file}
+
+        - Notes:
+            - Supports glob patterns (*, **)
+            - Supports dataset revisions and branch aliases (e.g., @refs/convert/parquet, @~parquet)
+            - HF_TOKEN environment variable is required to read private datasets.
+
+        - Examples:
+            - hf://datasets/datasets-examples/doc-formats-csv-1/data.csv
+            - hf://datasets/cais/mmlu/astronomy/*.parquet
+            - hf://datasets/datasets-examples/doc-formats-csv-1@~parquet/**/*.parquet
+
+    - Local Files (file:// or implicit)
+        - Format: file://{absolute_or_relative_path}
+
+        - Notes:
+            - Paths without a scheme (e.g., ./data.csv or /tmp/data.parquet) are treated as local files
+        - Examples:
+            - file:///home/user/data.csv
+            - ./data/*.parquet
     """
 
     def __init__(self, session_state: BaseSessionState):

--- a/src/fenic/api/io/writer.py
+++ b/src/fenic/api/io/writer.py
@@ -22,6 +22,26 @@ class DataFrameWriter:
     """Interface used to write a DataFrame to external storage systems.
     
     Similar to PySpark's DataFrameWriter.
+
+    Supported External Storage Schemes:
+    - Amazon S3 (s3://)
+        - Format: s3://{bucket_name}/{path_to_file}
+
+        - Notes:
+            - Uses boto3 to aquire AWS credentials.
+
+        - Examples:
+            - s3://my-bucket/data.csv
+            - s3://my-bucket/data/*.parquet
+
+    - Local Files (file:// or implicit)
+        - Format: file://{absolute_or_relative_path}
+
+        - Notes:
+            - Paths without a scheme (e.g., ./data.csv or /tmp/data.parquet) are treated as local files
+        - Examples:
+            - file:///home/user/data.csv
+            - ./data/*.parquet
     """
 
     def __init__(self, dataframe: DataFrame):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,12 @@ def pytest_addoption(parser):
         default="text-embedding-3-small",
         help="Model Name to run embeddings tests against",
     )
+    parser.addoption(
+        "--test-huggingface-reads",
+        action="store",
+        default=None,
+        help="If set, will run reader tests that read from HuggingFace.",
+    )
 
 @pytest.fixture
 def embedding_model_name_and_dimensions(local_session) -> Tuple[str, int]:


### PR DESCRIPTION
### TL;DR

Added support for HuggingFace datasets in Fenic's I/O operations (reads only).

### What changed?

- Added support for the `hf://` scheme to read and write data from HuggingFace datasets
- Implemented HuggingFace token authentication via environment variables (`HF_TOKEN`) or AWS Secrets Manager
- Updated DuckDB query building to handle HuggingFace credentials
- Added support for mixed source queries (e.g., reading from both S3 and HuggingFace)
- Updated documentation to reflect the new supported storage scheme
- Added comprehensive tests for public and private HuggingFace datasets

### How to test?

1. Unit tests 
 - Token reading and DuckDB query setup
 - Failing to authenticate Token
 - Reading CSV/Parquet, file lists, globs, hash revision
 - Mixing HuggingFace source with s3/local

2. Not covered by Unit Tests: Test reading from private HF datasets

-  Set your HuggingFace token:
   ```
   export HF_TOKEN=your_token_here
   ```

-  Read from a HuggingFace dataset:
   ```python
   import fenic as fn
   session = fn.Session.get_or_create()
   df = session.read.csv("hf://datasets/your-username/your-dataset/file.csv")
   ```

3. Not tested: using AWS secret manager for HuggingFace token


### Why make this change?

This change expands Fenic's data source capabilities to include HuggingFace datasets, which are widely used in the ML community. It allows users to seamlessly read from and write to HuggingFace datasets using the same familiar Fenic API, enabling more flexible data workflows that can combine data from multiple sources (local, S3, and now HuggingFace).