### PR TITLE
fix: add retry to OpenAI for 404 errors when no processing was done

### DIFF
--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -7,6 +7,7 @@ from openai import (
     APIConnectionError,
     APITimeoutError,
     AsyncOpenAI,
+    NotFoundError,
     OpenAIError,
     RateLimitError,
 )
@@ -177,6 +178,18 @@ class OpenAIChatCompletionsCore:
 
         except (RateLimitError, APITimeoutError, APIConnectionError) as e:
             return TransientException(e)
+
+        except NotFoundError as e:
+            # During our CI tests, where we run a larger set of tests, we've seen an intermittent 404 error
+            # that is not coming from OpenAI.
+            # Usually 404 errors should be considered as fatal, as there is no use in retrying them,
+            # in this case some of the requests have succeeded, so we're marking this as transient and as such
+            # the request will be retried.
+            if e.response.headers.get("openai-processing-ms") == "0":
+                logger.error("404 with zero processing time → likely routing glitch - Marking this as transient.")
+                return TransientException(e)
+            else:
+                return FatalException(e)
 
         except OpenAIError as e:
             return FatalException(e)


### PR DESCRIPTION
### TL;DR

Added a TransientException if we get a 404 and no processing from OpenAI.
Fenic's batch processing should be able to handle the exception and perform the retry.

### What changed?

- The error handling for both openai chat and embeddings now handle the NotFoundError. if we have the headers and the headers indicate no work was done on OpenAI, we'll retry the operation.

