### PR TITLE
feat: local metrics table

### DIFF
--- a/src/fenic/_backends/cloud/metrics.py
+++ b/src/fenic/_backends/cloud/metrics.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 async def get_query_execution_metrics(client: Client, execution_id: str) -> QueryMetrics:
     """Get query execution metrics from the cloud catalog."""
     query_metrics = QueryMetrics(
+        execution_id=execution_id,
+        session_id=None,
         execution_time_ms=0,
         num_output_rows=0,
         total_lm_metrics=LMMetrics(),
@@ -27,6 +29,7 @@ async def get_query_execution_metrics(client: Client, execution_id: str) -> Quer
     cloud_query_metrics: ListQueryExecutionMetricByQueryExecutionId = await client.list_query_execution_metric_by_query_execution_id(execution_id)
     if cloud_query_metrics.typedef_query_execution_by_pk.query_execution_metrics:
         for metric in cloud_query_metrics.typedef_query_execution_by_pk.query_execution_metrics:
+            query_metrics.end_ts = metric.metric_timestamp
             if metric.metric_name == "execution_time_ms":
                 query_metrics.execution_time_ms = metric.metric_value
             elif metric.metric_name == "num_output_rows":

--- a/src/fenic/_backends/local/execution.py
+++ b/src/fenic/_backends/local/execution.py
@@ -115,7 +115,7 @@ class LocalExecution(BaseExecution):
                 )
             if mode == "ignore":
                 logger.warning(f"Table {table_name} already exists, ignoring write.")
-                return QueryMetrics()
+                return QueryMetrics(session_id=self.session_state.session_id)
             if mode == "append":
                 saved_schema = self.session_state.catalog.describe_table(table_name)
                 plan_schema = logical_plan.schema()
@@ -171,7 +171,7 @@ class LocalExecution(BaseExecution):
             )
         if mode == "ignore" and file_exists:
             logger.warning(f"File {file_path} already exists, ignoring write.")
-            return QueryMetrics()
+            return QueryMetrics(session_id=self.session_state.session_id)
 
         physical_plan = self.transpiler.transpile(logical_plan)
         try:

--- a/src/fenic/_backends/local/system_table_client.py
+++ b/src/fenic/_backends/local/system_table_client.py
@@ -8,7 +8,7 @@ represented in the physical storage system.
 import base64
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import duckdb
 
@@ -17,12 +17,22 @@ from fenic._backends.utils.catalog_utils import normalize_object_name
 from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core._serde import LogicalPlanSerde
 from fenic.core.error import CatalogError
-from fenic.core.types import Schema
+from fenic.core.metrics import QueryMetrics
+from fenic.core.types import ColumnField, Schema
+from fenic.core.types.datatypes import (
+    DoubleType,
+    IntegerType,
+    StringType,
+)
 
 # Constants for system schema and table names
-SYSTEM_SCHEMA_NAME = "__fenic_system"
+SYSTEM_SCHEMA_NAME = "__fenic_system" 
 SCHEMA_METADATA_TABLE = "table_schemas"
 VIEWS_METADATA_TABLE = "table_views"
+
+# Constants for read-only system schema and tables
+READ_ONLY_SYSTEM_SCHEMA_NAME = "fenic_system"
+METRICS_TABLE_NAME = "metrics"
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +49,10 @@ class SystemTableClient:
         Raises:
             CatalogError: If the initialization of tables for schema or view metadata fails
         """
-        self._initialize_system_schema(connection)
-        self._initialize_views_metadata(connection)
+        self.connection = connection
+        self._initialize_system_schema()
+        self._initialize_views_metadata()
+        self._initialize_read_only_system_schema_and_tables()
 
     def save_schema(self, cursor: duckdb.DuckDBPyConnection, database_name: str, table_name: str, schema: Schema) -> None:
         """Save a table's schema metadata to the system table. This is used for storing logical type information that can't be directly represented in the physical storage.
@@ -313,39 +325,13 @@ class SystemTableClient:
                 f"Failed to delete views metadata for database {database_name}"
             ) from e
 
