### PR TITLE
fix: cloud execution save_ methods should get metrics from backend

### DIFF
--- a/src/fenic/_backends/cloud/execution.py
+++ b/src/fenic/_backends/cloud/execution.py
@@ -43,7 +43,7 @@ from fenic.core.error import (
     InternalError,
     ValidationError,
 )
-from fenic.core.metrics import LMMetrics, PhysicalPlanRepr, QueryMetrics, RMMetrics
+from fenic.core.metrics import QueryMetrics
 from fenic.core.types import Schema
 
 if TYPE_CHECKING:
@@ -184,14 +184,8 @@ class CloudExecution(BaseExecution):
             ),
             self.session_state.asyncio_loop,
         )
-        _ = future.result()
-        return QueryMetrics(
-            execution_time_ms=0.0,
-            num_output_rows=0,
-            total_lm_metrics=LMMetrics(),
-            total_rm_metrics=RMMetrics(),
-            _plan_repr=PhysicalPlanRepr(operator_id="empty"),
-        )
+        execution_id = future.result()
+        return self._get_query_execution_metrics(execution_id)
 
     def save_as_view(
         self,
@@ -236,14 +230,8 @@ class CloudExecution(BaseExecution):
             ),
             self.session_state.asyncio_loop,
         )
-        _ = future.result()
-        return QueryMetrics(
-            execution_time_ms=0.0,
-            num_output_rows=0,
-            total_lm_metrics=LMMetrics(),
-            total_rm_metrics=RMMetrics(),
-            _plan_repr=PhysicalPlanRepr(operator_id="empty"),
-        )
+        execution_id = future.result()
+        return self._get_query_execution_metrics(execution_id)
 
     def infer_schema_from_csv(
         self, paths: list[str], **options: Dict[str, Any]

--- a/src/fenic/core/_inference/model_provider.py
+++ b/src/fenic/core/_inference/model_provider.py
@@ -15,7 +15,7 @@ class ModelProviderClass(ABC):
         pass
     
     @abstractmethod
-    def create_client():
+    def create_client(self):
         """Create a synchronous client for this provider.
         
         Returns the provider-specific synchronous client instance configured with the
@@ -24,7 +24,7 @@ class ModelProviderClass(ABC):
         pass
 
     @abstractmethod
-    def create_aio_client():
+    def create_aio_client(self):
         """Create an async client for this provider.
 
         Returns the provider-specific asynchronous client instance configured with the
@@ -33,7 +33,7 @@ class ModelProviderClass(ABC):
         pass
     
     @abstractmethod
-    async def validate_api_key() -> None:
+    async def validate_api_key(self) -> None:
         """Validate the API key for this provider.
         
         This method should create the appropriate client and perform a lightweight 


### PR DESCRIPTION
### TL;DR

Return actual query metrics for `save_as_table` and `save_to_file` operations instead of empty metrics, and fix cloud unit tests.

### What changed?

Modified the `save_as_table` and `save_to_file` methods in the cloud execution backend to return actual query execution metrics instead of empty placeholder metrics. This also fixes cloud unit tests, which broke with QueryMetric changes in 0.4.0.  Both methods now call `self._get_query_execution_metrics()` with the execution ID returned from the future result.

### How to test?

1. Run cloud unit tests, which test the save_as_file path

