### PR TITLE
fix: raise if a request can't be handled by max token capacity

### DIFF
--- a/src/fenic/_inference/google/gemini_native_chat_completions_client.py
+++ b/src/fenic/_inference/google/gemini_native_chat_completions_client.py
@@ -350,7 +350,7 @@ class GeminiNativeChatCompletionsClient(
             else:
                 return FatalException(e)
         except Exception as e:  # noqa: BLE001 – catch-all mapped to Fatal
-            return TransientException(e)
+            return FatalException(e)
 
     def _prepare_schema(self, response_format: ResolvedResponseFormat) -> dict[str, Any]:
         """Google Gemini does not support additionalProperties in JSON schemas, even if it is set to False.


### PR DESCRIPTION
## Current behavior

- configuring tpm to something low will result in the program hanging forever if a single request has a higher token estimate than the max capacity.  
- when model_client process_queue caught an exception, the client stops processing the tasks, but nothing cancels the pending tasks so we never shut down.
- google models were retrying on catch-all errors

## What changed

- On detecting max tpm too low for request's estimated tokens, cancel model client tasks queue and raise error
- When _process_queue catches a non-cancel exception, clear the queue and shutdown
- google models  fail (raise FatalException) in catch-all error handling