### PR TITLE
feat: Validate provider API keys during session configure

### DIFF
--- a/src/fenic/_backends/cloud/engine_config.py
+++ b/src/fenic/_backends/cloud/engine_config.py
@@ -69,7 +69,7 @@ class CloudSessionConfig:
                 get_and_store_key("GOOGLE_CLOUD_PROJECT", provider)
                 get_and_store_key("GOOGLE_CLOUD_LOCATION", provider)
             else:
-                key = f"{provider.value.upper()}{API_KEY_SUFFIX}"
+                key = f"{provider.name.upper()}{API_KEY_SUFFIX}"
                 get_and_store_key(key, provider)
 
 

--- a/src/fenic/_backends/local/metrics_client.py
+++ b/src/fenic/_backends/local/metrics_client.py
@@ -1,0 +1,204 @@
+"""Client for managing metrics storage in DuckDB."""
+
+import logging
+from typing import Dict, List
+
+import duckdb
+import polars as pl
+
+from fenic.core.metrics import QueryMetrics
+from fenic.core.types import Field, FieldType, Schema
+
+logger = logging.getLogger(__name__)
+
+METRICS_TABLE_NAME = "metrics"
+METRICS_SCHEMA = Schema([
+    Field("row_id", FieldType.Int64),
+    Field("execution_id", FieldType.String),
+    Field("session_id", FieldType.String),
+    Field("start_ts", FieldType.Float64),
+    Field("end_ts", FieldType.Float64),
+    Field("execution_time_ms", FieldType.Float64),
+    Field("num_output_rows", FieldType.Int64),
+    Field("lm_cost", FieldType.Float64),
+    Field("lm_input_tokens", FieldType.Int64),
+    Field("lm_cached_input_tokens", FieldType.Int64),
+    Field("lm_output_tokens", FieldType.Int64),
+    Field("lm_requests", FieldType.Int64),
+    Field("rm_cost", FieldType.Float64),
+    Field("rm_input_tokens", FieldType.Int64),
+    Field("rm_requests", FieldType.Int64),
+])
+
+
+class MetricsClient:
+    """Client for managing metrics storage in a local DuckDB instance."""
+
+    def __init__(self, connection: duckdb.DuckDBPyConnection):
+        """Initialize the metrics client.
+        
+        Args:
+            connection: DuckDB connection instance
+        """
+        self.db_conn = connection
+        self._row_counter = 0
+        self._initialize_metrics_table()
+
+    def _initialize_metrics_table(self):
+        """Initialize the metrics table if it doesn't exist."""
+        try:
+            # Check if metrics table exists
+            table_exists = self.db_conn.execute(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?",
+                (METRICS_TABLE_NAME,)
+            ).fetchone()[0] > 0
+
+            if not table_exists:
+                # Create metrics table with proper schema
+                create_sql = f"""
+                CREATE TABLE {METRICS_TABLE_NAME} (
+                    row_id BIGINT PRIMARY KEY,
+                    execution_id VARCHAR,
+                    session_id VARCHAR,
+                    start_ts DOUBLE,
+                    end_ts DOUBLE,
+                    execution_time_ms DOUBLE,
+                    num_output_rows BIGINT,
+                    lm_cost DOUBLE,
+                    lm_input_tokens BIGINT,
+                    lm_cached_input_tokens BIGINT,
+                    lm_output_tokens BIGINT,
+                    lm_requests BIGINT,
+                    rm_cost DOUBLE,
+                    rm_input_tokens BIGINT,
+                    rm_requests BIGINT
+                );
+                """
+                self.db_conn.execute(create_sql)
+                logger.info(f"Created metrics table: {METRICS_TABLE_NAME}")
+            else:
+                # Get the current max row_id to continue sequence
+                max_id_result = self.db_conn.execute(
+                    f"SELECT COALESCE(MAX(row_id), 0) FROM {METRICS_TABLE_NAME}"
+                ).fetchone()
+                self._row_counter = max_id_result[0] if max_id_result else 0
+                logger.debug(f"Metrics table exists, continuing from row_id: {self._row_counter}")
+
+        except Exception as e:
+            logger.error(f"Failed to initialize metrics table: {e}")
+            raise
+
+    def append_metrics(self, query_metrics: QueryMetrics) -> int:
+        """Append QueryMetrics to the metrics table.
+        
+        Args:
+            query_metrics: QueryMetrics instance to store
+            
+        Returns:
+            int: The row_id assigned to this metrics entry
+        """
+        try:
+            # Increment row counter
+            self._row_counter += 1
+            row_id = self._row_counter
+
+            # Convert QueryMetrics to row dict
+            row_data = query_metrics.to_row_dict()
+            row_data["row_id"] = row_id
+
+            # Create DataFrame with single row
+            df = pl.DataFrame([row_data])
+
+            # Insert into DuckDB
+            temp_view_name = f"temp_metrics_{row_id}"
+            self.db_conn.register(temp_view_name, df)
+            
+            insert_sql = f"""
+            INSERT INTO {METRICS_TABLE_NAME}
+            SELECT * FROM {temp_view_name}
+            """
+            self.db_conn.execute(insert_sql)
+            
+            # Clean up temp view
+            self.db_conn.execute(f"DROP VIEW IF EXISTS {temp_view_name}")
+            
+            logger.debug(f"Appended metrics with execution_id: {query_metrics.execution_id}, row_id: {row_id}")
+            return row_id
+
+        except Exception as e:
+            logger.error(f"Failed to append metrics: {e}")
+            raise
+
+    def get_session_aggregated_metrics(self, session_id: str) -> Dict[str, float]:
+        """Get aggregated metrics for a specific session.
+        
+        Args:
+            session_id: Session identifier
+            
+        Returns:
+            Dict containing aggregated metrics for the session
+        """
+        try:
+            query = f"""
+            SELECT 
+                COUNT(*) as total_queries,
+                SUM(execution_time_ms) as total_execution_time_ms,
+                SUM(num_output_rows) as total_output_rows,
+                SUM(lm_cost) as total_lm_cost,
+                SUM(lm_input_tokens) as total_lm_input_tokens,
+                SUM(lm_cached_input_tokens) as total_lm_cached_input_tokens,
+                SUM(lm_output_tokens) as total_lm_output_tokens,
+                SUM(lm_requests) as total_lm_requests,
+                SUM(rm_cost) as total_rm_cost,
+                SUM(rm_input_tokens) as total_rm_input_tokens,
+                SUM(rm_requests) as total_rm_requests
+            FROM {METRICS_TABLE_NAME}
+            WHERE session_id = ?
+            """
+            
+            result = self.db_conn.execute(query, (session_id,)).fetchone()
+            
+            if result and result[0] > 0:  # Check if we have any records
+                return {
+                    "total_queries": result[0],
+                    "total_execution_time_ms": result[1] or 0.0,
+                    "total_output_rows": result[2] or 0,
+                    "total_lm_cost": result[3] or 0.0,
+                    "total_lm_input_tokens": result[4] or 0,
+                    "total_lm_cached_input_tokens": result[5] or 0,
+                    "total_lm_output_tokens": result[6] or 0,
+                    "total_lm_requests": result[7] or 0,
+                    "total_rm_cost": result[8] or 0.0,
+                    "total_rm_input_tokens": result[9] or 0,
+                    "total_rm_requests": result[10] or 0,
+                }
+            else:
+                return {
+                    "total_queries": 0,
+                    "total_execution_time_ms": 0.0,
+                    "total_output_rows": 0,
+                    "total_lm_cost": 0.0,
+                    "total_lm_input_tokens": 0,
+                    "total_lm_cached_input_tokens": 0,
+                    "total_lm_output_tokens": 0,
+                    "total_lm_requests": 0,
+                    "total_rm_cost": 0.0,
+                    "total_rm_input_tokens": 0,
+                    "total_rm_requests": 0,
+                }
+
+        except Exception as e:
+            logger.error(f"Failed to get session aggregated metrics: {e}")
+            raise
+
+    def read_metrics_table(self) -> pl.DataFrame:
+        """Read the entire metrics table as a Polars DataFrame.
+        
+        Returns:
+            Polars DataFrame containing all metrics data
+        """
+        try:
+            return self.db_conn.execute(f"SELECT * FROM {METRICS_TABLE_NAME} ORDER BY row_id").pl()
+        except Exception as e:
+            logger.error(f"Failed to read metrics table: {e}")
+            raise

