### PR TITLE
fix: regression when using google provider and logger level DEBUG

### DIFF
--- a/src/fenic/_inference/google/google_provider.py
+++ b/src/fenic/_inference/google/google_provider.py
@@ -23,7 +23,7 @@ class GoogleModelProvider(ModelProviderClass):
         client = self.create_client()
         aio_client = client.aio
         _ = await aio_client.models.list()
-        logger.debug(f"Google API key validation successful for {self._provider_type}")
+        logger.debug(f"Google API key validation successful for {self.name}")
 
     def create_aio_client(self):
         """Create a Google async client instance."""


### PR DESCRIPTION
### TL;DR

Fixed a logging statement in the Google provider to use the correct attribute name.

### How to test?

1. Configure a Google provider with a valid API key
2. Enable debug logging
3. Run a validation of the API key
4. Verify that the debug log shows the correct provider name

