### PR TITLE
fix: enforce that return types of all branches in conditional chains are equal and handle child exprs in IsNullExpr

### DIFF
--- a/src/fenic/_backends/local/system_table_client.py
+++ b/src/fenic/_backends/local/system_table_client.py
@@ -605,7 +605,7 @@ class SystemTableClient:
                 ),
             )
             # trunk-ignore-end(bandit/B608)
-            logger.info(f"Appended metrics for execution {metrics.execution_id}")
+            logger.debug(f"Appended metrics for execution {metrics.execution_id}")
         except Exception as e:
             raise CatalogError(
                 f"Failed to append metrics for execution {metrics.execution_id}: {e}"

--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -438,7 +438,7 @@ class ExprConverter:
         elif logical.input_type == "struct":
             return base_expr.struct.field(logical.index.literal)
         else:
-            raise NotImplementedError(f"Unsupported index key type: {type(logical.index)}")
+            raise InternalError(f"Unsupported index key type: {logical.input_type}")
 
 
     @_convert_expr.register(TsParseExpr)

--- a/src/fenic/core/_logical_plan/expressions/basic.py
+++ b/src/fenic/core/_logical_plan/expressions/basic.py
@@ -248,7 +248,7 @@ class StructExpr(ValidatedDynamicSignature, UnparameterizedExpr, LogicalExpr):
 
 class UDFExpr(LogicalExpr):
     """User-defined function expression.
-    
+
     Warning:
         UDFExpr cannot be serialized and is not supported in cloud execution.
         This expression contains arbitrary Python code that cannot be transmitted
@@ -285,7 +285,7 @@ class UDFExpr(LogicalExpr):
 
 class AsyncUDFExpr(LogicalExpr):
     """Expression for async user-defined functions with configurable concurrency and retries."""
-    
+
     def __init__(
         self,
         func: Callable,
@@ -317,7 +317,7 @@ class AsyncUDFExpr(LogicalExpr):
     def _eq_specific(self, other: AsyncUDFExpr) -> bool:
         # For dynamic UDFs, we can only check identity since its tricky to compare Callables
         return (
-            self.func is other.func 
+            self.func is other.func
             and self.return_type == other.return_type
             and self.max_concurrency == other.max_concurrency
             and self.timeout_seconds == other.timeout_seconds
@@ -335,6 +335,7 @@ class IsNullExpr(LogicalExpr):
         return f"{self.expr} IS {'' if self.is_null else 'NOT'} NULL"
 
     def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
+        _ = self.expr.to_column_field(plan, session_state)
         return ColumnField(str(self), BooleanType)
 
     def children(self) -> List[LogicalExpr]:

--- a/src/fenic/core/_logical_plan/expressions/case.py
+++ b/src/fenic/core/_logical_plan/expressions/case.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from fenic.core._interfaces.session_state import BaseSessionState
 from fenic.core._logical_plan.expressions.base import LogicalExpr, UnparameterizedExpr
+from fenic.core.error import TypeMismatchError, ValidationError
 from fenic.core.types import BooleanType, ColumnField
 
 
@@ -15,15 +16,26 @@ class WhenExpr(UnparameterizedExpr, LogicalExpr):
         self.expr = expr
         self.condition = condition
         self.value = value
+        if expr is not None and not isinstance(expr, WhenExpr):
+            raise ValidationError("Column.when() can only be called on when() expressions")
 
     def __str__(self):
         return f"{'CASE' if self.expr is None else self.expr} WHEN ({self.condition}) THEN ({self.value})"
 
     def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
-        if self.condition.to_column_field(plan, session_state).data_type != BooleanType:
-            raise TypeError(
+        if self.expr is not None:
+            expr_type = self.expr.to_column_field(plan, session_state).data_type
+            value_type = self.value.to_column_field(plan, session_state).data_type
+            if expr_type != value_type:
+                raise TypeMismatchError.from_message(
+                    f"Type mismatch in when(): all case branches must return the same type. "
+                    f"Previous branch has type {expr_type}, but this branch has type {value_type}."
+                )
+        condition_type = self.condition.to_column_field(plan, session_state).data_type
+        if condition_type != BooleanType:
+            raise TypeMismatchError.from_message(
                 "when() condition must be a boolean expression.  Got type: "
-                f"{self.condition.to_column_field(plan, session_state).data_type}"
+                f"{condition_type}"
             )
 
         return self.value.to_column_field(plan, session_state)
@@ -41,13 +53,21 @@ class OtherwiseExpr(UnparameterizedExpr, LogicalExpr):
         self.expr = expr
         self.value = value
         if not isinstance(self.expr, WhenExpr):
-            raise TypeError("otherwise() can only be called on when() expressions")
+            raise ValidationError("Column.otherwise() can only be called on when() expressions")
 
     def __str__(self):
         return f"{self.expr} ELSE ({self.value})"
 
     def to_column_field(self, plan: LogicalPlan, session_state: BaseSessionState) -> ColumnField:
-        return self.value.to_column_field(plan, session_state)
+        when_expr_type = self.expr.to_column_field(plan, session_state).data_type
+        value_field = self.value.to_column_field(plan, session_state)
+        if when_expr_type != value_field.data_type:
+            raise TypeMismatchError.from_message(
+                f"Type mismatch in otherwise(): when/then expression has type "
+                f"{when_expr_type}, but otherwise() value has type {value_field.data_type}. "
+                f"Both branches must return the same type."
+            )
+        return value_field
 
     def children(self) -> List[LogicalExpr]:
         return [self.expr, self.value]

--- a/tests/_logical_plan/serde/test_expression_serde.py
+++ b/tests/_logical_plan/serde/test_expression_serde.py
@@ -305,7 +305,7 @@ expression_examples = {
     WhenExpr: [
         WhenExpr(expr=None,condition=ColumnExpr("condition"), value=LiteralExpr("result", StringType)),
         WhenExpr(
-            expr=ColumnExpr("expr"),
+            expr=WhenExpr(expr=None,condition=ColumnExpr("condition"), value=LiteralExpr("result", StringType)),
             condition=LiteralExpr(True, BooleanType),
             value=LiteralExpr("true_result", StringType),
         ),

--- a/tests/_logical_plan/test_expression_equality.py
+++ b/tests/_logical_plan/test_expression_equality.py
@@ -514,8 +514,8 @@ class TestCaseExpressions:
         assert when1 == when2
 
         # Both with non-None expr
-        when3 = WhenExpr(col, cond, val)
-        when4 = WhenExpr(col, cond, val)
+        when3 = WhenExpr(when1, cond, val)
+        when4 = WhenExpr(when2, cond, val)
         assert when3 == when4
 
         # One None, one not None


### PR DESCRIPTION
1. Validate that all branch return types in when/when/otherwise are equal
   - Previously did not validate this and did not call to_column_field for all branches
   - This led to invalid expression trees that fail during runtime and not planning time

2. Disallow Column.when() variant to be called on non-when expressions
   - PySpark allows this but effectively ignores the non-when expression
   - This violates principle of least surprise, so we error out instead

3. Call to_column_field for NullExpr children and add test validating for this

4. Change appended metric log level from debug to info
   - Too noisy for default configure_logging() setup

5. Clean up docstrings for when/when/otherwise
   - Make behavior more explicit
   - Remove confusing descriptions about "list of conditions"
   - Add notes about type consistency requirements