-    def _initialize_system_schema(self, cursor: duckdb.DuckDBPyConnection) -> None:
-        """Initialize the system schema and metadata table for storing table schemas including logical type information.
-        Raises:
-            CatalogError: If the system schema or metadata table cannot be created.
-        """
-        try:
-            # Create system schema if it doesn't exist
-            cursor.execute(f'CREATE SCHEMA IF NOT EXISTS "{SYSTEM_SCHEMA_NAME}";')
-
-            # Create the schema metadata table if it doesn't exist
-            cursor.execute(
-                f"""
-                CREATE TABLE IF NOT EXISTS "{SYSTEM_SCHEMA_NAME}"."{SCHEMA_METADATA_TABLE}" (
-                    database_name TEXT NOT NULL,
-                    table_name TEXT NOT NULL,
-                    schema_blob TEXT NOT NULL,
-                    PRIMARY KEY (database_name, table_name)
-                );
-            """
-            )
-        except Exception as e:
-            raise CatalogError(
-                f"Failed to initialize system schema and {SCHEMA_METADATA_TABLE} table"
-            ) from e
-
-        logger.debug(f"Initialized system schema and {SCHEMA_METADATA_TABLE} table")
-
-    def _initialize_system_schema(self, cursor: duckdb.DuckDBPyConnection) -> None:
+    def _initialize_system_schema(self) -> None:
         """Initialize the system schema and metadata table for storing table schemas including logical type information.
 
         Raises:
             CatalogError: If the system schema or metadata table cannot be created.
         """
+        cursor = self.connection.cursor()
         try:
             # Create system schema if it doesn't exist
             cursor.execute(f'CREATE SCHEMA IF NOT EXISTS "{SYSTEM_SCHEMA_NAME}";')
@@ -368,11 +354,75 @@ class SystemTableClient:
 
         logger.debug(f"Initialized system schema and {SCHEMA_METADATA_TABLE} table")
 
