### PR TITLE
fix: Add 'self' to model_provider abstract methods

### DIFF
--- a/src/fenic/core/_inference/model_provider.py
+++ b/src/fenic/core/_inference/model_provider.py
@@ -15,7 +15,7 @@ class ModelProviderClass(ABC):
         pass
     
     @abstractmethod
-    def create_client():
+    def create_client(self):
         """Create a synchronous client for this provider.
         
         Returns the provider-specific synchronous client instance configured with the
@@ -24,7 +24,7 @@ class ModelProviderClass(ABC):
         pass
 
     @abstractmethod
-    def create_aio_client():
+    def create_aio_client(self):
         """Create an async client for this provider.
 
         Returns the provider-specific asynchronous client instance configured with the
@@ -33,7 +33,7 @@ class ModelProviderClass(ABC):
         pass
     
     @abstractmethod
-    async def validate_api_key() -> None:
+    async def validate_api_key(self) -> None:
         """Validate the API key for this provider.
         
         This method should create the appropriate client and perform a lightweight 


### PR DESCRIPTION
### What changed?

Added the missing `self` parameter to three abstract methods in the `ModelProvider` class

addresses https://github.com/typedef-ai/fenic/issues/180

### How to test?

1. Verify that implementations of the `ModelProvider` class can properly override these methods
2. Ensure that existing implementations still work correctly with this change
3. Run any tests that involve model provider implementations

### Why make this change?

This fix ensures that the abstract methods properly define the expected method signature for all implementations, maintaining proper object-oriented design principles.