### PR TITLE
fix: when querying files in public S3 buckets/HuggingFace Datasets, the user should not have to provide credentials

### DIFF
--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -92,7 +92,7 @@ def query_files(query: str, paths: List[str], s3_session: BotoSession) -> pl.Dat
                 if has_hf_creds:
                     message = f"Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: {e.status_code})"
                 else:
-                    message = f"Failed to read from Hugging Face -- credentials were not found and the dataset is private or gated. (Status code: {e.status_code})"
+                    message = f"Failed to read from Hugging Face -- credentials were not found and the dataset is private or gated. Set HF_TOKEN environment variable. (Status code: {e.status_code})"
             else:
                 message = f"Failed to read from Hugging Face. {e}"
         else:

--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -131,7 +131,7 @@ def write_file(
     except duckdb.Error as e:
         logger.debug("DuckDB write query failed for path=%s: %s", path, e, exc_info=True)
         if scheme == "s3":
-            message = "Failed to write to S3. Ensure AWS credentials permit write access and the bucket/path exist."
+            message = f"Failed to write to S3. Ensure AWS credentials permit write access and the bucket/path exist. {e}"
         else:
             message = "Failed to write file. Verify the destination path exists and is writable."
         raise FileLoaderError(message) from e

--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -10,7 +10,7 @@ import polars as pl
 from boto3.session import Session as BotoSession
 from botocore.credentials import ReadOnlyCredentials
 
-from fenic.core.error import ConfigurationError, ValidationError
+from fenic.core.error import ConfigurationError, FileLoaderError, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +57,50 @@ def query_files(query: str, paths: List[str], s3_session: BotoSession) -> pl.Dat
     if has_s3_paths or has_hf_paths:
         query = _build_query_with_httpfs_extensions(query)
         if has_s3_paths:
-            query = _build_query_with_s3_creds(query, s3_session)
+            query, has_s3_creds = _build_query_with_s3_creds(query, s3_session)
+            if not has_s3_creds:
+                logger.warning(
+                    "Unable to locate AWS credentials for fetching data from S3 -- will still attempt to do so, "
+                    "but the query will fail unless the data is in a public bucket."
+                )
         if has_hf_paths:
-            query = _build_query_with_hf_creds(query)
-
-    arrow_result = duckdb_conn.execute(query).arrow()
-    return pl.from_arrow(arrow_result)
+            query, has_hf_creds = _build_query_with_hf_creds(query)
+            if not has_hf_creds:
+                logger.warning(
+                    "HuggingFace token not found. Will attempt to read dataset, this will fail if the dataset is private or gated."
+                    "Set HF_TOKEN environment variable to authenticate to HuggingFace."
+                )
+    try:
+        arrow_result = duckdb_conn.execute(query).arrow()
+        return pl.from_arrow(arrow_result)
+    except duckdb.HTTPException as e:
+        logger.debug("DuckDB read query failed for paths=%s: %s", paths, e, exc_info=True)
+        if has_s3_paths:
+            if e.status_code == 404:
+                message = "Failed to read from S3. The object does not exist."
+            elif e.status_code == 401 or e.status_code == 403:
+                if has_s3_creds:
+                    message = ("Failed to read from S3. The provided credentials do not have the required permissions.")
+                else:
+                    message = ("Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable.")
+            else:
+                message = f"Failed to read from S3. {e}"
+        elif has_hf_paths:
+            if e.status_code == 404:
+                message = "Failed to read from Hugging Face. The object does not exist."
+            elif e.status_code == 401 or e.status_code == 403:
+                if has_hf_creds:
+                    message = "Failed to read from Hugging Face. Ensure the path exists and that the provided credentials have the required permissions."
+                else:
+                    message = "Failed to read from Hugging Face. Credentials were not found. Set HF_TOKEN environment variable."
+            else:
+                message = f"Failed to read from Hugging Face. {e}"
+        else:
+            message = "Failed to read from HTTPFS. Verify the path(s) exist and are readable."
+        raise FileLoaderError(message) from e
+    except duckdb.Error as e:
+        logger.debug("DuckDB read query failed for paths=%s: %s", paths, e, exc_info=True)
+        raise FileLoaderError(e) from e
 
 
 def write_file(
@@ -85,9 +123,18 @@ def write_file(
     scheme = urlparse(path).scheme
     if scheme == "s3":
         query = _build_query_with_httpfs_extensions(query)
-        query = _build_query_with_s3_creds(query, s3_session)
-
-    duckdb_conn.execute(query)
+        query, has_s3_creds = _build_query_with_s3_creds(query, s3_session)
+        if not has_s3_creds:
+            raise ConfigurationError("AWS credentials were not found. Configure AWS credentials (env/aws_config) to write to S3.")
+    try:
+        duckdb_conn.execute(query)
+    except duckdb.Error as e:
+        logger.debug("DuckDB write query failed for path=%s: %s", path, e, exc_info=True)
+        if scheme == "s3":
+            message = "Failed to write to S3. Ensure AWS credentials permit write access and the bucket/path exist."
+        else:
+            message = "Failed to write file. Verify the destination path exists and is writable."
+        raise FileLoaderError(message) from e
 
 
 def _fetch_and_validate_s3_credentials(s3_session: BotoSession) -> Tuple[ReadOnlyCredentials, str]:
@@ -113,7 +160,7 @@ def _build_query_with_httpfs_extensions(query: str) -> str:
     """Helper method to add httpfs extensions to a DuckDB query."""
     return f"INSTALL httpfs; LOAD httpfs; {query}"
 
-def _build_query_with_s3_creds(query: str, s3_session: BotoSession) -> str:
+def _build_query_with_s3_creds(query: str, s3_session: BotoSession) -> tuple[str, bool]:
     """Helper method to add AWS credentials to a DuckDB query."""
     try:
         frozen_creds, region = _fetch_and_validate_s3_credentials(s3_session)
@@ -123,19 +170,22 @@ def _build_query_with_s3_creds(query: str, s3_session: BotoSession) -> str:
         if frozen_creds.token:
             s3_setup_query += f"SET s3_session_token='{frozen_creds.token}'; "
         query = f"{s3_setup_query} {query}"
+        return query, True
     except ConfigurationError:
-        logger.warning("Unable to locate AWS credentials for fetching data from S3 -- will still attempt to do so,"
-                        "but the query will fail unless the data is in a public accessible bucket.")
-        return query
+        return query, False
 
 
-def _build_query_with_hf_creds(query: str) -> str:
+def _build_query_with_hf_creds(query: str) -> tuple[str, bool]:
     """Helper method to add HuggingFace credentials to a DuckDB query."""
     hf_token = _fetch_hf_token()
     if not hf_token:
-        raise ConfigurationError("HuggingFace token not found. Set HF_TOKEN environment variable.")
+        logger.warning(
+            "HuggingFace token not found. Will attempt to read dataset, this will fail if the dataset is private or gated."
+            "Set HF_TOKEN environment variable to authenticate to HuggingFace."
+        )
+        return query, False
 
-    return f"CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN '{hf_token}'); {query}"
+    return f"CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN '{hf_token}'); {query}", True
 
 def configure_duckdb_conn_for_path(db_path: Path) -> duckdb.DuckDBPyConnection:
     """Create a duckdb connection for a given path, applying common configuration."""

--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -67,7 +67,7 @@ def query_files(query: str, paths: List[str], s3_session: BotoSession) -> pl.Dat
             query, has_hf_creds = _build_query_with_hf_creds(query)
             if not has_hf_creds:
                 logger.warning(
-                    "HuggingFace token not found. Will attempt to read dataset, this will fail if the dataset is private or gated."
+                    "HuggingFace token not found. Will attempt to read dataset, this will fail if the dataset is private or gated. "
                     "Set HF_TOKEN environment variable to authenticate to HuggingFace."
                 )
     try:
@@ -80,9 +80,9 @@ def query_files(query: str, paths: List[str], s3_session: BotoSession) -> pl.Dat
                 message = "Failed to read from S3. The object does not exist."
             elif e.status_code == 401 or e.status_code == 403:
                 if has_s3_creds:
-                    message = ("Failed to read from S3. The provided credentials do not have the required permissions.")
+                    message = f"Failed to read from S3. The provided credentials do not have the required permissions. (Status code: {e.status_code})"
                 else:
-                    message = ("Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable.")
+                    message = f"Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: {e.status_code})"
             else:
                 message = f"Failed to read from S3. {e}"
         elif has_hf_paths:
@@ -90,9 +90,9 @@ def query_files(query: str, paths: List[str], s3_session: BotoSession) -> pl.Dat
                 message = "Failed to read from Hugging Face. The object does not exist."
             elif e.status_code == 401 or e.status_code == 403:
                 if has_hf_creds:
-                    message = "Failed to read from Hugging Face. Ensure the path exists and that the provided credentials have the required permissions."
+                    message = f"Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: {e.status_code})"
                 else:
-                    message = "Failed to read from Hugging Face. Credentials were not found. Set HF_TOKEN environment variable."
+                    message = f"Failed to read from Hugging Face -- credentials were not found and the dataset is private or gated. (Status code: {e.status_code})"
             else:
                 message = f"Failed to read from Hugging Face. {e}"
         else:
@@ -179,10 +179,6 @@ def _build_query_with_hf_creds(query: str) -> tuple[str, bool]:
     """Helper method to add HuggingFace credentials to a DuckDB query."""
     hf_token = _fetch_hf_token()
     if not hf_token:
-        logger.warning(
-            "HuggingFace token not found. Will attempt to read dataset, this will fail if the dataset is private or gated."
-            "Set HF_TOKEN environment variable to authenticate to HuggingFace."
-        )
         return query, False
 
     return f"CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN '{hf_token}'); {query}", True

--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -115,14 +115,18 @@ def _build_query_with_httpfs_extensions(query: str) -> str:
 
 def _build_query_with_s3_creds(query: str, s3_session: BotoSession) -> str:
     """Helper method to add AWS credentials to a DuckDB query."""
-    frozen_creds, region = _fetch_and_validate_s3_credentials(s3_session)
-    s3_setup_query = f"SET s3_region='{region}'; "
-    s3_setup_query += f"SET s3_access_key_id='{frozen_creds.access_key}'; "
-    s3_setup_query += f"SET s3_secret_access_key='{frozen_creds.secret_key}'; "
-    if frozen_creds.token:
-        s3_setup_query += f"SET s3_session_token='{frozen_creds.token}'; "
-    query = f"{s3_setup_query} {query}"
-    return query
+    try:
+        frozen_creds, region = _fetch_and_validate_s3_credentials(s3_session)
+        s3_setup_query = f"SET s3_region='{region}'; "
+        s3_setup_query += f"SET s3_access_key_id='{frozen_creds.access_key}'; "
+        s3_setup_query += f"SET s3_secret_access_key='{frozen_creds.secret_key}'; "
+        if frozen_creds.token:
+            s3_setup_query += f"SET s3_session_token='{frozen_creds.token}'; "
+        query = f"{s3_setup_query} {query}"
+    except ConfigurationError:
+        logger.warning("Unable to locate AWS credentials for fetching data from S3 -- will still attempt to do so,"
+                        "but the query will fail unless the data is in a public accessible bucket.")
+        return query
 
 
 def _build_query_with_hf_creds(query: str) -> str:

--- a/tests/_backends/local/io/test_reader.py
+++ b/tests/_backends/local/io/test_reader.py
@@ -42,6 +42,7 @@ from tests.conftest import _save_pdf_file
 
 COLUMNS = {"name", "age", "city"}
 
+
 def write_test_file(
     path: str,
     content: Union[pl.DataFrame, str],
@@ -90,7 +91,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Collect the full DataFrame and verify data
@@ -110,7 +111,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
 
@@ -151,7 +152,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     collected = df.to_polars()
@@ -162,11 +163,10 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
     collected = df.to_polars()
     assert collected.height == 11, f"Expected 11 rows, got {collected.height}"
-
 
 
 def test_parquet_single_file(local_session, temp_dir):
@@ -198,7 +198,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Collect the full DataFrame and verify data
@@ -218,7 +218,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
 
@@ -264,7 +264,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Verify row count
@@ -279,7 +279,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-        actual_columns == COLUMNS
+            actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Verify row count
@@ -362,7 +362,6 @@ Carol,28,91.7"""
             ]
         )
         df = local_session.read.csv(test_file_path, schema=schema)
-
 
 
 def test_csv_merge_schemas_true_union_columns(local_session, temp_dir):
@@ -532,6 +531,7 @@ dog, 1.2"""
         ColumnField("id2", DoubleType),
     ]
 
+
 def test_parquet_merge_schemas_true_union_columns(local_session, temp_dir):
     """Test Parquet schema merging with merge_schemas=True.
 
@@ -636,7 +636,6 @@ def test_parquet_merge_schemas_false_first_file_determines_schema(local_session,
         ColumnField("id2", StringType),
     ]
 
-
     data1 = {"id": [1, 2], "id2": ["1", "2"]}
     data2 = {"id": ["cat", "dog"], "id2": [3, 4]}
 
@@ -648,7 +647,6 @@ def test_parquet_merge_schemas_false_first_file_determines_schema(local_session,
 
     with pytest.raises(PlanError, match="Failed to infer schema"):
         df = local_session.read.parquet([file1_path, file2_path])
-
 
     data1 = {"id": [1, 2], "id2": ["1", "2"]}
     data2 = {"id2": [3, 4]}
@@ -727,7 +725,7 @@ Bob,30,Chicago"""
     write_test_file(test_file_path, csv_data, local_session, "csv")
 
     with pytest.raises(
-        ValidationError, match="Cannot specify both 'schema' and 'merge_schemas=True' - these options conflict."
+            ValidationError, match="Cannot specify both 'schema' and 'merge_schemas=True' - these options conflict."
     ):
         schema = {"name": StringType, "age": IntegerType}
         local_session.read.csv(test_file_path, schema=schema, merge_schemas=True)
@@ -757,12 +755,12 @@ def test_read_query_setup_with_aws_credentials(local_session_config, monkeypatch
     secret_key = frozen_credentials.secret_key
     token = frozen_credentials.token
     region = session._session_state.s3_session.region_name
- 
+
     # Test that read queries to s3 have the configured credentials
     paths = ["s3://test-bucket/test-file.csv"]
     query = session._session_state.execution._build_read_csv_query(
         paths,
-        infer_schema =True,
+        infer_schema=True,
     )
     query = _build_query_with_httpfs_extensions(query)
     query, has_s3_creds = _build_query_with_s3_creds(query, session._session_state.s3_session)
@@ -774,6 +772,7 @@ def test_read_query_setup_with_aws_credentials(local_session_config, monkeypatch
     assert f"SET s3_region='{region}'" in query
 
     session.stop()
+
 
 def test_read_queries_with_no_aws_credentials(local_session_config, temp_dir):
     """Test that local read queries work and that read queries to s3 will fail without aws credentials."""
@@ -802,14 +801,21 @@ def test_read_queries_with_no_aws_credentials(local_session_config, temp_dir):
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv("s3://test-bucket/test-file.csv")
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
+    assert (
+            str(exc_info.value.__cause__) ==
+            "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
+    )
 
     with pytest.raises(PlanError, match="Failed to infer schema from Parquet files") as exc_info:
         session.read.parquet("s3://test-bucket/test-file.parquet")
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
+    assert (
+            str(exc_info.value.__cause__) ==
+            "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
+    )
 
     session.stop()
+
 
 # =============================================================================
 # HuggingFace Credentials Tests
@@ -825,7 +831,10 @@ def test_read_queries_with_invalid_huggingface_credentials(local_session_config,
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv(paths[0])
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: 401)"
+    assert str(
+        exc_info.value.__cause__) == "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: 401)"
+
+    session.stop()
 
 def test_read_query_setup_with_huggingface_credentials(local_session_config, monkeypatch):
     """Test that read queries to huggingface datasets will succeed with hf credentials."""
@@ -844,6 +853,7 @@ def test_read_query_setup_with_huggingface_credentials(local_session_config, mon
     assert "INSTALL httpfs; LOAD httpfs;" in query
     assert "CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN 'test_token');" in query
 
+    session.stop()
 
 def test_read_query_setup_with_huggingface_credentials_and_s3_credentials(local_session_config, monkeypatch):
     """Test that read queries to huggingface datasets will succeed with hf credentials."""
@@ -862,7 +872,6 @@ def test_read_query_setup_with_huggingface_credentials_and_s3_credentials(local_
     secret_key = frozen_credentials.secret_key
     token = frozen_credentials.token
     region = session._session_state.s3_session.region_name
-    
     # Test that read queries to s3 have the configured credentials
     paths = ["hf://datasets/typedef-ai/fenic-test-datasets-private/last_names_1.csv"]
     query = session._session_state.execution._build_read_csv_query(
@@ -880,6 +889,9 @@ def test_read_query_setup_with_huggingface_credentials_and_s3_credentials(local_
     assert f"SET s3_secret_access_key='{secret_key}'" in query
     assert f"SET s3_session_token='{token}'" in query
     assert f"SET s3_region='{region}'" in query
+
+    session.stop()
+
 
 # =============================================================================
 # HuggingFace Test Reads on Public Datasets
@@ -900,6 +912,7 @@ TEST_PARQUET_SCHEMA = Schema(column_fields=[
     ColumnField(name="location_type", data_type=StringType),
 ])
 
+
 def test_read_public_huggingface_datasets(request, local_session_config, temp_dir):
     """Test that read queries to public huggingface datasets will succeed without hf credentials."""
     if not request.config.getoption("--test-huggingface-reads"):
@@ -912,7 +925,6 @@ def test_read_public_huggingface_datasets(request, local_session_config, temp_di
     df = session.read.csv(csv_path)
     assert df.schema == TEST_CSV_SCHEMA, f"Expected {TEST_CSV_SCHEMA}, got {df.schema}"
     assert df.count() == 10
-
 
     # Test with single parquet file
     parquet_path = "hf://datasets/typedef-ai/fenic-test-datasets-public/names_and_occupations_3.parquet"
@@ -942,6 +954,7 @@ def test_read_public_huggingface_datasets(request, local_session_config, temp_di
     assert df.count() == 10
     assert df.schema == TEST_PARQUET_SCHEMA
 
+    session.stop()
 
 def test_read_public_huggingface_datasets_with_other_sources(request, local_session_config, temp_dir):
     """Test that read queries to public huggingface datasets will succeed with other schemes."""
@@ -960,6 +973,7 @@ Francis
     assert df.count() == 13
     assert df.schema == TEST_CSV_SCHEMA
 
+    session.stop()
 # =============================================================================
 # Ingestion Type Coercions Tests
 # =============================================================================
@@ -1025,6 +1039,7 @@ def test_ingest_datetime_type(local_session, temp_dir):
     - Filtering on datetime string values
     - Consistency across read methods (parquet vs in-memory)
     """
+    print(local_session._session_state.s3_session)
     PARQUET_FILE_NAME = f"{temp_dir.path}/test.parquet"
     DATETIME_COLUMN_NAME = "some_datetime"
     CSV_FILE_NAME = f"{temp_dir.path}/test.csv"
@@ -1069,7 +1084,7 @@ def test_ingest_datetime_type(local_session, temp_dir):
         }
     )
     assert (
-        result.schema == expected_schema
+            result.schema == expected_schema
     ), "Datetime should be converted to String"
     assert result[DATETIME_COLUMN_NAME].to_list() == ["2024-01-04 07:10:13.000000"]
 
@@ -1081,7 +1096,7 @@ def test_ingest_datetime_type(local_session, temp_dir):
     result = fenic_df.to_polars()
 
     assert (
-        result.schema == expected_schema
+            result.schema == expected_schema
     ), "Datetime should be converted to String"
     assert result[DATETIME_COLUMN_NAME].to_list() == ["2024-01-04 07:10:13.000000"]
 
@@ -1093,6 +1108,7 @@ def test_ingest_datetime_type(local_session, temp_dir):
     )
     result = fenic_df.to_polars()
     assert result[DATETIME_COLUMN_NAME].to_list() == ["2024-01-04 07:10:13.000000"]
+
 
 def test_ingest_array_type(local_session, temp_dir):
     """Test automatic conversion of array columns to lists."""
@@ -1151,7 +1167,7 @@ David,33,Seattle"""
 
     table_name = "test_overwrite_table"
     df = local_session.create_dataframe([{"name": "Alice", "age": 30, "city": "SF"},
-                                          {"name": "Carol", "age": 34, "city": "Boston"}])
+                                         {"name": "Carol", "age": 34, "city": "Boston"}])
     df.write.save_as_table(table_name, mode="overwrite")
     df_table = local_session.table(table_name)
     df_table.write.save_as_view("df_view")
@@ -1167,6 +1183,7 @@ David,33,Seattle"""
     result_name = df_view_union.select(col("name")).collect("polars").data
     values_name = result_name["name"].to_list()
     assert values_name == ["John", "David", "Alice", "Carol"]
+
 
 def test_view_schema_validation(local_session, temp_dir):
     """Test that views are validated against the current state of the source."""
@@ -1232,6 +1249,7 @@ def test_read_docs_invalid_type(local_session, temp_dir_with_test_files):
             data_type=StringType,
             recursive=True)
 
+
 def test_read_docs_no_wildcard_only_valid_files(local_session, temp_dir_with_test_files):
     """Test that reading JSON files from a folder works."""
     # Create a test JSON file
@@ -1258,6 +1276,7 @@ def test_read_docs_no_wildcard_only_valid_files(local_session, temp_dir_with_tes
     # Verify our test file is in the results
     assert any("test.json" in path for path in results["file_path"])
 
+
 def test_read_markdown_no_wildcard_only_valid_files(local_session, temp_dir_just_one_file):
     """Test that reading from a path with (and no wild card) only valid files works."""
     df = local_session.read.docs(
@@ -1266,6 +1285,7 @@ def test_read_markdown_no_wildcard_only_valid_files(local_session, temp_dir_just
     df.collect()
     dict = df.to_pydict()
     assert len(dict["file_path"]) == 1
+
 
 def test_read_docs_no_files_valid_paths(local_session, temp_dir_with_test_files):
     """Test that if no files are found, we'll get a dataframe with the path and an error message."""
@@ -1276,6 +1296,7 @@ def test_read_docs_no_files_valid_paths(local_session, temp_dir_with_test_files)
     df.collect()
     results = df.to_pydict()
     assert len(results["file_path"]) == 0
+
 
 def test_read_docs_no_wildcard_path_is_file(local_session, temp_dir_just_one_file):
     """Test that reading from a path to a file works."""
@@ -1295,25 +1316,28 @@ def test_read_pdfs_invalid_path(local_session):
             "/invalid/path",
             recursive=True)
 
+
 pdf_metadata_schema = Schema(
-        [
-            ColumnField(name="doc_path", data_type=StringType),
-            ColumnField(name="error", data_type=StringType),
-            ColumnField(name="size", data_type=IntegerType),
-            ColumnField(name="title", data_type=StringType),
-            ColumnField(name="author", data_type=StringType),
-            ColumnField(name="creation_date", data_type=StringType),
-            ColumnField(name="mod_date", data_type=StringType),
-            ColumnField(name="page_count", data_type=IntegerType),
-            ColumnField(name="has_forms", data_type=BooleanType),
-            ColumnField(name="has_signature_fields", data_type=BooleanType),
-            ColumnField(name="image_count", data_type=IntegerType),
-            ColumnField(name="is_encrypted", data_type=BooleanType),
-        ]
+    [
+        ColumnField(name="doc_path", data_type=StringType),
+        ColumnField(name="error", data_type=StringType),
+        ColumnField(name="size", data_type=IntegerType),
+        ColumnField(name="title", data_type=StringType),
+        ColumnField(name="author", data_type=StringType),
+        ColumnField(name="creation_date", data_type=StringType),
+        ColumnField(name="mod_date", data_type=StringType),
+        ColumnField(name="page_count", data_type=IntegerType),
+        ColumnField(name="has_forms", data_type=BooleanType),
+        ColumnField(name="has_signature_fields", data_type=BooleanType),
+        ColumnField(name="image_count", data_type=IntegerType),
+        ColumnField(name="is_encrypted", data_type=BooleanType),
+    ]
 )
+
 
 def _get_globbed_path(path: str, file_extension: str) -> list[str]:
     return [str(Path.joinpath(Path(path), file_extension))]
+
 
 def test_read_pdfs_basic(local_session, temp_dir_just_one_file):
     """Test that reading PDFs from a folder."""
@@ -1336,8 +1360,8 @@ def test_read_pdfs_basic(local_session, temp_dir_just_one_file):
     # Verify that size field is populated with positive values
     all_data = df.to_polars()
     for i in range(3):
-        row = all_data.filter(pl.col("title") == f"File {i+1} Title").to_dicts()[0]
-        assert row["author"] == f"File {i+1} Author"
+        row = all_data.filter(pl.col("title") == f"File {i + 1} Title").to_dicts()[0]
+        assert row["author"] == f"File {i + 1} Author"
         assert row["size"] > 0
         creation_date = row["creation_date"]
         mod_date = row["mod_date"]
@@ -1349,6 +1373,7 @@ def test_read_pdfs_basic(local_session, temp_dir_just_one_file):
 
     for size_value in all_data["size"]:
         assert size_value > 0, f"Size should be positive, got {size_value}"
+
 
 def test_read_large_pdfs_with_fields(local_session, temp_dir_just_one_file):
     """Test that reading PDFs with text and fields from a folder."""
@@ -1390,8 +1415,8 @@ def test_read_large_pdfs_with_fields(local_session, temp_dir_just_one_file):
     all_data = df.to_polars()
     prev_doc_size = 0
     for i in range(3):
-        row = all_data.filter(pl.col("title") == f"File {i+1} Title").to_dicts()[0]
-        assert row["author"] == f"File {i+1} Author"
+        row = all_data.filter(pl.col("title") == f"File {i + 1} Title").to_dicts()[0]
+        assert row["author"] == f"File {i + 1} Author"
         assert row["size"] > 0
         creation_date = row["creation_date"]
         mod_date = row["mod_date"]

--- a/tests/_backends/local/io/test_reader.py
+++ b/tests/_backends/local/io/test_reader.py
@@ -91,7 +91,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+      actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Collect the full DataFrame and verify data
@@ -111,7 +111,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+      actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
 
@@ -152,7 +152,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+      actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     collected = df.to_polars()
@@ -163,7 +163,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+      actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
     collected = df.to_polars()
     assert collected.height == 11, f"Expected 11 rows, got {collected.height}"
@@ -198,7 +198,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+          actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Collect the full DataFrame and verify data
@@ -218,7 +218,7 @@ David,33,Seattle"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+          actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
 
@@ -264,7 +264,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+          actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Verify row count
@@ -279,7 +279,7 @@ Emma,36,Phoenix"""
     schema = df.schema
     actual_columns = {field.name for field in schema.column_fields}
     assert (
-            actual_columns == COLUMNS
+          actual_columns == COLUMNS
     ), f"Expected columns {COLUMNS}, got {actual_columns}"
 
     # Verify row count
@@ -725,7 +725,7 @@ Bob,30,Chicago"""
     write_test_file(test_file_path, csv_data, local_session, "csv")
 
     with pytest.raises(
-            ValidationError, match="Cannot specify both 'schema' and 'merge_schemas=True' - these options conflict."
+        ValidationError, match="Cannot specify both 'schema' and 'merge_schemas=True' - these options conflict."
     ):
         schema = {"name": StringType, "age": IntegerType}
         local_session.read.csv(test_file_path, schema=schema, merge_schemas=True)
@@ -826,13 +826,28 @@ def test_read_queries_with_invalid_huggingface_credentials(local_session_config,
     session = Session.get_or_create(local_session_config)
     paths = ["hf://datasets/typedef-ai/fenic-test-datasets-private/last_names_1.csv"]
 
+    # Test with no token
+    if os.getenv("HF_TOKEN"):
+        monkeypatch.delenv("HF_TOKEN")
+    with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
+        session.read.csv(paths[0])
+    assert isinstance(exc_info.value.__cause__, FileLoaderError)
+    assert (
+        str(exc_info.value.__cause__) ==
+        "File loader error: Failed to read from Hugging Face -- credentials were not found and the dataset is private or gated. "
+        "Set HF_TOKEN environment variable. (Status code: 401)"
+    )
+
     # Test with invalid token
     monkeypatch.setenv("HF_TOKEN", "invalid_token")
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv(paths[0])
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert str(
-        exc_info.value.__cause__) == "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: 401)"
+    assert (
+        str(exc_info.value.__cause__) ==
+        "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required "
+        "permissions. (Status code: 401)"
+    )
 
     session.stop()
 
@@ -1039,7 +1054,6 @@ def test_ingest_datetime_type(local_session, temp_dir):
     - Filtering on datetime string values
     - Consistency across read methods (parquet vs in-memory)
     """
-    print(local_session._session_state.s3_session)
     PARQUET_FILE_NAME = f"{temp_dir.path}/test.parquet"
     DATETIME_COLUMN_NAME = "some_datetime"
     CSV_FILE_NAME = f"{temp_dir.path}/test.csv"
@@ -1360,8 +1374,8 @@ def test_read_pdfs_basic(local_session, temp_dir_just_one_file):
     # Verify that size field is populated with positive values
     all_data = df.to_polars()
     for i in range(3):
-        row = all_data.filter(pl.col("title") == f"File {i + 1} Title").to_dicts()[0]
-        assert row["author"] == f"File {i + 1} Author"
+        row = all_data.filter(pl.col("title") == f"File {i+1} Title").to_dicts()[0]
+        assert row["author"] == f"File {i+1} Author"
         assert row["size"] > 0
         creation_date = row["creation_date"]
         mod_date = row["mod_date"]
@@ -1415,8 +1429,8 @@ def test_read_large_pdfs_with_fields(local_session, temp_dir_just_one_file):
     all_data = df.to_polars()
     prev_doc_size = 0
     for i in range(3):
-        row = all_data.filter(pl.col("title") == f"File {i + 1} Title").to_dicts()[0]
-        assert row["author"] == f"File {i + 1} Author"
+        row = all_data.filter(pl.col("title") == f"File {i+1} Title").to_dicts()[0]
+        assert row["author"] == f"File {i+1} Author"
         assert row["size"] > 0
         creation_date = row["creation_date"]
         mod_date = row["mod_date"]

--- a/tests/_backends/local/io/test_reader.py
+++ b/tests/_backends/local/io/test_reader.py
@@ -9,7 +9,6 @@ import boto3
 import polars as pl
 import pytest
 from botocore.session import get_session
-from duckdb import HTTPException
 
 from fenic import (
     ArrayType,
@@ -33,7 +32,7 @@ from fenic._backends.local.utils.io_utils import (
 )
 from fenic.api.session import Session
 from fenic.core.error import (
-    ConfigurationError,
+    FileLoaderError,
     InternalError,
     PlanError,
     UnsupportedFileTypeError,
@@ -766,7 +765,8 @@ def test_read_query_setup_with_aws_credentials(local_session_config, monkeypatch
         infer_schema =True,
     )
     query = _build_query_with_httpfs_extensions(query)
-    query = _build_query_with_s3_creds(query, session._session_state.s3_session)
+    query, has_s3_creds = _build_query_with_s3_creds(query, session._session_state.s3_session)
+    assert has_s3_creds
     assert "http"
     assert f"SET s3_access_key_id='{access_key}'" in query
     assert f"SET s3_secret_access_key='{secret_key}'" in query
@@ -801,13 +801,13 @@ def test_read_queries_with_no_aws_credentials(local_session_config, temp_dir):
     # Test that read queries to s3 will fail without credentials
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv("s3://test-bucket/test-file.csv")
-    assert isinstance(exc_info.value.__cause__, ConfigurationError)
-    assert str(exc_info.value.__cause__) == "Unable to locate AWS credentials."
+    assert isinstance(exc_info.value.__cause__, FileLoaderError)
+    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
 
     with pytest.raises(PlanError, match="Failed to infer schema from Parquet files") as exc_info:
         session.read.parquet("s3://test-bucket/test-file.parquet")
-    assert isinstance(exc_info.value.__cause__, ConfigurationError)
-    assert str(exc_info.value.__cause__) == "Unable to locate AWS credentials."
+    assert isinstance(exc_info.value.__cause__, FileLoaderError)
+    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from S3, the object is not publicly readable and no AWS credentials were provided. Configure AWS credentials (env/aws_config) or ensure the object is publicly readable. (Status code: 403)"
 
     session.stop()
 
@@ -820,22 +820,12 @@ def test_read_queries_with_invalid_huggingface_credentials(local_session_config,
     session = Session.get_or_create(local_session_config)
     paths = ["hf://datasets/typedef-ai/fenic-test-datasets-private/last_names_1.csv"]
 
-    # Test with no token
-    if os.getenv("HF_TOKEN"):
-        monkeypatch.delenv("HF_TOKEN")
-
-    with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
-        session.read.csv(paths[0])
-    assert isinstance(exc_info.value.__cause__, ConfigurationError)
-    assert str(exc_info.value.__cause__) == "HuggingFace token not found. Set HF_TOKEN environment variable."
-
     # Test with invalid token
     monkeypatch.setenv("HF_TOKEN", "invalid_token")
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv(paths[0])
-    assert isinstance(exc_info.value.__cause__, HTTPException)
-    assert str(exc_info.value.__cause__) == "HTTP Error: HTTP GET error on 'https://huggingface.co/datasets/typedef-ai/fenic-test-datasets-private/resolve/main/last_names_1.csv' (HTTP 401)"
-
+    assert isinstance(exc_info.value.__cause__, FileLoaderError)
+    assert str(exc_info.value.__cause__) == "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required permissions. (Status code: 401)"
 
 def test_read_query_setup_with_huggingface_credentials(local_session_config, monkeypatch):
     """Test that read queries to huggingface datasets will succeed with hf credentials."""
@@ -849,7 +839,8 @@ def test_read_query_setup_with_huggingface_credentials(local_session_config, mon
         infer_schema=True,
     )
     query = _build_query_with_httpfs_extensions(query)
-    query = _build_query_with_hf_creds(query)
+    query, has_hf_creds = _build_query_with_hf_creds(query)
+    assert has_hf_creds
     assert "INSTALL httpfs; LOAD httpfs;" in query
     assert "CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN 'test_token');" in query
 
@@ -879,8 +870,10 @@ def test_read_query_setup_with_huggingface_credentials_and_s3_credentials(local_
         infer_schema=True,
     )
     query = _build_query_with_httpfs_extensions(query)
-    query = _build_query_with_s3_creds(query, session._session_state.s3_session)
-    query = _build_query_with_hf_creds(query)
+    query, has_s3_creds = _build_query_with_s3_creds(query, session._session_state.s3_session)
+    assert has_s3_creds
+    query, has_hf_creds = _build_query_with_hf_creds(query)
+    assert has_hf_creds
     assert "INSTALL httpfs; LOAD httpfs;" in query
     assert "CREATE SECRET hf_token (TYPE HUGGINGFACE, TOKEN 'test_token');" in query
     assert f"SET s3_access_key_id='{access_key}'" in query
@@ -1246,7 +1239,7 @@ def test_read_docs_no_wildcard_only_valid_files(local_session, temp_dir_with_tes
     json_path = Path(temp_dir_with_test_files) / "test.json"
     with open(json_path, 'w') as f:
         json.dump({"test": "data", "number": 42}, f)
-    
+
     df = local_session.read.docs(
         _get_globbed_path(temp_dir_with_test_files, "**/*.json"),
         data_type=JsonType,

--- a/tests/_backends/local/test_session.py
+++ b/tests/_backends/local/test_session.py
@@ -43,7 +43,6 @@ def test_multiple_sessions(local_session_config):
     session4 = Session.get_or_create(local_session_config)
 
     assert session != session4
-    session4.stop()
 
 def test_combining_dataframes_from_different_sessions_raises():
     config1 = SessionConfig(

--- a/tests/_backends/local/test_session.py
+++ b/tests/_backends/local/test_session.py
@@ -43,6 +43,7 @@ def test_multiple_sessions(local_session_config):
     session4 = Session.get_or_create(local_session_config)
 
     assert session != session4
+    session4.stop()
 
 def test_combining_dataframes_from_different_sessions_raises():
     config1 = SessionConfig(


### PR DESCRIPTION
### TL;DR

Allow users to pull public datasets from Hugging Face and publicaly accessible files from S3 without setting up an HF_TOKEN/AWS_ACCESS_KEY. 

### What changed?

- Enhanced error handling in `query_files` and `write_file` functions to provide more specific error messages
- Modified credential handling functions to return a boolean indicating if credentials were found
- Added graceful fallback for HuggingFace paths without credentials (will attempt to read public datasets)
- Added warning logs when credentials are missing but operation might still succeed
- Added error handling for HTTP status codes (404, 401, 403) with contextual messages
- Updated tests to match the new error handling behavior

### How to test?

- Test reading from S3 with valid credentials, invalid credentials, and no credentials
- Test reading from HuggingFace with valid token, invalid token, and no token
- Test writing to S3 with and without credentials
- Verify error messages are clear and actionable for each failure case

### Why make this change?

The previous implementation would fail with generic or confusing error messages when credential issues occurred. This change provides more user-friendly error messages that explain exactly what went wrong and how to fix it, improving the developer experience when working with remote data sources. It also allows reading from public HuggingFace datasets without requiring a token.