### PR TITLE
fix: gemini-2.5-pro default model without profiles

### DIFF
--- a/src/fenic/_inference/google/google_profile_manager.py
+++ b/src/fenic/_inference/google/google_profile_manager.py
@@ -135,17 +135,30 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
         """Get default Google configuration.
 
         Returns:
-            Default configuration with thinking disabled
+            Default configuration with thinking disabled if supported, otherwise default to low reasoning
         """
         if self.model_parameters.supports_reasoning:
-            return GoogleCompletionsProfileConfig(
-                thinking_enabled=False,
-                thinking_token_budget=0,
-                additional_generation_config=GenerateContentConfigDict(
-                    thinking_config=ThinkingConfigDict(
-                        include_thoughts=False,
-                        thinking_budget=0
+            if self.model_parameters.supports_disabled_reasoning:
+                return GoogleCompletionsProfileConfig(
+                    thinking_enabled=False,
+                    thinking_token_budget=0,
+                    additional_generation_config=GenerateContentConfigDict(
+                        thinking_config=ThinkingConfigDict(
+                            include_thoughts=False,
+                            thinking_budget=0
+                        )
                     )
                 )
-            )
+            else:
+                # default to low reasoning
+                return GoogleCompletionsProfileConfig(
+                    thinking_enabled=True,
+                    thinking_token_budget=1024,
+                    additional_generation_config=GenerateContentConfigDict(
+                        thinking_config=ThinkingConfigDict(
+                            include_thoughts=True,
+                            thinking_budget=1024
+                        )
+                    )
+                )
         return GoogleCompletionsProfileConfig()

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -1178,7 +1178,7 @@ def _validate_language_profile(language_model: LanguageModel, model_alias: str, 
         if not completion_model_params.supports_verbosity and profile.verbosity is not None:
             raise ConfigurationError(f"Model '{model_alias}' does not support verbosity. Please remove verbosity from '{profile_alias}'.")
     elif isinstance(language_model, GoogleDeveloperLanguageModel) or isinstance(language_model, GoogleVertexLanguageModel):
-        if not profile.thinking_token_budget or profile.thinking_token_budget == 0 and model_alias == "gemini-2.5-pro":
+        if (not profile.thinking_token_budget or profile.thinking_token_budget == 0) and not completion_model_params.supports_disabled_reasoning:
             raise ConfigurationError(f"Model '{model_alias}' does not support disabling reasoning. Please set thinking_token_budget on '{profile_alias}' to a non-zero value.")
 
 def _validate_embedding_profile(

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -58,6 +58,7 @@ class CompletionModelParameters:
         supports_profiles = True,
         supports_reasoning = False,
         supports_minimal_reasoning = False,
+        supports_disabled_reasoning = True,
         supports_custom_temperature = True,
         supports_verbosity = False,
     ):
@@ -73,6 +74,7 @@ class CompletionModelParameters:
         self.supports_profiles = supports_profiles
         self.supports_reasoning = supports_reasoning
         self.supports_minimal_reasoning = supports_minimal_reasoning
+        self.supports_disabled_reasoning = supports_disabled_reasoning
         self.supports_custom_temperature = supports_custom_temperature
         self.supports_verbosity = supports_verbosity
 
@@ -663,6 +665,7 @@ class ModelCatalog:
                 context_window_length=1_048_576,
                 max_output_tokens=65_536,
                 supports_reasoning=True,
+                supports_disabled_reasoning=False,
                 max_temperature=2.0,
                 tiered_token_costs={
                     200_000: TieredTokenCost(
@@ -780,6 +783,7 @@ class ModelCatalog:
                 max_output_tokens=65_536,
                 max_temperature=2.0,
                 supports_reasoning=True,
+                supports_disabled_reasoning=False,
                 tiered_token_costs={
                     200_000: TieredTokenCost(
                         input_token_cost=2.50 / 1_000_000,  # $2.50 per 1M tokens

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,18 +335,20 @@ def configure_language_model(model_provider: ModelProvider, model_name: str) -> 
             )
     elif model_provider == ModelProvider.GOOGLE_DEVELOPER:
         if model_parameters.supports_reasoning:
+            profiles = {
+                "auto": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=-1),
+                "low": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=1024),
+                "medium": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=4096),
+                "high": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=8192),
+            }
+            if model_parameters.supports_disabled_reasoning:
+                profiles["thinking_disabled"] = GoogleDeveloperLanguageModel.Profile()
             language_model = GoogleDeveloperLanguageModel(
                 model_name=model_name,
                 rpm=1000,
                 tpm=500_000,
-                profiles={
-                    "thinking_disabled": GoogleDeveloperLanguageModel.Profile(),
-                    "auto": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=-1),
-                    "low": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=1024),
-                    "medium": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=4096),
-                    "high": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=8192),
-                },
-                default_profile="auto",
+                profiles=profiles,
+                default_profile="thinking_disabled" if "thinking_disabled" in profiles else "auto",
             )
         else:
             language_model = GoogleDeveloperLanguageModel(


### PR DESCRIPTION
## Why the change

Gemini-2.5-pro does not allow disabled reasoning.  We had special checks for the Profile path, but we weren't handling the default model path with no profiles properly.

With this change, user can configure gemini-2.5-pro in a single line without profiles and we default the thinking budget to 'low'.  Also introduced concept of ‘supports-disabled-reasoning’ to our model-params to remove special case code

## How to test

Run unit tests with gemini-2.5-pro and removing all profiles to ensure default behavior works