--- a/src/fenic/_backends/local/model_registry.py
+++ b/src/fenic/_backends/local/model_registry.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
+from fenic._backends.local.async_utils import EventLoopManager
 from fenic._inference import (
     EmbeddingModel,
     LanguageModel,
@@ -56,12 +58,20 @@ class SessionModelRegistry:
 
         Args:
             config (ResolvedSemanticConfig): Configuration containing model settings and defaults.
+
+        Notes:
+            We only need to validate an API key once for each provider.  We prefer to validate a provider with
+            a language model over an embedding model, since the ping for an LLM is cheaper than
+            the embedding models (returning a single token calling list models, vs embedding a small string)
         """
+        validate_providers: set[str] = set()
         if config.language_models:
             language_model_config = config.language_models
             models: dict[str, LanguageModel] = {}
             for alias, model_config in language_model_config.model_configs.items():
-                models[alias] = self._initialize_language_model(model_config)
+                model = self._initialize_language_model(model_config)
+                models[alias] = model
+                validate_providers.add(model.client.model_provider)
             self.language_model_registry = LanguageModelRegistry(
                 models=models,
                 default_model=models[language_model_config.default_model],
@@ -71,11 +81,20 @@ class SessionModelRegistry:
             embedding_model_config = config.embedding_models
             models: dict[str, EmbeddingModel] = {}
             for alias, model_config in embedding_model_config.model_configs.items():
-                models[alias] = self._initialize_embedding_model(model_config)
+                model = self._initialize_embedding_model(model_config)
+                models[alias] = model
+                validate_providers.add(model.client.model_provider)
             self.embedding_model_registry = EmbeddingModelRegistry(
                 models=models,
                 default_model=models[embedding_model_config.default_model],
             )
+        if len(validate_providers) > 0:
+            with EventLoopManager().loop_context() as loop:
+                future = asyncio.run_coroutine_threadsafe(
+                    _validate_provider_api_keys(validate_providers),
+                    loop,
+                )
+                future.result()
 
     def get_language_model_metrics(self) -> LMMetrics:
         """Get aggregated metrics for all language models.
@@ -171,6 +190,8 @@ class SessionModelRegistry:
                     embedding_model.client.shutdown()
                 except Exception as e:
                     logger.warning(f"Failed graceful shutdown of embedding model client {alias}: {e}")
+
+
 
     def _initialize_embedding_model(self, model_config: ResolvedModelConfig) -> EmbeddingModel:
         """Initialize an embedding model with the given configuration.
@@ -302,3 +323,20 @@ class SessionModelRegistry:
 
         except Exception as e:
             raise SessionError(f"Failed to create language model client: {e}") from e
+
+
+async def _validate_provider_api_keys(validate_providers: set[str]):
+    """Validate api keys for all providers with registered models."""
+    tasks = []
+    if len(validate_providers) == 0:
+        return
+    
+    # Create validation tasks for each unique provider
+    for provider in validate_providers:
+        tasks.append(provider.validate_api_key())
+
+    # Run all validations concurrently
+    try:
+        await asyncio.gather(*tasks)
+    except Exception as e:
+        raise ConfigurationError(f"Error during API key validation: {e}") from e

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import math
 from typing import Any, Optional, Union
 
@@ -39,7 +40,6 @@ from fenic._inference.types import (
     ResponseUsage,
 )
 from fenic.core._inference.model_catalog import (
-    ModelProvider,
     model_catalog,
 )
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
@@ -47,6 +47,8 @@ from fenic.core._resolved_session_config import (
     ResolvedAnthropicModelProfile,
 )
 from fenic.core.metrics import LMMetrics
+
+logger = logging.getLogger(__name__)
 
 TEXT_DELTA = "text_delta"
 
@@ -90,9 +92,10 @@ class AnthropicBatchCompletionsClient(
             profiles: Dictionary of profile configurations
             default_profile_name: Name of the default profile to use
         """
+        from fenic._inference.anthropic.anthropic_provider import anthropic_provider
         super().__init__(
             model=model,
-            model_provider=ModelProvider.ANTHROPIC,
+            model_provider=anthropic_provider,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,
@@ -100,12 +103,12 @@ class AnthropicBatchCompletionsClient(
         )
         # Apply this factor to the estimated token count to approximate Anthropic's encoding.
         self._tokenizer_adjustment_ratio = 1.05
-        self._sync_client = anthropic.Client()
-        self._client = AsyncAnthropic()
+        self._sync_client = anthropic_provider.get_sync_client()
+        self._client = anthropic_provider.get_client()
         self._metrics = LMMetrics()
         self._output_formatter_tool_name = "output_formatter"
         self._output_formatter_tool_description = "Format the output of the model to correspond strictly to the provided schema."
-        self._model_parameters = model_catalog.get_completion_model_parameters(ModelProvider.ANTHROPIC, model)
+        self._model_parameters = model_catalog.get_completion_model_parameters(anthropic_provider, model)
 
         # Use the profile configuration manager
         self._profile_manager = AnthropicCompletionsProfileManager(
@@ -182,7 +185,7 @@ class AnthropicBatchCompletionsClient(
                 self._metrics.num_output_tokens += output_tokens
                 self._metrics.num_requests += 1
                 self._metrics.cost += model_catalog.calculate_completion_model_cost(
-                    model_provider=ModelProvider.ANTHROPIC,
+                    model_provider=anthropic_provider,
                     model_name=self.model,
                     uncached_input_tokens=num_uncached_input_tokens,
                     cached_input_tokens_read=num_pre_cached_tokens,
@@ -400,3 +403,4 @@ class AnthropicBatchCompletionsClient(
         )
         message_params.append(MessageParam(content=[user_prompt], role="user"))
         return system_prompt, message_params
+

--- a/src/fenic/_inference/anthropic/anthropic_provider.py
+++ b/src/fenic/_inference/anthropic/anthropic_provider.py
@@ -1,0 +1,39 @@
+"""Anthropic model provider implementation."""
+
+import logging
+from anthropic import AsyncAnthropic, Client
+
+from fenic.core._inference.model_provider import ModelProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicModelProvider(ModelProvider):
+    """Anthropic implementation of ModelProvider."""
+    
+    @property
+    def name(self) -> str:
+        return "anthropic"
+    
+    def get_client(self):
+        """Get Anthropic async client instance."""
+        return AsyncAnthropic()
+    
+    def get_sync_client(self):
+        """Get Anthropic sync client instance."""
+        return Client()
+    
+    async def validate_api_key(self) -> None:
+        """Validate Anthropic API key by making a minimal completion request."""
+        client = self.get_client()
+        _ = await client.completions.create(
+            model="claude-3-haiku-20240307",  # Use cheapest available model for validation
+            prompt="ping",
+            max_tokens_to_sample=1,
+            temperature=0
+        )
+        logger.debug("Anthropic API key validation successful")
+
+
+# Create singleton instance
+anthropic_provider = AnthropicModelProvider()

--- a/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
+++ b/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 from typing import List, Optional, Union
 
@@ -18,9 +19,11 @@ from fenic._inference.rate_limit_strategy import (
 )
 from fenic._inference.token_counter import TiktokenTokenCounter
 from fenic._inference.types import FenicEmbeddingsRequest
-from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.model_catalog import model_catalog
 from fenic.core._resolved_session_config import ResolvedCohereModelProfile
 from fenic.core.metrics import RMMetrics
+
+logger = logging.getLogger(__name__)
 
 
 class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float]]):
@@ -45,9 +48,10 @@ class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
             preset_configurations: Dictionary of preset configurations
             default_preset_name: Default preset to use when none specified
         """
+        from fenic._inference.cohere.cohere_provider import cohere_provider
         super().__init__(
             model=model,
-            model_provider=ModelProvider.COHERE,
+            model_provider=cohere_provider,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,
@@ -63,7 +67,7 @@ class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
         self.model = model
         
         self._model_parameters = model_catalog.get_embedding_model_parameters(
-            ModelProvider.COHERE, model
+            "cohere", model
         )
         self._metrics = RMMetrics()
         
@@ -114,7 +118,7 @@ class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
             self._metrics.num_input_tokens += total_tokens
             self._metrics.num_requests += 1
             self._metrics.cost += model_catalog.calculate_embedding_model_cost(
-                model_provider=ModelProvider.COHERE,
+                model_provider=cohere_provider,
                 model_name=self.model,
                 billable_inputs=total_tokens,
             )
@@ -191,3 +195,4 @@ class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
             The current metrics
         """
         return self._metrics
+

--- a/src/fenic/_inference/cohere/cohere_provider.py
+++ b/src/fenic/_inference/cohere/cohere_provider.py
@@ -1,0 +1,30 @@
+"""Cohere model provider implementation."""
+
+import logging
+import cohere
+
+from fenic.core._inference.model_provider import ModelProvider
+
+logger = logging.getLogger(__name__)
+
+
+class CohereModelProvider(ModelProvider):
+    """Cohere implementation of ModelProvider."""
+    
+    @property
+    def name(self) -> str:
+        return "cohere"
+    
+    def get_client(self):
+        """Get Cohere client instance."""
+        return cohere.AsyncClientV2()
+    
+    async def validate_api_key(self) -> None:
+        """Validate Cohere API key by making a minimal API call."""
+        client = self.get_client()
+        _ = await client.models.list()
+        logger.debug("Cohere API key validation successful")
+
+
+# Create singleton instance
+cohere_provider = CohereModelProvider()

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -60,7 +60,7 @@ class OpenAIChatCompletionsCore:
         self._client = client
         self._metrics = LMMetrics()
         self._model_parameters = model_catalog.get_completion_model_parameters(self._model_provider, self._model)
-        self._model_identifier = f"{model_provider.value}:{model}"
+        self._model_identifier = f"{model_provider.name}:{model}"
 
     def reset_metrics(self) -> None:
         """Reset the metrics."""
@@ -168,7 +168,7 @@ class OpenAIChatCompletionsCore:
             completion = response.choices[0].message.content
             if completion is None:
                 logger.warning(
-                    f"[{self._model_provider.value}:{self._model}] returned None for completion for {self.get_request_key(request)}: {response}")
+                    f"[{self._model_provider.name}:{self._model}] returned None for completion for {self.get_request_key(request)}: {response}")
             return FenicCompletionsResponse(
                 completion=response.choices[0].message.content,
                 logprobs=response.choices[0].logprobs,

--- a/src/fenic/_inference/common_openai/openai_embeddings_core.py
+++ b/src/fenic/_inference/common_openai/openai_embeddings_core.py
@@ -51,7 +51,7 @@ class OpenAIEmbeddingsCore:
         self._client = client
         self._metrics = RMMetrics()
         self._model_parameters = model_catalog.get_embedding_model_parameters(self._model_provider, self._model)
-        self._model_identifier = f"{model_provider.value}/{model}"
+        self._model_identifier = f"{model_provider.name}/{model}"
 
     def reset_metrics(self) -> None:
         """Reset the metrics."""

--- a/src/fenic/_inference/common_openai/openai_provider.py
+++ b/src/fenic/_inference/common_openai/openai_provider.py
@@ -1,0 +1,30 @@
+"""OpenAI model provider implementation."""
+
+import logging
+from openai import AsyncOpenAI
+
+from fenic.core._inference.model_provider import ModelProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIModelProvider(ModelProvider):
+    """OpenAI implementation of ModelProvider."""
+    
+    @property
+    def name(self) -> str:
+        return "openai"
+    
+    def get_client(self):
+        """Get OpenAI client instance."""
+        return AsyncOpenAI()
+    
+    async def validate_api_key(self) -> None:
+        """Validate OpenAI API key by listing models."""
+        client = self.get_client()
+        _ = await client.models.list()
+        logger.debug("OpenAI API key validation successful")
+
+
+# Create singleton instance
+openai_provider = OpenAIModelProvider()

--- a/src/fenic/_inference/google/gemini_batch_embeddings_client.py
+++ b/src/fenic/_inference/google/gemini_batch_embeddings_client.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 from typing import List, Optional, Union
 
@@ -20,16 +21,18 @@ from fenic._inference.rate_limit_strategy import (
 )
 from fenic._inference.token_counter import TiktokenTokenCounter
 from fenic._inference.types import FenicEmbeddingsRequest
-from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.model_catalog import model_catalog
 from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
 from fenic.core.metrics import RMMetrics
+
+logger = logging.getLogger(__name__)
 
 
 class GoogleBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float]]):
     def __init__(
         self,
         rate_limit_strategy: UnifiedTokenRateLimitStrategy,
-        model_provider: ModelProvider,
+        model_provider,
         model: str,
         queue_size: int = 100,
         max_backoffs: int = 10,
@@ -47,7 +50,7 @@ class GoogleBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
         self.model = model
         # Native gen-ai client. Passing `vertexai=True` automatically routes traffic
         # through Vertex-AI if the environment is configured for it.
-        if model_provider == ModelProvider.GOOGLE_DEVELOPER:
+        if model_provider.name == "google-developer":
             if "GEMINI_API_KEY" in os.environ:
                 self._base_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
             else:
@@ -135,3 +138,4 @@ class GoogleBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
 
     def get_metrics(self) -> RMMetrics:
         return self._metrics
+

--- a/src/fenic/_inference/google/gemini_native_chat_completions_client.py
+++ b/src/fenic/_inference/google/gemini_native_chat_completions_client.py
@@ -33,7 +33,6 @@ from fenic._inference.types import (
     ResponseUsage,
 )
 from fenic.core._inference.model_catalog import (
-    ModelProvider,
     model_catalog,
 )
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
@@ -59,7 +58,7 @@ class GeminiNativeChatCompletionsClient(
     def __init__(
         self,
         rate_limit_strategy: UnifiedTokenRateLimitStrategy,
-        model_provider: ModelProvider,
+        model_provider,
         model: str,
         queue_size: int = 100,
         max_backoffs: int = 10,
@@ -89,15 +88,7 @@ class GeminiNativeChatCompletionsClient(
             token_counter=token_counter,
         )
 
-        # Native gen-ai client. Passing `vertexai=True` automatically routes traffic
-        # through Vertex-AI if the environment is configured for it.
-        if model_provider == ModelProvider.GOOGLE_DEVELOPER:
-            if "GEMINI_API_KEY" in os.environ:
-                self._base_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-            else:
-                self._base_client = genai.Client()
-        else:
-            self._base_client = genai.Client(vertexai=True)
+        self._base_client = model_provider.get_client()
         self._client = self._base_client.aio
         self._metrics = LMMetrics()
         self._token_counter = token_counter  # For type checkers
@@ -437,3 +428,4 @@ class GeminiNativeChatCompletionsClient(
             return result
 
         return remove_additional_properties(copy.deepcopy(response_format.strict_schema))
+

--- a/src/fenic/_inference/google/google_provider.py
+++ b/src/fenic/_inference/google/google_provider.py
@@ -1,0 +1,48 @@
+"""Google model provider implementation."""
+
+import logging
+import os
+from google import genai
+
+from fenic.core._inference.model_provider import ModelProvider
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleModelProvider(ModelProvider):
+    """Google implementation of ModelProvider."""
+    
+    def __init__(self, provider_type: str = "google-developer"):
+        """Initialize Google provider.
+        
+        Args:
+            provider_type: Either "google-developer" or "google-vertex"
+        """
+        self._provider_type = provider_type
+    
+    @property
+    def name(self) -> str:
+        return self._provider_type
+    
+    def get_client(self):
+        # Native gen-ai client. Passing `vertexai=True` automatically routes traffic
+        # through Vertex-AI if the environment is configured for it.
+        if self._provider_type == "google-developer":
+            if "GEMINI_API_KEY" in os.environ:
+                return genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+            else:
+                return genai.Client()
+        else:
+            return genai.Client(vertexai=True)
+    
+    async def validate_api_key(self) -> None:
+        """Validate Google API key by listing models."""
+        client = self.get_client()
+        aio_client = client.aio
+        _ = await aio_client.models.list()
+        logger.debug(f"Google API key validation successful for {self._provider_type}")
+
+
+# Create singleton instances
+google_developer_provider = GoogleModelProvider("google-developer")
+google_vertex_provider = GoogleModelProvider("google-vertex")

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -27,7 +27,6 @@ from fenic._inference.rate_limit_strategy import (
     TokenEstimate,
 )
 from fenic._inference.token_counter import TiktokenTokenCounter, Tokenizable
-from fenic.core._inference.model_catalog import ModelProvider
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core.metrics import LMMetrics
 
@@ -74,7 +73,7 @@ class QueueItem(Generic[RequestT]):
 
 
 class ModelClient(Generic[RequestT, ResponseT], ABC):
-    """Base client for interacting with language models.
+    """Base client for interacting with language and embedding models.
 
     This abstract base class provides a robust framework for interacting with language models,
     handling rate limiting, request queuing, retries, and deduplication. It manages concurrent
@@ -86,7 +85,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
 
     Attributes:
         model (str): The name or identifier of the model
-        model_provider (ModelProvider): The provider of the model (e.g., OPENAI, ANTHROPIC)
+        model_provider: The provider instance
         rate_limit_strategy (RateLimitStrategy): Strategy for rate limiting requests
         token_counter (TiktokenTokenCounter): Counter for estimating token usage
     """
@@ -94,7 +93,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
     def __init__(
             self,
             model: str,
-            model_provider: ModelProvider,
+            model_provider,
             rate_limit_strategy: RateLimitStrategy,
             token_counter: TiktokenTokenCounter,
             queue_size: int = 100,
@@ -106,7 +105,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
 
         Args:
             model: The name or identifier of the model
-            model_provider: The model provider (OPENAI, ANTHROPIC)
+            model_provider: The model provider instance
             alias: The Model Client's alias, for logging purposes
             rate_limit_strategy: Strategy for rate limiting requests
             token_counter: Implementation for predicting input token counts
@@ -222,6 +221,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
     def reset_metrics(self):
         """Reset all metrics for this model client to their initial values."""
         pass
+
 
     def _count_auxiliary_input_tokens(self, request: RequestT) -> int:
         """Count extra input tokens for structured output, tools, etc. Override as needed."""

--- a/src/fenic/_inference/openai/openai_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openai/openai_batch_chat_completions_client.py
@@ -21,7 +21,7 @@ from fenic._inference.rate_limit_strategy import (
 )
 from fenic._inference.token_counter import TiktokenTokenCounter
 from fenic._inference.types import FenicCompletionsRequest, FenicCompletionsResponse
-from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.model_catalog import model_catalog
 from fenic.core._resolved_session_config import ResolvedOpenAIModelProfile
 from fenic.core.metrics import LMMetrics
 
@@ -50,15 +50,16 @@ class OpenAIBatchChatCompletionsClient(ModelClient[FenicCompletionsRequest, Feni
             profiles: Dictionary of profile configurations
             default_profile_name: Default profile to use when none specified
         """
+        from fenic._inference.common_openai.openai_provider import openai_provider
         super().__init__(
             model=model,
-            model_provider=ModelProvider.OPENAI,
+            model_provider=openai_provider,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,
             token_counter=TiktokenTokenCounter(model_name=model, fallback_encoding="o200k_base"),
         )
-        self._model_parameters = model_catalog.get_completion_model_parameters(ModelProvider.OPENAI, model)
+        self._model_parameters = model_catalog.get_completion_model_parameters(openai_provider, model)
         self._profile_manager = OpenAICompletionsProfileManager(
             model_parameters=self._model_parameters,
             profile_configurations=profiles,
@@ -67,9 +68,9 @@ class OpenAIBatchChatCompletionsClient(ModelClient[FenicCompletionsRequest, Feni
 
         self._core = OpenAIChatCompletionsCore(
             model=model,
-            model_provider=ModelProvider.OPENAI,
+            model_provider=openai_provider,
             token_counter=TiktokenTokenCounter(model_name=model, fallback_encoding="o200k_base"),
-            client=AsyncOpenAI()
+            client=openai_provider.get_client()
         )
 
     async def make_single_request(
@@ -129,3 +130,4 @@ class OpenAIBatchChatCompletionsClient(ModelClient[FenicCompletionsRequest, Feni
         # Get profile-specific reasoning effort
         profile_config = self._profile_manager.get_profile_by_name(request.model_profile)
         return base_tokens + profile_config.expected_additional_reasoning_tokens
+

--- a/src/fenic/_inference/openai/openai_batch_embeddings_client.py
+++ b/src/fenic/_inference/openai/openai_batch_embeddings_client.py
@@ -1,5 +1,6 @@
 """Client for making batch requests to OpenAI's embeddings API."""
 
+import logging
 from typing import Union
 
 from openai import AsyncOpenAI
@@ -22,6 +23,8 @@ from fenic._inference.types import FenicEmbeddingsRequest
 from fenic.core._inference.model_catalog import ModelProvider
 from fenic.core.metrics import RMMetrics
 
+logger = logging.getLogger(__name__)
+
 
 class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float]]):
     """Client for making batch requests to OpenAI's embeddings API."""
@@ -41,9 +44,10 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
             model: The model to use
             max_backoffs: Maximum number of backoff attempts
         """
+        from fenic._inference.common_openai.openai_provider import openai_provider
         super().__init__(
             model=model,
-            model_provider=ModelProvider.OPENAI,
+            model_provider=openai_provider,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,
@@ -51,9 +55,9 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
         )
         self._core = OpenAIEmbeddingsCore(
             model=self.model,
-            model_provider=self.model_provider,
+            model_provider=openai_provider,
             token_counter=TiktokenTokenCounter(model_name=model),
-            client=AsyncOpenAI(),
+            client=openai_provider.get_client(),
         )
 
     async def make_single_request(
@@ -106,3 +110,4 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
 
     def _get_max_output_tokens(self, request: RequestT) -> int:
         return 0
+

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -17,10 +17,10 @@ from fenic.core._inference.model_catalog import (
     GoogleDeveloperLanguageModelName,
     GoogleVertexEmbeddingModelName,
     GoogleVertexLanguageModelName,
-    ModelProvider,
     OpenAIEmbeddingModelName,
     OpenAILanguageModelName,
     model_catalog,
+    ModelProvider,
 )
 from fenic.core._resolved_session_config import (
     ReasoningEffort,
@@ -102,7 +102,7 @@ class GoogleDeveloperEmbeddingModel(BaseModel):
         ```
     """
     model_name: GoogleDeveloperEmbeddingModelName
-    model_provider: ModelProvider = Field(default=ModelProvider.GOOGLE_DEVELOPER)
+    model_provider: Literal["google-developer"] = Field(default="google-developer")
     rpm: int = Field(..., gt=0, description="Requests per minute; must be > 0")
     tpm: int = Field(..., gt=0, description="Tokens per minute; must be > 0")
     profiles: Optional[dict[str, Profile]] = Field(default=None, description=profiles_desc)
@@ -267,7 +267,7 @@ class GoogleVertexEmbeddingModel(BaseModel):
         ```
     """
     model_name: GoogleVertexEmbeddingModelName
-    model_provider: ModelProvider = Field(default=ModelProvider.GOOGLE_VERTEX)
+    model_provider: Literal["google-vertex"] = Field(default="google-vertex")
     rpm: int = Field(..., gt=0, description="Requests per minute; must be > 0")
     tpm: int = Field(..., gt=0, description="Tokens per minute; must be > 0")
     profiles: Optional[dict[str, Profile]] = Field(default=None, description=profiles_desc)
@@ -1052,9 +1052,11 @@ class SessionConfig(BaseModel):
 
     def _to_resolved_config(self) -> ResolvedSessionConfig:
         def resolve_model(model: ModelConfig) -> ResolvedModelConfig:
+            provider = _get_model_provider_for_model_config(model)
             if isinstance(model, OpenAIEmbeddingModel):
                 return ResolvedOpenAIModelConfig(
                     model_name=model.model_name,
+                    model_provider=provider,
                     rpm=model.rpm,
                     tpm=model.tpm,
                 )
@@ -1065,6 +1067,7 @@ class SessionConfig(BaseModel):
                 } if model.profiles else None
                 return ResolvedOpenAIModelConfig(
                     model_name=model.model_name,
+                    model_provider=provider,
                     rpm=model.rpm,
                     tpm=model.tpm,
                     profiles=profiles,
@@ -1077,7 +1080,7 @@ class SessionConfig(BaseModel):
                 } if model.profiles else None
                 return ResolvedGoogleModelConfig(
                     model_name=model.model_name,
-                    model_provider=_get_model_provider_for_model_config(model),
+                    model_provider=provider,
                     rpm=model.rpm,
                     tpm=model.tpm,
                     profiles=profiles,
@@ -1093,7 +1096,7 @@ class SessionConfig(BaseModel):
                 } if model.profiles else None
                 return ResolvedGoogleModelConfig(
                     model_name=model.model_name,
-                    model_provider=model.model_provider,
+                    model_provider=provider,
                     rpm=model.rpm,
                     tpm=model.tpm,
                     profiles=resolved_profiles,
@@ -1106,6 +1109,7 @@ class SessionConfig(BaseModel):
                 } if model.profiles else None
                 return ResolvedAnthropicModelConfig(
                     model_name=model.model_name,
+                    model_provider=provider,
                     rpm=model.rpm,
                     input_tpm=model.input_tpm,
                     output_tpm=model.output_tpm,
@@ -1119,6 +1123,7 @@ class SessionConfig(BaseModel):
                 } if model.profiles else None
                 return ResolvedCohereModelConfig(
                     model_name=model.model_name,
+                    model_provider=provider,
                     rpm=model.rpm,
                     tpm=model.tpm,
                     profiles=profiles,
@@ -1185,7 +1190,7 @@ def _validate_embedding_profile(
             f"Available Options: {embedding_model_parameters.get_possible_dimensions()}")
 
 def _get_model_provider_for_model_config(model_config: ModelConfig) -> ModelProvider:
-    """Determine the ModelProvider for the given model configuration."""
+    """Determine the model provider name for the given model configuration."""
     if isinstance(model_config, (OpenAILanguageModel, OpenAIEmbeddingModel)):
         return ModelProvider.OPENAI
     elif isinstance(model_config, (GoogleDeveloperLanguageModel, GoogleDeveloperEmbeddingModel)):

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -1,17 +1,82 @@
-from enum import Enum
 from typing import Dict, Literal, Optional, TypeAlias, Union
 
-from fenic.core.error import InternalError
+from fenic.core.error import ConfigurationError, InternalError
 
+# Import the new ModelProvider base class
+from fenic.core._inference.model_provider import ModelProvider as ModelProviderBase
 
-class ModelProvider(Enum):
-    """Enum representing different model providers supported by the system."""
+# Backward compatibility - import provider instances
+def _get_provider_constants():
+    """Lazy import of provider instances for backward compatibility."""
+    from fenic._inference.common_openai.openai_provider import openai_provider
+    from fenic._inference.anthropic.anthropic_provider import anthropic_provider
+    from fenic._inference.google.google_provider import google_developer_provider, google_vertex_provider
+    from fenic._inference.cohere.cohere_provider import cohere_provider
+    
+    class ModelProviderConstants:
+        OPENAI = openai_provider
+        ANTHROPIC = anthropic_provider
+        GOOGLE_DEVELOPER = google_developer_provider
+        GOOGLE_VERTEX = google_vertex_provider
+        COHERE = cohere_provider
+    
+    return ModelProviderConstants()
 
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    GOOGLE_DEVELOPER = "google-developer"
-    GOOGLE_VERTEX = "google-vertex"
-    COHERE = "cohere"
+# Lazy initialization of backward compatibility constants
+_provider_constants = None
+
+def _get_provider_const():
+    global _provider_constants
+    if _provider_constants is None:
+        _provider_constants = _get_provider_constants()
+    return _provider_constants
+
+# Create namespace for backward compatibility
+class _ModelProviderNamespace:
+    def __init__(self):
+        self._name_to_provider_map = {
+            "openai": "OPENAI",
+            "anthropic": "ANTHROPIC", 
+            "google-developer": "GOOGLE_DEVELOPER",
+            "google-vertex": "GOOGLE_VERTEX",
+            "cohere": "COHERE"
+        }
+    
+    @property
+    def OPENAI(self):
+        return _get_provider_const().OPENAI
+    
+    @property  
+    def ANTHROPIC(self):
+        return _get_provider_const().ANTHROPIC
+    
+    @property
+    def GOOGLE_DEVELOPER(self):
+        return _get_provider_const().GOOGLE_DEVELOPER
+    
+    @property
+    def GOOGLE_VERTEX(self):
+        return _get_provider_const().GOOGLE_VERTEX
+    
+    @property
+    def COHERE(self):
+        return _get_provider_const().COHERE
+    
+    def __call__(self, provider_name: str):
+        """Make ModelProvider callable to handle ModelProvider(string) pattern."""
+        return self.get_provider(provider_name)
+    
+    def get_provider(self, provider_name: str):
+        """Get provider instance by string name."""
+        if provider_name not in self._name_to_provider_map:
+            raise ConfigurationError(f"Unknown provider: {provider_name}. Available providers: {list(self._name_to_provider_map.keys())}")
+        
+        # Get the corresponding constant name and return the provider instance
+        constant_name = self._name_to_provider_map[provider_name]
+        return getattr(self, constant_name)
+
+# Create the backward compatibility interface
+ModelProvider = _ModelProviderNamespace()
 
 class TieredTokenCost:
     def __init__(
@@ -229,8 +294,12 @@ class ProviderModelCollection:
     """
 
 
-    def __init__(self, provider: ModelProvider) -> None:
-        self.provider = provider
+    def __init__(self, provider: Union[ModelProviderBase, str]) -> None:
+        # Handle provider instances and strings
+        if isinstance(provider, str):
+            self.provider_name = provider
+        else:
+            self.provider_name = provider.name
         self.completion_models: CompletionModelCollection = {}
         self.embedding_models: EmbeddingModelCollection = {}
 
@@ -280,7 +349,7 @@ class ModelCatalog:
 
     def __init__(self):
         self.provider_model_collections: dict[
-            ModelProvider, ProviderModelCollection
+            str, ProviderModelCollection
         ] = {}
         self._initialize_models()
 
@@ -294,8 +363,11 @@ class ModelCatalog:
 
     def _initialize_anthropic_models(self):
         """Initialize Anthropic models in the catalog."""
+        # Lazy import to avoid circular dependencies
+        from fenic._inference.anthropic.anthropic_provider import anthropic_provider
+        
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-opus-4-1",
             CompletionModelParameters(
                 input_token_cost=15.00 / 1_000_000,  # $15 per 1M tokens
@@ -310,7 +382,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-opus-4-0",
             CompletionModelParameters(
                 input_token_cost=15.00 / 1_000_000,  # $15 per 1M tokens
@@ -325,7 +397,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-sonnet-4-0",
             CompletionModelParameters(
                 input_token_cost=3.00 / 1_000_000,  # $3 per 1M tokens
@@ -340,7 +412,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-3-7-sonnet-latest",
             CompletionModelParameters(
                 input_token_cost=3.0 / 1_000_000,  # $3 per 1M tokens
@@ -355,7 +427,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-3-5-sonnet-latest",
             CompletionModelParameters(
                 input_token_cost=3 / 1_000_000,  # $3 per 1M tokens
@@ -370,7 +442,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-3-5-haiku-latest",
             CompletionModelParameters(
                 input_token_cost=0.80 / 1_000_000,  # $0.80 per 1M tokens
@@ -385,7 +457,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-3-opus-latest",
             CompletionModelParameters(
                 input_token_cost=15.00 / 1_000_000,  # $15 per 1M tokens
@@ -400,7 +472,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
+            anthropic_provider,
             "claude-3-haiku-20240307",
             CompletionModelParameters(
                 input_token_cost=0.25 / 1_000_000,  # $0.25 per 1M tokens
@@ -415,8 +487,9 @@ class ModelCatalog:
 
     def _initialize_openai_models(self):
         """Initialize OpenAI models in the catalog."""
+        from fenic._inference.common_openai.openai_provider import openai_provider
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4",
             CompletionModelParameters(
                 input_token_cost=30 / 1_000_000,  # $30 per 1M tokens
@@ -431,7 +504,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4-turbo",
             CompletionModelParameters(
                 input_token_cost=10 / 1_000_000,  # $10 per 1M tokens
@@ -446,7 +519,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4o-mini",
             CompletionModelParameters(
                 input_token_cost=0.300 / 1_000_000,  # $0.300 per 1M tokens
@@ -461,7 +534,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4o",
             CompletionModelParameters(
                 input_token_cost=3.750 / 1_000_000,  # $3.750 per 1M tokens
@@ -476,7 +549,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4.1-nano",
             CompletionModelParameters(
                 input_token_cost=0.100 / 1_000_000,  # $0.100 per 1M tokens
@@ -491,7 +564,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4.1-mini",
             CompletionModelParameters(
                 input_token_cost=0.400 / 1_000_000,  # $0.400 per 1M tokens
@@ -506,7 +579,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-4.1",
             CompletionModelParameters(
                 input_token_cost=2.00 / 1_000_000,  # $2.00 per 1M tokens
@@ -521,7 +594,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "o1",
             CompletionModelParameters(
                 input_token_cost=15 / 1_000_000,  # $15 per 1M tokens
@@ -536,7 +609,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "o1-mini",
             CompletionModelParameters(
                 input_token_cost=1.10 / 1_000_000,  # $1.10 per 1M tokens
@@ -550,7 +623,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "o3",
             CompletionModelParameters(
                 input_token_cost=2 / 1_000_000,  # $2 per 1M tokens
@@ -565,7 +638,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "o3-mini",
             CompletionModelParameters(
                 input_token_cost=1.10 / 1_000_000,  # $1.10 per 1M tokens
@@ -580,7 +653,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "o4-mini",
             CompletionModelParameters(
                 input_token_cost=1.10 / 1_000_000,  # $1.10 per 1M tokens
@@ -594,7 +667,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-5",
             CompletionModelParameters(
                 input_token_cost=1.25 / 1_000_000,  # $1.25 per 1M tokens
@@ -611,7 +684,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-5-mini",
             CompletionModelParameters(
                 input_token_cost=0.25 / 1_000_000,  # $0.25 per 1M tokens
@@ -628,7 +701,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "gpt-5-nano",
             CompletionModelParameters(
                 input_token_cost=0.05 / 1_000_000,  # $0.05 per 1M tokens
@@ -646,7 +719,7 @@ class ModelCatalog:
 
         # OpenAI Embedding Models
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "text-embedding-3-small",
             EmbeddingModelParameters(
                 input_token_cost=0.02 / 1_000_000,  # $0.02 per 1M tokens
@@ -656,7 +729,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.OPENAI,
+            openai_provider,
             "text-embedding-3-large",
             EmbeddingModelParameters(
                 input_token_cost=0.13 / 1_000_000,  # $0.13 per 1M tokens
@@ -667,8 +740,9 @@ class ModelCatalog:
 
     def _initialize_google_vertex_models(self):
         """Initialize the Google Vertex Models."""
+        from fenic._inference.google.google_provider import google_vertex_provider
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-2.5-pro",
             CompletionModelParameters(
                 input_token_cost=1.25 / 1_000_000,  # $1.25 per 1M tokens
@@ -692,7 +766,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-2.5-flash",
             CompletionModelParameters(
                 input_token_cost=0.30 / 1_000_000,  # $0.30 per 1M tokens
@@ -706,7 +780,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-2.5-flash-lite",
             CompletionModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -719,7 +793,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-2.0-flash-lite",
             CompletionModelParameters(
                 input_token_cost=0.075 / 1_000_000,  # $0.075 per 1M tokens
@@ -732,7 +806,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-2.0-flash",
             CompletionModelParameters(
                 input_token_cost=0.15 / 1_000_000,  # $0.15 per 1M tokens
@@ -746,7 +820,7 @@ class ModelCatalog:
             snapshots=["gemini-2.0-flash-001", "gemini-2.0-flash-exp"],
         )
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "gemini-embedding-001",
             EmbeddingModelParameters(
                 input_token_cost=0.00015 / 1_000,  # $0.00015 per 1k tokens
@@ -758,7 +832,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "text-embedding-005",
             EmbeddingModelParameters(
                 input_token_cost=0.000025
@@ -770,7 +844,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_VERTEX,
+            google_vertex_provider,
             "text-multilingual-embedding-002",
             EmbeddingModelParameters(
                 input_token_cost=0.000025
@@ -782,9 +856,10 @@ class ModelCatalog:
 
     def _initialize_google_gla_models(self):
         """Initialize Google models in the catalog."""
+        from fenic._inference.google.google_provider import google_developer_provider
         # Google GLA Models (same models, possibly different pricing)
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-2.5-pro",
             CompletionModelParameters(
                 input_token_cost=1.25 / 1_000_000,  # $1.25 per 1M tokens
@@ -808,7 +883,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-2.5-flash",
             CompletionModelParameters(
                 input_token_cost=0.15 / 1_000_000,  # $0.15 per 1M tokens
@@ -822,7 +897,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-2.5-flash-lite",
             CompletionModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -835,7 +910,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-2.0-flash-lite",
             CompletionModelParameters(
                 input_token_cost=0.075 / 1_000_000,  # $0.075 per 1M tokens
@@ -849,7 +924,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-2.0-flash",
             CompletionModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -865,7 +940,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "gemini-embedding-001",
             EmbeddingModelParameters(
                 input_token_cost=0.15 / 1_000_000,  # $0.15 per 1M tokens
@@ -877,7 +952,7 @@ class ModelCatalog:
         )
 
         self._add_model_to_catalog(
-            ModelProvider.GOOGLE_DEVELOPER,
+            google_developer_provider,
             "text-embedding-004",
             EmbeddingModelParameters(
                 input_token_cost=0.15 / 1_000_000,  # $0.15 per 1M tokens
@@ -888,9 +963,10 @@ class ModelCatalog:
 
     def _initialize_cohere_models(self):
         """Initialize Cohere models in the catalog."""
+        from fenic._inference.cohere.cohere_provider import cohere_provider
         # embed-v4.0 - Latest multimodal model with variable dimensions
         self._add_model_to_catalog(
-            ModelProvider.COHERE,
+            cohere_provider,
             "embed-v4.0",
             EmbeddingModelParameters(
                 input_token_cost=0.12 / 1_000_000,  # $0.12 per 1M tokens
@@ -902,7 +978,7 @@ class ModelCatalog:
 
         # embed-english-v3.0 - English-only model
         self._add_model_to_catalog(
-            ModelProvider.COHERE,
+            cohere_provider,
             "embed-english-v3.0",
             EmbeddingModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -913,7 +989,7 @@ class ModelCatalog:
 
         # embed-english-light-v3.0 - Smaller, faster English-only model
         self._add_model_to_catalog(
-            ModelProvider.COHERE,
+            cohere_provider,
             "embed-english-light-v3.0",
             EmbeddingModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -924,7 +1000,7 @@ class ModelCatalog:
 
         # embed-multilingual-v3.0 - Multi-language support
         self._add_model_to_catalog(
-            ModelProvider.COHERE,
+            cohere_provider,
             "embed-multilingual-v3.0",
             EmbeddingModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -935,7 +1011,7 @@ class ModelCatalog:
 
         # embed-multilingual-light-v3.0 - Smaller, faster multilingual model
         self._add_model_to_catalog(
-            ModelProvider.COHERE,
+            cohere_provider,
             "embed-multilingual-light-v3.0",
             EmbeddingModelParameters(
                 input_token_cost=0.10 / 1_000_000,  # $0.10 per 1M tokens
@@ -945,7 +1021,7 @@ class ModelCatalog:
         )
 
     # Public methods
-    def get_completion_model_parameters(self, model_provider: ModelProvider,
+    def get_completion_model_parameters(self, model_provider: Union[ModelProviderBase, str],
                                         model_name: str) -> CompletionModelParameters | None:
         """Gets the parameters for a specific completion model.
 
@@ -956,9 +1032,10 @@ class ModelCatalog:
         Returns:
             Model parameters if found, None otherwise
         """
-        return self._get_supported_completions_models_by_provider(model_provider).get(model_name)
+        provider_name = self._normalize_provider_name(model_provider)
+        return self._get_supported_completions_models_by_provider(provider_name).get(model_name)
 
-    def get_embedding_model_parameters(self, model_provider: ModelProvider, model_name: str) -> EmbeddingModelParameters | None:
+    def get_embedding_model_parameters(self, model_provider: Union[ModelProviderBase, str], model_name: str) -> EmbeddingModelParameters | None:
         """Gets the parameters for a specific embedding model.
 
         Args:
@@ -968,9 +1045,10 @@ class ModelCatalog:
         Returns:
             Model parameters if found, None otherwise
         """
-        return self._get_supported_embeddings_models_by_provider(model_provider).get(model_name)
+        provider_name = self._normalize_provider_name(model_provider)
+        return self._get_supported_embeddings_models_by_provider(provider_name).get(model_name)
 
-    def generate_unsupported_completion_model_error_message(self, model_provider: ModelProvider,
+    def generate_unsupported_completion_model_error_message(self, model_provider: Union[ModelProviderBase, str],
                                                             model_name: str) -> str:
         """Generates an error message for unsupported completion models.
 
@@ -981,9 +1059,10 @@ class ModelCatalog:
         Returns:
             Error message string
         """
-        return f"Model '{model_name}' is not supported for {model_provider.value}. Supported Models: {self._get_supported_completions_models_by_provider_as_string(model_provider)}"
+        provider_name = self._normalize_provider_name(model_provider)
+        return f"Model '{model_name}' is not supported for {provider_name}. Supported Models: {self._get_supported_completions_models_by_provider_as_string(provider_name)}"
 
-    def generate_unsupported_embedding_model_error_message(self, model_provider: ModelProvider, model_name: str) -> str:
+    def generate_unsupported_embedding_model_error_message(self, model_provider: Union[ModelProviderBase, str], model_name: str) -> str:
         """Generates an error message for unsupported embedding models.
 
         Args:
@@ -993,8 +1072,9 @@ class ModelCatalog:
         Returns:
             Error message string
         """
-        return (f"Model '{model_name}' is not supported for {model_provider.value}."
-                f" Supported Models: {self._get_supported_embeddings_models_by_provider_as_string(model_provider)}")
+        provider_name = self._normalize_provider_name(model_provider)
+        return (f"Model '{model_name}' is not supported for {provider_name}."
+                f" Supported Models: {self._get_supported_embeddings_models_by_provider_as_string(provider_name)}")
 
     def get_supported_completions_models_as_string(self) -> str:
         """Returns a comma-separated string of all supported completion models.
@@ -1003,9 +1083,9 @@ class ModelCatalog:
             Comma-separated string of model names in format 'provider:model'
         """
         all_models = []
-        for model_provider in ModelProvider:
-            for model in self._get_supported_completions_models_by_provider(model_provider).keys():
-                all_models.append(f"{model_provider.value}:{model}")
+        for provider_name in self.provider_model_collections.keys():
+            for model in self._get_supported_completions_models_by_provider(provider_name).keys():
+                all_models.append(f"{provider_name}:{model}")
         return ", ".join(sorted(all_models))
 
     def get_supported_embeddings_models_as_string(self) -> str:
@@ -1015,14 +1095,22 @@ class ModelCatalog:
             Comma-separated string of model names
         """
         all_models = []
-        for model_provider in ModelProvider:
-            for model in self._get_supported_embeddings_models_by_provider(model_provider).keys():
-                all_models.append(f"{model_provider.value}:{model}")
+        for provider_name in self.provider_model_collections.keys():
+            for model in self._get_supported_embeddings_models_by_provider(provider_name).keys():
+                all_models.append(f"{provider_name}:{model}")
         return ", ".join(sorted(all_models))
+    
+    def _normalize_provider_name(self, provider: Union[ModelProviderBase, str]) -> str:
+        """Normalize provider to string name for internal use."""
+        if isinstance(provider, str):
+            return provider
+        else:
+            # All ModelProvider instances must have a name property
+            return provider.name
 
     def calculate_completion_model_cost(
         self,
-        model_provider: ModelProvider,
+        model_provider: Union[ModelProviderBase, str],
         model_name: str,
         uncached_input_tokens: int,
         cached_input_tokens_read: int,
@@ -1045,9 +1133,10 @@ class ModelCatalog:
         Raises:
             ValueError: If the model is not supported
         """
-        model_parameters = self.get_completion_model_parameters(model_provider, model_name)
+        provider_name = self._normalize_provider_name(model_provider)
+        model_parameters = self.get_completion_model_parameters(provider_name, model_name)
         if model_parameters is None:
-            raise ValueError(self.generate_unsupported_completion_model_error_message(model_provider, model_name))
+            raise ValueError(self.generate_unsupported_completion_model_error_message(provider_name, model_name))
         input_token_cost = model_parameters.input_token_cost
         cached_input_tokens_read_cost = model_parameters.cached_input_token_read_cost
         output_token_cost = model_parameters.output_token_cost
@@ -1067,7 +1156,7 @@ class ModelCatalog:
         )
 
     def calculate_embedding_model_cost(
-        self, model_provider: ModelProvider, model_name: str, billable_inputs: int
+        self, model_provider: Union[ModelProviderBase, str], model_name: str, billable_inputs: int
     ) -> float:
         """Calculates the total cost for an embedding model operation.
 
@@ -1082,18 +1171,19 @@ class ModelCatalog:
         Raises:
             ValueError: If the model is not supported
         """
-        model_costs = self.get_embedding_model_parameters(model_provider, model_name)
+        provider_name = self._normalize_provider_name(model_provider)
+        model_costs = self.get_embedding_model_parameters(provider_name, model_name)
         if model_costs is None:
             raise ValueError(
                 self.generate_unsupported_embedding_model_error_message(
-                    model_provider, model_name
+                    provider_name, model_name
                 )
             )
         return billable_inputs * model_costs.input_token_cost
 
     def _add_model_to_catalog(
         self,
-        model_provider: ModelProvider,
+        model_provider: Union[ModelProviderBase, str],
         name: str,
         parameters: Union[CompletionModelParameters, EmbeddingModelParameters],
         snapshots: Optional[list[str]] = None,
@@ -1109,14 +1199,15 @@ class ModelCatalog:
         Raises:
             InternalError: If the model already exists in the catalog
         """
+        provider_name = self._normalize_provider_name(model_provider)
         provider_model_collection = self.provider_model_collections.get(
-            model_provider, ProviderModelCollection(model_provider)
+            provider_name, ProviderModelCollection(model_provider)
         )
         provider_model_collection.add_model(name, parameters, snapshots)
-        self.provider_model_collections[model_provider] = provider_model_collection
+        self.provider_model_collections[provider_name] = provider_model_collection
 
     def _get_supported_completions_models_by_provider(
-        self, model_provider: ModelProvider
+        self, model_provider: Union[ModelProviderBase, str]
     ) -> CompletionModelCollection:
         """Returns the collection of completion models for a specific provider.
 
@@ -1126,10 +1217,11 @@ class ModelCatalog:
         Returns:
             Collection of completion models for the specified provider, including snapshots
         """
-        return self.provider_model_collections[model_provider].completion_models
+        provider_name = self._normalize_provider_name(model_provider)
+        return self.provider_model_collections[provider_name].completion_models
 
     def _get_supported_embeddings_models_by_provider(
-        self, model_provider: ModelProvider
+        self, model_provider: Union[ModelProviderBase, str]
     ) -> EmbeddingModelCollection:
         """Returns the collection of embedding models for a specific provider.
 
@@ -1139,10 +1231,11 @@ class ModelCatalog:
         Returns:
             Collection of embedding models for the specified provider, including snapshots
         """
-        return self.provider_model_collections[model_provider].embedding_models
+        provider_name = self._normalize_provider_name(model_provider)
+        return self.provider_model_collections[provider_name].embedding_models
 
     def _get_supported_completions_models_by_provider_as_string(
-        self, model_provider: ModelProvider
+        self, model_provider: Union[ModelProviderBase, str]
     ) -> str:
         """Returns a comma-separated string of supported completion model names for a provider.
 
@@ -1152,16 +1245,17 @@ class ModelCatalog:
         Returns:
             Comma-separated string of model names
         """
+        provider_name = self._normalize_provider_name(model_provider)
         return ", ".join(
             sorted(
                 self._get_supported_completions_models_by_provider(
-                    model_provider
+                    provider_name
                 ).keys()
             )
         )
 
     def _get_supported_embeddings_models_by_provider_as_string(
-        self, model_provider: ModelProvider
+        self, model_provider: Union[ModelProviderBase, str]
     ) -> str:
         """Returns a comma-separated string of supported completion model names for a provider.
 
@@ -1171,14 +1265,28 @@ class ModelCatalog:
         Returns:
             Comma-separated string of model names
         """
+        provider_name = self._normalize_provider_name(model_provider)
         return ", ".join(
             sorted(
                 self._get_supported_embeddings_models_by_provider(
-                    model_provider
+                    provider_name
                 ).keys()
             )
         )
 
 
-# Create a singleton instance
-model_catalog = ModelCatalog()
+class _ModelCatalogSingleton:
+    """Lazy singleton wrapper for ModelCatalog."""
+    _instance = None
+    
+    def __getattribute__(self, name):
+        if name.startswith('_') or name in ['__class__', '__dict__']:
+            return object.__getattribute__(self, name)
+        
+        if self._instance is None:
+            self._instance = ModelCatalog()
+        
+        return getattr(self._instance, name)
+
+# Create a singleton instance that initializes lazily
+model_catalog = _ModelCatalogSingleton()

--- a/src/fenic/core/_inference/model_provider.py
+++ b/src/fenic/core/_inference/model_provider.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+
+
+class ModelProvider(ABC):
+    """Abstract base class for model providers.
+    
+    This class defines the interface that all model providers must implement,
+    including API key validation functionality.
+    """
+    
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the string identifier for this provider."""
+        pass
+    
+    @abstractmethod
+    def get_client(self):
+        """Get the client for this provider.
+        
+        Returns the provider-specific client instance configured with the
+        appropriate credentials and settings.
+        """
+        pass
+    
+    @abstractmethod
+    async def validate_api_key(self) -> None:
+        """Validate the API key for this provider.
+        
+        This method should create the appropriate client and perform a lightweight 
+        API call to verify that the configured credentials are valid and the 
+        service is accessible. Should log success but let exceptions bubble up.
+        """
+        pass
+    
+    def __str__(self) -> str:
+        return self.name
+    
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name='{self.name}')"
+    
+    def __hash__(self) -> int:
+        return hash(self.name)

--- a/src/fenic/core/_inference/model_provider_registry.py
+++ b/src/fenic/core/_inference/model_provider_registry.py
@@ -1,0 +1,62 @@
+"""Registry for model provider instances."""
+
+from typing import Dict
+
+from fenic.core._inference.model_provider import ModelProvider
+
+
+class ModelProviderRegistry:
+    """Registry for managing model provider instances."""
+    
+    def __init__(self):
+        self._providers: Dict[str, ModelProvider] = {}
+        self._initialized = False
+    
+    def _initialize_providers(self):
+        """Initialize all available providers."""
+        if self._initialized:
+            return
+            
+        # Import here to avoid circular dependencies
+        from fenic._inference.common_openai.openai_provider import openai_provider
+        from fenic._inference.anthropic.anthropic_provider import anthropic_provider
+        from fenic._inference.google.google_provider import (
+            google_developer_provider,
+            google_vertex_provider,
+        )
+        from fenic._inference.cohere.cohere_provider import cohere_provider
+        
+        self._providers = {
+            "openai": openai_provider,
+            "anthropic": anthropic_provider,
+            "google-developer": google_developer_provider,
+            "google-vertex": google_vertex_provider,
+            "cohere": cohere_provider,
+        }
+        self._initialized = True
+    
+    def get_provider(self, name: str) -> ModelProvider:
+        """Get a provider by name.
+        
+        Args:
+            name: The provider name (e.g., "openai", "anthropic")
+            
+        Returns:
+            The provider instance
+            
+        Raises:
+            ValueError: If the provider is not found
+        """
+        self._initialize_providers()
+        if name not in self._providers:
+            raise ValueError(f"Unknown provider: {name}. Available providers: {list(self._providers.keys())}")
+        return self._providers[name]
+    
+    def get_all_providers(self) -> Dict[str, ModelProvider]:
+        """Get all registered providers."""
+        self._initialize_providers()
+        return self._providers.copy()
+
+
+# Create singleton instance
+model_provider_registry = ModelProviderRegistry()

--- a/src/fenic/core/_logical_plan/expressions/semantic.py
+++ b/src/fenic/core/_logical_plan/expressions/semantic.py
@@ -561,7 +561,7 @@ class EmbeddingsExpr(ValidatedDynamicSignature, SemanticExpr):
             self.dimensions = embedding_params.default_dimensions
 
         return EmbeddingType(
-            embedding_model=f"{model_provider.value}/{model_name}",
+            embedding_model=f"{model_provider.name}/{model_name}",
             dimensions=self.dimensions,
         )
 

--- a/src/fenic/core/_logical_plan/utils.py
+++ b/src/fenic/core/_logical_plan/utils.py
@@ -81,9 +81,9 @@ def validate_completion_parameters(
         model_provider = ModelProvider.ANTHROPIC
     completion_parameters: CompletionModelParameters = model_catalog.get_completion_model_parameters(model_provider, model_config.model_name)
     if max_tokens is not None and max_tokens > completion_parameters.max_output_tokens:
-        raise ValidationError(f"[{model_provider.value}:{model_config.model_name}] max_output_tokens must be a positive integer less than or equal to {completion_parameters.max_output_tokens}")
+        raise ValidationError(f"[{model_provider.name}:{model_config.model_name}] max_output_tokens must be a positive integer less than or equal to {completion_parameters.max_output_tokens}")
     if temperature is not None and (temperature < 0 or temperature > completion_parameters.max_temperature):
-        raise ValidationError(f"[{model_provider.value}:{model_config.model_name}] temperature must be between 0 and {completion_parameters.max_temperature}")
+        raise ValidationError(f"[{model_provider.name}:{model_config.model_name}] temperature must be between 0 and {completion_parameters.max_temperature}")
 
 def validate_scalar_expr(expr: LogicalExpr, function_name: str):
     if isinstance(expr, SortExpr):

--- a/src/fenic/core/_resolved_session_config.py
+++ b/src/fenic/core/_resolved_session_config.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from fenic.core._inference.model_catalog import ModelProvider
+if TYPE_CHECKING:
+    from fenic.core._inference.model_catalog import ModelProvider
 
 ReasoningEffort = Literal["minimal", "low", "medium", "high"]
 Verbosity = Literal["low", "medium", "high"]
@@ -42,11 +43,13 @@ class ResolvedGoogleModelProfile:
 
 @dataclass
 class ResolvedOpenAIModelProfile:
+    model_provider: "ModelProvider"
     reasoning_effort: Optional[ReasoningEffort] = None
     verbosity: Optional[Verbosity] = None
 
 @dataclass
 class ResolvedCohereModelProfile:
+    model_provider: "ModelProvider"
     embedding_dimensionality: Optional[int] = None
     embedding_task_type: Optional[str] = None
 
@@ -55,7 +58,7 @@ class ResolvedOpenAIModelConfig:
     model_name: str
     rpm: int
     tpm: int
-    model_provider: ModelProvider = ModelProvider.OPENAI
+    model_provider: "ModelProvider"
     profiles: Optional[dict[str, ResolvedOpenAIModelProfile]] = None
     default_profile: Optional[str] = None
 
@@ -66,14 +69,14 @@ class ResolvedAnthropicModelConfig:
     rpm: int
     input_tpm: int
     output_tpm: int
-    model_provider: ModelProvider = ModelProvider.ANTHROPIC
+    model_provider: "ModelProvider"
     profiles: Optional[dict[str, ResolvedAnthropicModelProfile]] = None
     default_profile: Optional[str] = None
 
 @dataclass
 class ResolvedGoogleModelConfig:
     model_name: str
-    model_provider: Literal[ModelProvider.GOOGLE_DEVELOPER, ModelProvider.GOOGLE_VERTEX]
+    model_provider: "ModelProvider"
     rpm: int
     tpm: int
     profiles: Optional[dict[str, ResolvedGoogleModelProfile]] = None
@@ -84,7 +87,7 @@ class ResolvedCohereModelConfig:
     model_name: str
     rpm: int
     tpm: int
-    model_provider: ModelProvider = ModelProvider.COHERE
+    model_provider: "ModelProvider"
     profiles: Optional[dict[str, ResolvedCohereModelProfile]] = None
     default_profile: Optional[str] = None
 

--- a/tests/_backends/local/functions/test_embed.py
+++ b/tests/_backends/local/functions/test_embed.py
@@ -53,7 +53,7 @@ def test_embeddings(extract_data_df, embedding_model_name_and_dimensions):
 
 def test_embedding_very_long_string(local_session, embedding_model_name_and_dimensions):
     embedding_model_name, _ = embedding_model_name_and_dimensions
-    if ModelProvider.OPENAI.value in embedding_model_name:
+    if ModelProvider.OPENAI.name in embedding_model_name:
         string_val = "".join((" " if i%5 == 0 else choice(ascii_lowercase)) for i in range(32768))
         data = {
             "review": [string_val],

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -7,10 +7,13 @@ import pytest
 from pydantic import ValidationError as PydanticValidationError
 
 from fenic import (
+    AnthropicLanguageModel,
     CohereEmbeddingModel,
     ColumnField,
     GoogleDeveloperEmbeddingModel,
+    GoogleDeveloperLanguageModel,
     GoogleVertexEmbeddingModel,
+    GoogleVertexLanguageModel,
     IntegerType,
     OpenAIEmbeddingModel,
     OpenAILanguageModel,
@@ -20,7 +23,6 @@ from fenic import (
     StringType,
     col,
 )
-from fenic.api.session.config import GoogleDeveloperLanguageModel
 from fenic.core._inference.model_catalog import ModelProvider
 from fenic.core._logical_plan.plans import InMemorySource
 from fenic.core.error import ConfigurationError
@@ -505,3 +507,107 @@ def test_model_profile_validation():
                 language_models={"o3": OpenAILanguageModel(model_name="o3", rpm=100, tpm=1000, profiles={"fast": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=0)})}
             )
         )
+
+def test_session_config_with_invalid_api_keys(monkeypatch):
+    """Test that session configuration validation rejects models with invalid API keys."""
+    monkeypatch.setenv("OPENAI_API_KEY", "__invalid__")
+    # test openai chat completions client
+    with pytest.raises(ConfigurationError, match="Incorrect API key provided: __invalid__."):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                language_models={"o3": OpenAILanguageModel(model_name="o3", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+
+    # test openai embedding client
+    with pytest.raises(ConfigurationError, match="Incorrect API key provided: __invalid__."):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                embedding_models={"oai-small": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+
+def test_session_config_with_invalid_gemini_api_key(monkeypatch):
+    """Test that session configuration validation rejects models with invalid Gemini API keys."""
+    pytest.importorskip("google")
+
+    monkeypatch.setenv("GEMINI_API_KEY", "__invalid__")
+    # test google developer chat completions client
+    with pytest.raises(ConfigurationError, match="API key not valid. Please pass a valid API key."):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                language_models={"gemini_2.5_pro": GoogleDeveloperLanguageModel(model_name="gemini-2.5-pro", rpm=100, tpm=1000)}
+            )
+        )   
+        _ = Session.get_or_create(config)
+
+    # test google developer embedding client
+    with pytest.raises(ConfigurationError, match="API key not valid. Please pass a valid API key."):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                embedding_models={"google_embed": GoogleDeveloperEmbeddingModel(model_name="gemini-embedding-001", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+    
+    # test google developer chat completions client
+    # mock default credentials error
+    import google.auth
+    from google.auth.exceptions import DefaultCredentialsError
+    monkeypatch.setattr(
+        google.auth,
+        "default",
+        lambda *a, **kw: (_ for _ in ()).throw(DefaultCredentialsError("No ADC"))
+    )
+    with pytest.raises(ConfigurationError, match="401 UNAUTHENTICATED"):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                language_models={"gemini_2.5_pro": GoogleVertexLanguageModel(model_name="gemini-2.5-pro", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+
+    # test google vertex embedding client
+    with pytest.raises(ConfigurationError, match="401 UNAUTHENTICATED"):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                embedding_models={"google_embed": GoogleVertexEmbeddingModel(model_name="gemini-embedding-001", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+
+def test_session_config_with_invalid_cohere_api_key(monkeypatch):
+    pytest.importorskip("cohere")
+    
+    monkeypatch.setenv("COHERE_API_KEY", "__invalid__")
+    # test cohere embedding client
+    with pytest.raises(ConfigurationError, match="invalid api token"):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                embedding_models={"cohere_embed": CohereEmbeddingModel(model_name="embed-v4.0", rpm=100, tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)
+
+def test_session_config_with_invalid_anthropic_api_key(monkeypatch):
+    pytest.importorskip("anthropic")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "__invalid__")
+    # test anthropic chat completions client
+    with pytest.raises(ConfigurationError, match="'type': 'authentication_error'"):
+        config = SessionConfig(
+            app_name="test_app",
+            semantic=SemanticConfig(
+                language_models={"claude": AnthropicLanguageModel(model_name="claude-opus-4-1", rpm=100, input_tpm=100, output_tpm=1000)}
+            )
+        )
+        _ = Session.get_or_create(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,7 @@ def pytest_addoption(parser):
 def embedding_model_name_and_dimensions(local_session) -> Tuple[str, int]:
     """Returns the embedding model name and dimensions for the default embedding model."""
     embedding_model = local_session._session_state.get_embedding_model()
-    embedding_model_name = f"{embedding_model.model_provider.value}/{embedding_model.model}"
+    embedding_model_name = f"{embedding_model.model_provider.name}/{embedding_model.model}"
     embedding_dimensions = embedding_model.model_parameters.default_dimensions
     return embedding_model_name, embedding_dimensions
 
@@ -234,8 +234,16 @@ def multi_model_local_session(multi_model_local_session_config, request):
 
 
 @pytest.fixture
-def local_session_config(app_name, request) -> SessionConfig:
-    """Creates a test session config."""
+def local_session_config(app_name, request, monkeypatch) -> SessionConfig:
+    """Creates a test session config.
+
+    Notes:
+        We mock the api key validation to avoid the noticeable delay of validating our api key in every test.
+    """
+    async def mock_validate_provider_api_keys(*args, **kwargs):
+        return
+    monkeypatch.setattr("fenic._backends.local.model_registry._validate_provider_api_keys", mock_validate_provider_api_keys)
+
     language_model_provider = ModelProvider(request.config.getoption(LANGUAGE_MODEL_PROVIDER_ARG))
     embedding_model_provider = ModelProvider(request.config.getoption(EMBEDDING_MODEL_PROVIDER_ARG))
     language_model = configure_language_model(language_model_provider, request.config.getoption(LANGUAGE_MODEL_NAME_ARG))


### PR DESCRIPTION
### TL;DR

Added API key validation for model providers during session initialization to catch bad API keys early.

### What changed?

- Implemented `validate_api_key()` method for all model clients (OpenAI, Anthropic, Google, Cohere)
- Added asynchronous validation of provider API keys during session creation
- Created a validation mechanism that runs once per provider to avoid redundant validation
- Added tests to verify behavior with invalid API keys for each provider

### How to test?

1. Create a session with an invalid API key for each provider.  Make sure it fails the validate step with an authentication-related failure
2. Run the new tests, with and without anthropic, cohere, and google

### Why make this change?

Previously, API key validation only happened when a model was actually used, which could lead to delayed errors during execution. This change provides immediate feedback during session initialization, helping users identify configuration issues early.