### PR TITLE
fix: shutdown event loop and cancel tasks on program exit

### DIFF
--- a/src/fenic/_backends/local/manager.py
+++ b/src/fenic/_backends/local/manager.py
@@ -46,6 +46,7 @@ class LocalSessionManager:
         """
         with self._sessions_lock:
             if app_name not in self._live_session_states:
+                logger.info(f"Redundant stop request: session.stop() invoked for {app_name}, which is already stopped")
                 return
             session_state: LocalSessionState = self._live_session_states[
                 app_name


### PR DESCRIPTION
Here's a cleaned up PR description:

**Fix async task cleanup on interpreter shutdown and optimize generator handling**

This PR addresses two issues:

1. **Prevents "Task was destroyed but it is pending!" errors on program exit**
   - The background asyncio thread runs long-running actors that continue executing when the program shuts down
   - Without proper cleanup, these actors can't be cancelled, resulting in "Task was destroyed but it is pending!" errors
   - This PR registers an `atexit` handler to properly cancel tasks, shutdown the event loop, and join the background thread
   - The background thread still needs `daemon=True` because with `daemon=False`, the interpreter won't shut down until the thread is joined. This would require signaling shutdown through an event when the user script terminates, but there's no reliable way to detect when the user's script has finished executing
   - The `atexit` approach ensures graceful cleanup while allowing normal interpreter shutdown

2. **Optimizes Polars Series construction from generators**
   - Passes generators directly to `pl.Series()` constructor instead of exhausting them first
   - Lets Polars handle the generator consumption internally for better performance