-    def _initialize_views_metadata(self, cursor: duckdb.DuckDBPyConnection) -> None:
+    def _initialize_read_only_system_schema_and_tables(self) -> None:
+        """Initialize the read-only system schema and tables, including the metrics table.
+        Raises:
+            CatalogError: If the read-only system schema or tables cannot be created.
+        """
+        cursor = self.connection.cursor()
+        try:
+            cursor.execute(f'CREATE SCHEMA IF NOT EXISTS "{READ_ONLY_SYSTEM_SCHEMA_NAME}";')
+
+            cursor.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS "{READ_ONLY_SYSTEM_SCHEMA_NAME}"."{METRICS_TABLE_NAME}" (
+                    index INTEGER PRIMARY KEY,
+                    execution_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    execution_time_ms DOUBLE NOT NULL,
+                    num_output_rows INTEGER NOT NULL,
+                    start_ts TIMESTAMP NOT NULL,
+                    end_ts TIMESTAMP NOT NULL,
+                    total_lm_cost DOUBLE NOT NULL DEFAULT 0.0,
+                    total_lm_uncached_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_lm_cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_lm_output_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_lm_requests INTEGER NOT NULL DEFAULT 0,
+                    total_rm_cost DOUBLE NOT NULL DEFAULT 0.0,
+                    total_rm_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_rm_requests INTEGER NOT NULL DEFAULT 0
+                );
+            """
+            )
+            
+            # Define the schema for the system tables
+            metrics_schema = Schema(column_fields=[
+                ColumnField(name="index", data_type=IntegerType),
+                ColumnField(name="execution_id", data_type=StringType),
+                ColumnField(name="session_id", data_type=StringType),
+                ColumnField(name="execution_time_ms", data_type=DoubleType),
+                ColumnField(name="num_output_rows", data_type=IntegerType),
+                ColumnField(name="start_ts", data_type=StringType),  # Store as ISO timestamp string
+                ColumnField(name="end_ts", data_type=StringType),    # Store as ISO timestamp string
+                ColumnField(name="total_lm_cost", data_type=DoubleType),
+                ColumnField(name="total_lm_uncached_input_tokens", data_type=IntegerType),
+                ColumnField(name="total_lm_cached_input_tokens", data_type=IntegerType),
+                ColumnField(name="total_lm_output_tokens", data_type=IntegerType),
+                ColumnField(name="total_lm_requests", data_type=IntegerType),
+                ColumnField(name="total_rm_cost", data_type=DoubleType),
+                ColumnField(name="total_rm_input_tokens", data_type=IntegerType),
+                ColumnField(name="total_rm_requests", data_type=IntegerType),
+            ])
+            
+            # Save the schema to system tables
+            self.save_schema(
+                cursor=cursor,
+                database_name=READ_ONLY_SYSTEM_SCHEMA_NAME,
+                table_name=METRICS_TABLE_NAME,
+                schema=metrics_schema
+            )
+            
+        except Exception as e:
+            raise CatalogError(
+                f"Failed to initialize read-only system schema and tables: {e}"
+            ) from e
+
+    def _initialize_views_metadata(self) -> None:
         """Initialize the table for storing views metadata.
         Raises:
             CatalogError: If the views metadata table cannot be created.
         """
+        cursor = self.connection.cursor()
         try:
             # Create system schema if it doesn't exist
             cursor.execute(f'CREATE SCHEMA IF NOT EXISTS "{SYSTEM_SCHEMA_NAME}";')
@@ -395,3 +445,108 @@ class SystemTableClient:
             ) from e
 
         logger.debug(f"Initialized views and {VIEWS_METADATA_TABLE} table")
+
+    def insert_metrics(self, metrics: QueryMetrics) -> None:
+        """Append query execution metrics to the metrics table.
+
+        Uses atomic SQL to determine the next index value to prevent race conditions
+        in parallel sessions.
+
+        Args:
+            metrics: The QueryMetrics instance to store
+
+        Raises:
+            CatalogError: If the metrics cannot be saved
+        """
+        metrics_dict = metrics.to_dict()
+        cursor = self.connection.cursor()
+        try:
+            # trunk-ignore-begin(bandit/B608): No major risk of SQL injection here, this client is not exposed to the user.
+            cursor.execute(
+                f"""
+                INSERT INTO "{READ_ONLY_SYSTEM_SCHEMA_NAME}"."{METRICS_TABLE_NAME}" (
+                    index, execution_id, session_id, execution_time_ms, num_output_rows,
+                    start_ts, end_ts, total_lm_cost, total_lm_uncached_input_tokens, 
+                    total_lm_cached_input_tokens, total_lm_output_tokens, total_lm_requests,
+                    total_rm_cost, total_rm_input_tokens, total_rm_requests
+                )
+                SELECT 
+                    COALESCE(MAX(index), 0) + 1,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                FROM "{READ_ONLY_SYSTEM_SCHEMA_NAME}"."{METRICS_TABLE_NAME}"
+            """,
+                (
+                    metrics_dict["execution_id"],
+                    metrics_dict["session_id"],
+                    metrics_dict["execution_time_ms"],
+                    metrics_dict["num_output_rows"],
+                    metrics_dict["start_ts"],
+                    metrics_dict["end_ts"],
+                    metrics_dict["total_lm_cost"],
+                    metrics_dict["total_lm_uncached_input_tokens"],
+                    metrics_dict["total_lm_cached_input_tokens"],
+                    metrics_dict["total_lm_output_tokens"],
+                    metrics_dict["total_lm_requests"],
+                    metrics_dict["total_rm_cost"],
+                    metrics_dict["total_rm_input_tokens"],
+                    metrics_dict["total_rm_requests"],
+                ),
+            )
+            # trunk-ignore-end(bandit/B608)
+
+            logger.debug(f"Appended metrics for execution {metrics.execution_id}")
+        except Exception as e:
+            raise CatalogError(
+                f"Failed to append metrics for execution {metrics.execution_id}: {e}"
+            ) from e
+
+    def get_metrics_for_session(self, session_id: str) -> Dict[str, float]:
+        """Get aggregated metrics and costs for a specific session.
+
+        Args:
+            session_id: The session ID to aggregate costs for
+
+        Returns:
+            Dictionary containing aggregated cost information
+
+        Raises:
+            CatalogError: If there's an error retrieving the costs
+        """
+        cursor = self.connection.cursor()
+        try:
+            # trunk-ignore-begin(bandit/B608): No major risk of SQL injection here, this client is not exposed to the user.
+            result = cursor.execute(
+                f"""
+                SELECT 
+                    SUM(total_lm_cost) as total_lm_cost,
+                    SUM(total_rm_cost) as total_rm_cost,
+                    COUNT(*) as query_count,
+                    SUM(execution_time_ms) as total_execution_time_ms,
+                    SUM(num_output_rows) as total_output_rows
+                FROM "{READ_ONLY_SYSTEM_SCHEMA_NAME}"."{METRICS_TABLE_NAME}"
+                WHERE session_id = ?
+            """,
+                (session_id,),
+            ).fetchone()
+            # trunk-ignore-end(bandit/B608)
+            if result is None:
+                return {
+                    "total_lm_cost": 0.0,
+                    "total_rm_cost": 0.0,
+                    "query_count": 0,
+                    "total_execution_time_ms": 0.0,
+                    "total_output_rows": 0,
+                }
+
+            return {
+                "total_lm_cost": result[0],
+                "total_rm_cost": result[1],
+                "query_count": result[2],
+                "total_execution_time_ms": result[3],
+                "total_output_rows": result[4],
+            }
+            
+        except Exception as e:
+            raise CatalogError(
+                f"Failed to get session aggregate costs for {session_id}: {e}"
+            ) from e

--- a/src/fenic/_backends/utils/catalog_utils.py
+++ b/src/fenic/_backends/utils/catalog_utils.py
@@ -108,6 +108,14 @@ class TableIdentifier(BaseIdentifier):
             table=self.table,
         )
 
+    def build_qualified_table_name(self) -> str:
+        """Build a qualified table name."""
+        return f'"{self.db}"."{self.table}"'
+
+    def __str__(self) -> str:
+        """String representation of the table identifier."""
+        return f'{self.db}.{self.table}'
+
 
 @dataclass(frozen=True)
 class DBIdentifier(BaseIdentifier):

--- a/src/fenic/api/session/session.py
+++ b/src/fenic/api/session/session.py
@@ -335,7 +335,10 @@ class Session:
         )
 
     def stop(self):
-        """Stops the session and closes all connections."""
+        """Stops the session and closes all connections.
+
+        A summary of your session's metrics will print once you stop your session.
+        """
         self._session_state.stop()
 
 

--- a/tests/_backends/local/catalog/test_metrics_table.py
+++ b/tests/_backends/local/catalog/test_metrics_table.py
@@ -1,0 +1,156 @@
+import pytest
+
+from fenic import (
+    Session,
+    SessionConfig,
+)
+from fenic.core.error import CatalogError
+
+
+def test_metrics_table_created_automatically(local_session: Session):
+    """Test that metrics table is automatically created and appears in catalog."""
+    # Metrics table should be created automatically when session starts
+    assert local_session.catalog.does_table_exist("fenic_system.metrics")
+    
+    # Should be listed in tables in the fenic_system database
+    current_db = local_session.catalog.get_current_database()
+    local_session.catalog.set_current_database("fenic_system")
+    tables = local_session.catalog.list_tables()
+    assert "metrics" in tables
+    local_session.catalog.set_current_database(current_db)
+
+
+def test_metrics_table_schema(local_session: Session):
+    """Test that metrics table has correct schema."""
+    schema = local_session.catalog.describe_table("fenic_system.metrics")
+    
+    # Check that all required columns exist
+    column_names = [field.name for field in schema.column_fields]
+    expected_columns = [
+        "index", "execution_id", "session_id", "execution_time_ms",
+        "num_output_rows", "start_ts", "end_ts", "total_lm_cost",
+        "total_lm_uncached_input_tokens", "total_lm_cached_input_tokens",
+        "total_lm_output_tokens", "total_lm_requests", "total_rm_cost",
+        "total_rm_input_tokens", "total_rm_requests"
+    ]
+    
+    for col in expected_columns:
+        assert col in column_names, f"Missing column: {col}"
+
+
+def test_metrics_table_read_only_protection(local_session: Session):
+    """Test that metrics table cannot be modified by users."""
+    with pytest.raises(CatalogError, match="Cannot drop table.*from read-only system database"):
+        local_session.catalog.drop_table("fenic_system.metrics")
+
+
+def test_metrics_collected_on_dataframe_operations(local_session: Session, sample_df):
+    """Test that metrics are collected when DataFrames are executed."""
+    # Get initial row count
+    initial_metrics = local_session.table("fenic_system.metrics")
+    initial_count = initial_metrics.count()
+    
+    # Execute some operations
+    sample_df.show()  # This should add 1 metric row
+    sample_df.count()  # This should add another metric row
+    sample_df.collect()  # This should add another metric row
+    
+    # Check that metrics were added
+    final_metrics = local_session.table("fenic_system.metrics")
+    final_count = final_metrics.count() # This adds a 4th entry
+    
+    assert final_count == initial_count + 4, f"Expected 4 new metrics, got {final_count - initial_count}"
+
+
+def test_metrics_session_id(local_session: Session, sample_df):
+    """Test that we can read metrics table as a DataFrame."""
+    # Execute an operation to generate metrics
+    sample_df.show()
+    
+    # Read metrics table as DataFrame
+    metrics_df = local_session.table("fenic_system.metrics")
+    result = metrics_df.collect()
+    
+    assert len(result.data) > 0
+    # Check that session_id matches current session
+    querymetrics_session_id = result.metrics.session_id
+    table_session_id = result.data["session_id"][0]
+
+    assert local_session._session_state.session_id == querymetrics_session_id
+    assert local_session._session_state.session_id == table_session_id
+
+
+def test_metrics_table_contains_execution_data(local_session: Session, sample_df):
+    """Test that metrics table contains expected execution data."""
+    # Get initial state
+    initial_metrics = local_session.table("fenic_system.metrics")
+    initial_metrics.count()
+    
+    # Execute operation
+    result = sample_df.collect()
+    expected_rows = len(result.data)
+    execution_id = result.metrics.execution_id
+    
+    # Get final state
+    metrics_data = local_session.table("fenic_system.metrics").collect().data
+    
+    # Should have new metric row
+    assert len(metrics_data) > 0
+    
+    # Check the latest metric entry
+    latest_metric = metrics_data[-1]
+    assert latest_metric["session_id"][0] == local_session._session_state.session_id
+    assert latest_metric["num_output_rows"][0] == expected_rows
+    assert latest_metric["execution_time_ms"][0] >= 0
+    assert latest_metric["execution_id"][0] == execution_id
+    assert latest_metric["start_ts"][0] is not None
+    assert latest_metric["end_ts"][0] is not None
+
+
+def test_multiple_sessions_different_metrics(local_session_config):
+    """Test that different sessions have separate metrics tracking."""
+    # Create first session and run queries
+    session1 = Session.get_or_create(local_session_config)
+    df1 = session1.create_dataframe({"a": [1, 2, 3]})
+    df1.show()  # 1 query
+    df1.count()  # 1 query
+    
+    session1_id = session1._session_state.session_id
+    
+    # Create second session with different config
+    session_config2 = SessionConfig(
+        app_name="metrics_test_2",
+        semantic=local_session_config.semantic
+    )
+    session2 = Session.get_or_create(session_config2)
+    df2 = session2.create_dataframe({"a": [1, 2, 3]})
+    df2.show()  # 1 query
+    
+    session2_id = session2._session_state.session_id
+    
+    try:
+        # Check metrics for session1 - need to account for count() calls adding metrics
+        metrics1_data = session1.table("fenic_system.metrics").filter(
+            session1.table("fenic_system.metrics")["session_id"] == session1_id
+        ).collect().data
+        count1 = len(metrics1_data)
+        
+        # Check metrics for session2 - need to account for collect() call adding metrics
+        metrics2_data = session2.table("fenic_system.metrics").filter(
+            session2.table("fenic_system.metrics")["session_id"] == session2_id
+        ).collect().data
+        count2 = len(metrics2_data)
+        
+        # Session1 should have 2 metrics, for show and count
+        assert count1 == 2, f"Session1 should have 2 metrics, got {count1}"
+        
+        # Session2 should have 1 metric, for show
+        assert count2 == 1, f"Session2 should have 1 metric, got {count2}"
+        
+        assert session1_id != session2_id
+        
+    finally:
+        # Clean up sessions
+        session1.stop()
+        session2.stop()
+


### PR DESCRIPTION
### TL;DR

Added a metrics tracking system that automatically records query execution statistics in a read-only `metrics` table.

### What changed?

- Created a new read-only `metrics` table that tracks query execution statistics
- Added concept of read-only database in the catalog: `fenic_system`
- Added ability to System_Table_client to insert metrics and aggregate from last session
- Added ability for session to manage metrics table through catalog api
- Enhanced `QueryMetrics` with session tracking and timestamp information
- Added session usage summary that displays at the end of a session

### Example Output on session.close():

Session Usage Summary:
App Name: test_app
Session ID: 268f2b29-096a-4a90-bbd2-abb02e9a382b
Total queries executed: 4
Total execution time: 15.22ms
Total rows processed: 10
Total language model cost: $0.000000
Total embedding model cost: $0.000000
Total cost: $0.000000

### How to test?

1. Run queries and verify metrics are being collected:
2. Verify read-only protection works:
3. Test session usage summary by stopping a session:

### Why make this change?

This change enables automatic tracking of query execution metrics, providing users with insights into their session's performance and cost. The metrics table stores information about execution time, row counts, token usage, and estimated costs, which helps users understand and optimize their queries. The session summary provides a convenient overview of resource usage when a session ends.