### PR TITLE
fix: skip local gemini token counting tests if google-genai is not installed

### DIFF
--- a/tests/_inference/google/test_gemini_token_counter.py
+++ b/tests/_inference/google/test_gemini_token_counter.py
@@ -1,4 +1,8 @@
 
+import pytest
+
+pytest.importorskip("google.genai")
+
 from fenic._inference.google.gemini_token_counter import GeminiLocalTokenCounter
 from fenic._inference.types import FewShotExample, LMRequestMessages
 


### PR DESCRIPTION
^