### PR TITLE
feat: Add page chunking to semantic parse_pdf, refactor token estimation

### DIFF
--- a/src/fenic/_backends/local/semantic_operators/parse_pdf.py
+++ b/src/fenic/_backends/local/semantic_operators/parse_pdf.py
@@ -1,7 +1,8 @@
 import logging
 from textwrap import dedent
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
+import fitz
 import jinja2
 import polars as pl
 
@@ -11,10 +12,13 @@ from fenic._backends.local.semantic_operators.base import (
 )
 from fenic._backends.local.utils.doc_loader import DocFolderLoader
 from fenic._inference.language_model import InferenceConfiguration, LanguageModel
+from fenic._inference.types import LMRequestFile, LMRequestMessages
 from fenic.core._logical_plan.resolved_types import ResolvedModelAlias
 
 logger = logging.getLogger(__name__)
 
+PDF_MARKDOWN_OUTPUT_TOKEN_MULTIPLIER = 1.5 # Add buffer, account for markdown and table formatting, image descriptions, and other overheads
+PDF_MAX_PAGES_CHUNK = 3 # Fenic can't handle large outputs until we implement streamed responses, so limit chunk size
 
 class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
     """Operator for parsing PDF files using language models with PDF parsing capabilities."""
@@ -24,10 +28,12 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
          - Preserve the structure, formatting, headings, lists, and any tables to the best of your ability
          - Format tables as github markdown tables, however:
              - for table headings, immediately add ' |' after the table heading
+        {% if multiple_pages %}
         {% if page_separator and '{page}' in page_separator %}
          - Insert the page separator '{{ page_separator }}' as a markdown line for each page break, replacing the '{{ '{page}' }}' pattern with the current page number. If the document contains page numbers, do not include them in the output, instead replace them with this page separator.
         {% elif page_separator %}
          - Don't include the page numbers in the output, instead insert the page separator '{{ page_separator }}' as a markdown line for each page break
+        {% endif %}
         {% endif %}
         {% if describe_images %}
          - For each image, describe them briefly in a markdown section with 'Image' in the title, preserving the output order.
@@ -65,13 +71,144 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
         )
 
 
-    def build_system_message(self) -> str:
+    def build_system_message(self, multiple_pages: bool = False) -> str:
         """Build system message for PDF parsing."""
         return self.SYSTEM_PROMPT.render(
             page_separator=self.page_separator,
-            describe_images=self.describe_images
+            describe_images=self.describe_images,
+            multiple_pages=multiple_pages
+        )
+    def execute(self) -> pl.Series:
+        """ Executes the PDF parsing operator.
+
+        Flow:
+            - build messages may chunk the PDF based on internal limits and model output token limit,
+                - A request is created for each PDF chunk, holding an in-memory PDF file with that range of pages
+                - We keep a list of chunk sizes (i.e. page ranges) for each row
+            - send the requests to the LLM and wait for the responses.
+            - Postprocess concats the markdown responses for PDF chunks in each row.
+            - NOTE: this depends on the behavior of ModelClient returning responses in the same order they are queued.
+
+        Returns:
+            A Polars Series containing the markdown translation of each PDF file
+        """
+        prompts, page_counts_per_chunk_per_row = self.build_request_messages_batch()
+        responses = self.request_sender.send_requests(prompts)
+        postprocessed_responses = self.postprocess(responses, page_counts_per_chunk_per_row)
+        return pl.Series(postprocessed_responses)
+
+    def build_request_messages_batch(self) -> Tuple[List[Optional[LMRequestMessages]], List[List[int]]]:
+        """ Create the messages for each PDF in this column, chunking large PDFs into multiple messages.
+
+        Returns:
+            Messages for this column of PDFs
+            List of the each chunk size (page count) per PDF (page_counts_per_chunk_per_row)"""
+        messages_batch = []
+        page_counts_per_chunk_per_row = []
+        for path in self.input:
+            if not path:
+                messages_batch.append(None)
+                page_counts_per_chunk_per_row.append([1])
+            else:
+                file_chunks = self._get_file_chunks(path)
+                page_counts_per_chunk = []
+                for file in file_chunks:
+                    messages_batch.append(
+                        self.build_request_messages(file, multiple_pages=len(file_chunks) > 1)
+                    )
+                    page_counts_per_chunk.append(file.page_range[1] - file.page_range[0] + 1)
+                page_counts_per_chunk_per_row.append(page_counts_per_chunk)
+        return messages_batch, page_counts_per_chunk_per_row
+
+
+    def _get_file_chunks(self, file_path: str) -> List[LMRequestFile]:
+        """Get the page chunks for the PDF file.
+
+        Limit the pages based on the model's output token limit and internal max pages per chunk.
+
+        Args:
+            file_path: Path to the PDF file
+
+        Returns:
+            List of LMRequestFile objects
+            List of (start_page, end_page) tuples (inclusive, 0-indexed)
+        """
+        chunks = []
+        range_start_page = 0
+        range_tokens = 0
+        range_page_count = 0
+
+        with fitz.open(file_path) as doc:
+            total_pages = doc.page_count
+            for page_num in range(total_pages):
+                text = doc[page_num].get_text("text")
+                page_tokens = self.model.count_tokens(text)
+                # Check if we need to start a new range, either by reaching the token limit or the requested page range size
+                would_exceed_tokens = range_tokens > 0 and (range_tokens + page_tokens) * PDF_MARKDOWN_OUTPUT_TOKEN_MULTIPLIER > self.model.model_parameters.max_output_tokens
+                would_exceed_page_limit = range_page_count >= PDF_MAX_PAGES_CHUNK
+
+                if would_exceed_tokens or would_exceed_page_limit:
+                    # Save current batch
+                    last_page = page_num - 1
+                    page_range = (range_start_page, last_page)
+                    with fitz.open() as doc_chunk:
+                        doc_chunk.insert_pdf(doc, from_page=range_start_page, to_page=last_page)
+                        chunks.append(LMRequestFile(path=file_path, pdf_chunk_bytes=doc_chunk.tobytes(), page_range=page_range))
+                    range_start_page = page_num
+                    range_tokens = page_tokens
+                    range_page_count = 1
+                else:
+                    range_tokens += page_tokens
+                    range_page_count += 1
+
+            # Add the last batch if there are remaining pages
+            if range_start_page < total_pages:
+                if range_start_page == 0:
+                    # whole pdf fits in one chunk, no need to keep data in memory
+                    chunks.append(LMRequestFile(path=file_path, pdf_chunk_bytes=None, page_range=(0, total_pages - 1)))
+                else:
+                    # multi-page chunk
+                    with fitz.open() as doc_chunk:
+                        doc_chunk.insert_pdf(doc, from_page=range_start_page, to_page=total_pages - 1)
+                        chunks.append(LMRequestFile(path=file_path, pdf_chunk_bytes=doc_chunk.tobytes(), page_range=(range_start_page, total_pages - 1)))
+
+            return chunks
+
+    def build_request_messages(self, file: LMRequestFile, multiple_pages: bool = False) -> LMRequestMessages:
+        """Construct a request for PDF parsing with optional page range.
+
+        Args:
+            file_path: Path to the PDF file
+            page_range: Optional tuple of (start_page, end_page) inclusive, 0-indexed
+        """
+        # Determine if we're processing multiple pages for system message
+        return LMRequestMessages(
+            system=self.build_system_message(multiple_pages=multiple_pages),
+            user_file=file,
+            examples=self.build_examples() if self.examples else [],
         )
 
-    def postprocess(self, responses: List[Optional[str]]) -> List[Optional[str]]:
-        """Return parsed PDF content as-is."""
-        return responses
+    def postprocess(self, responses: List[Optional[str]], page_counts_per_chunk_per_row: List[List[int]]) -> List[Optional[str]]:
+        """Combine responses from multiple page ranges if needed.
+
+        Uses the list of chunk sizes per PDF to keep track of the page count and add correct page delimination"""
+        combined_responses = []
+        path_first_chunk_idx = 0
+        chunk_separator = "\n"
+        if self.page_separator:
+            chunk_separator += self.page_separator + "\n"
+
+        for page_counts_per_chunk in page_counts_per_chunk_per_row:
+            # Combine the responses/chunks for this path
+            combined_response = ""
+            last_page_number = 0
+            for chunk_idx, page_count in enumerate(page_counts_per_chunk):
+                combined_response += responses[path_first_chunk_idx + chunk_idx]
+                if chunk_idx < len(page_counts_per_chunk) - 1:
+                    # Add page separator between chunks, skip the last chunk
+                    last_page_number = last_page_number + page_count
+                    combined_response += chunk_separator.replace("{page}", str(last_page_number))
+            combined_responses.append(combined_response)
+            path_first_chunk_idx += len(page_counts_per_chunk)
+
+        return combined_responses

--- a/src/fenic/_inference/common_openai/openai_utils.py
+++ b/src/fenic/_inference/common_openai/openai_utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+from fenic._inference.request_utils import pdf_to_base64
 from fenic._inference.types import LMRequestMessages
 
 
@@ -14,14 +15,14 @@ def convert_messages(lm_request_messages: LMRequestMessages) -> List[Dict[str, s
     if lm_request_messages.user:
         # text - use simple string content
         messages.append({"role": "user", "content": lm_request_messages.user})
-    if lm_request_messages.user_file_path:
+    if lm_request_messages.user_file:
         # file - use structured content with file
         user_message = {"role": "user", "content": [
             {
                 "type": "file",
-                "content": {
-                    "filename": lm_request_messages.user_file_path,
-                    "file_data": lm_request_messages.user_file_path
+                "file": {
+                    "filename": lm_request_messages.user_file.path,
+                    "file_data": f"data:application/pdf;base64,{pdf_to_base64(lm_request_messages.user_file)}",
                 }
             }
         ]}

--- a/src/fenic/_inference/google/gemini_token_counter.py
+++ b/src/fenic/_inference/google/gemini_token_counter.py
@@ -1,12 +1,12 @@
 import logging
 
-import fitz  # PyMuPDF
 from google.genai.local_tokenizer import LocalTokenizer
 from google.genai.types import (
     CountTokensConfig,
 )
 
 from fenic._inference.google.google_utils import convert_text_messages
+from fenic._inference.request_utils import get_pdf_page_count, get_pdf_text
 from fenic._inference.token_counter import (
     TokenCounter,
     Tokenizable,
@@ -55,20 +55,32 @@ class GeminiLocalTokenCounter(TokenCounter):
         elif isinstance(messages, LMRequestMessages):
             return self._count_request_tokens(messages)
 
+    def count_file_input_tokens(self, messages: LMRequestMessages) -> int:
+        # Gemini 2.0 charges 258 tokens per page for all PDF inputs.  For more detail, see https://gemini-api.apidog.io/doc-965859#technical-details
+        page_count = get_pdf_page_count(messages.user_file)
+        tokens = page_count * 258
+        return tokens
+
+    def count_file_output_tokens(self, messages: LMRequestMessages) -> int:
+        # TODO: we do this twice, once for estimating input and once for estimating output.  We can cache the text in the LMFile object.
+        text = get_pdf_text(messages.user_file)
+        # Note: we currently aren't counting any text tokens for describing images, since that defaults to False.
+        # In our estimates we add buffer, both for markdown structure and in case we ask the model to describe images.
+        return self.google_tokenizer.count_tokens(text).total_tokens
+
     def _count_request_tokens(self, messages: LMRequestMessages) -> int:
         """Count tokens for an `LMRequestMessages` object."""
         contents = convert_text_messages(messages)
         tokens = 0
         if len(contents) > 0:
-            tokens += self.google_tokenizer.count_tokens(
+            count_tokens = self.google_tokenizer.count_tokens(
                 convert_text_messages(messages),
                 config=CountTokensConfig(system_instruction=messages.system)
             ).total_tokens
+            tokens += count_tokens
 
-        if messages.user_file_path:
-            # Gemini 2.0 charges 258 tokens per page for all PDF inputs.  For more detail, see https://gemini-api.apidog.io/doc-965859#technical-details
-            doc = fitz.open(messages.user_file_path)
-            tokens += len(doc) * 258
+        if messages.user_file:
+            tokens += self.count_file_input_tokens(messages)
         return tokens
 
 

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -578,6 +578,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         """
         try:
             try:
+                # TODO: make the timeout configurable, or dynamic based on request size.
                 maybe_response = await asyncio.wait_for(
                     self.make_single_request(queue_item.request),
                     timeout=120.0,

--- a/src/fenic/api/functions/semantic.py
+++ b/src/fenic/api/functions/semantic.py
@@ -608,6 +608,9 @@ def parse_pdf(
         page_separator: Optional page separator to use for the parsing.  If the separator includes the {page} placeholder, the model will replace it with the current page number.
         describe_images:  Flag to describe images in the PDF. If True, the prompt will ask the model to include a description of the image in the markdown output.  If False, the prompt asks the model to ignore images that aren't tables or charts.
 
+    Note:
+        For Gemini models, this function uses the google file API, uploading PDF files to Google's file store and deleting them after each request.
+
     Raises:
         ExecutionError: If paths in the column are not valid PDF files.
 

--- a/src/fenic/core/_logical_plan/expressions/semantic.py
+++ b/src/fenic/core/_logical_plan/expressions/semantic.py
@@ -663,4 +663,6 @@ class SemanticParsePDFExpr(ValidatedSignature, SemanticExpr):
         return f"semantic.parse_pdf({self.expr}, model:{self.model_alias})"
 
     def _eq_specific(self, other: SemanticParsePDFExpr) -> bool:
-        return self.model_alias == other.model_alias and self.page_separator == other.page_separator and self.describe_images == other.describe_images
+        return (self.model_alias == other.model_alias
+                and self.page_separator == other.page_separator
+                and self.describe_images == other.describe_images)

--- a/tests/_backends/local/functions/test_semantic_parse_pdf.py
+++ b/tests/_backends/local/functions/test_semantic_parse_pdf.py
@@ -4,9 +4,11 @@ from textwrap import wrap
 from typing import List, Optional
 
 import pytest
+from pydantic import BaseModel
 
 from fenic import SemanticConfig, Session, SessionConfig, col, semantic
-from fenic.api.session.config import GoogleDeveloperLanguageModel
+from fenic.api.session.config import GoogleDeveloperLanguageModel, OpenAILanguageModel
+from fenic.core._inference.model_catalog import ModelProvider, model_catalog
 from fenic.core.error import ValidationError
 from tests.conftest import _save_pdf_file
 
@@ -16,39 +18,20 @@ basic_text_content = [
     "Content about war and peace, examining the complex relationship between conflict and harmony throughout human history. This analysis covers major historical conflicts, their causes and consequences, as well as the various peace movements and diplomatic efforts that have shaped our world. The discussion includes philosophical perspectives on violence, justice, and the pursuit of lasting peace.",
 ]
 
-def make_test_pdf_paths(text_content: list[str],
-                        temp_dir: str,
-                        pdf_count: int,
-                        page_count: int,
-                        include_images:Optional[List[bool]] = None,
-                        include_small_images: Optional[List[bool]] = None,
-                        include_signatures: Optional[List[bool]] = None):
-    """Create PDFs with varying content in the given temporary directory."""
-    pdf_paths = []
-    for i in range(pdf_count):
-        path = os.path.join(temp_dir, f"file{i}.pdf")
-        _save_pdf_file(Path(path),
-                   title=f"File {i} Title", author=f"File {i} Author", page_count=page_count,
-                   text_content=text_content,
-                   include_headers_and_footers=True,
-                   include_images=False if not include_images else include_images[i],
-                   include_small_images=False if not include_small_images else include_small_images[i],
-                   include_signatures=False if not include_signatures else include_signatures[i])
-        pdf_paths.append(path)
+vlms_to_test = [
+    # TODO: add openai tests when adding openai parse_pdf support
+    #(OpenAILanguageModel, "gpt-5-nano"),
+    #(OpenAILanguageModel, "gpt-4o-mini"),
+    #(OpenAILanguageModel, "o3-mini"),
+    (GoogleDeveloperLanguageModel, "gemini-2.5-pro"),
+    (GoogleDeveloperLanguageModel, "gemini-2.0-flash-lite"),
+    (GoogleDeveloperLanguageModel, "gemini-2.5-flash-lite"),
+]
 
-    return pdf_paths
 
-@pytest.fixture
-def google_genai_session_config():
-    config = SessionConfig(
-        app_name="test_app_google",
-        semantic=SemanticConfig(
-            language_models={"gemini_2.0_flash-lite": GoogleDeveloperLanguageModel(model_name="gemini-2.0-flash-lite", rpm=1000, tpm=100000)}
-        ),
-    )
-    return Session.get_or_create(config)
-
-def test_semantic_parse_pdf_basic_markdown(request, temp_dir_just_one_file, google_genai_session_config):
+@pytest.mark.parametrize("pdf_chunk_size", [1, 0])
+@pytest.mark.parametrize("test_model_class, test_model_name", vlms_to_test)
+def test_semantic_parse_pdf_basic_markdown(request, temp_dir_just_one_file, test_model_class, test_model_name, pdf_chunk_size, monkeypatch):
     """Test basic PDF parsing functionality.
 
     By default, just parse the PDFS and make sure non-empty markdown is returned.
@@ -60,13 +43,18 @@ def test_semantic_parse_pdf_basic_markdown(request, temp_dir_just_one_file, goog
     if request.config.getoption("--test-model-evaluation"):
         evaluate_response = True
 
-    pdf_paths = make_test_pdf_paths(basic_text_content,
+    if pdf_chunk_size > 0:
+        # Mock PDF_MAX_PAGES_CHUNK
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", pdf_chunk_size)
+
+    local_session = _setup_session_with_vlm(test_model_class=test_model_class, model_name=test_model_name)
+    pdf_paths = _make_test_pdf_paths(basic_text_content,
                                     temp_dir_just_one_file,
                                     pdf_count=pdf_count,
                                     page_count=page_count,
                                     include_images=[True, False])
     try:
-        df = google_genai_session_config.create_dataframe({"pdf_path": pdf_paths})
+        df = local_session.create_dataframe({"pdf_path": pdf_paths})
         markdown_result = df.select(
             semantic.parse_pdf(col("pdf_path")).alias("markdown_content")
         ).collect()
@@ -82,9 +70,12 @@ def test_semantic_parse_pdf_basic_markdown(request, temp_dir_just_one_file, goog
                         assert line in markdown_result.data["markdown_content"][i]
                 assert "Image" not in markdown_result.data["markdown_content"][i]
     finally:
-        google_genai_session_config.stop()
+        local_session.stop()
 
-def test_semantic_parse_pdf_markdown_with_simple_page_break_and_images(request,temp_dir_just_one_file, google_genai_session_config):
+
+@pytest.mark.parametrize("pdf_chunk_size", [1, 0])
+@pytest.mark.parametrize("test_model_class, test_model_name", vlms_to_test)
+def test_semantic_parse_pdf_markdown_with_simple_page_break_and_images(request, temp_dir_just_one_file, test_model_class, test_model_name, pdf_chunk_size, monkeypatch):
     """Test basic PDF parsing functionality with page separators and image descriptions.
 
     By default, just parse the PDFS and make sure non-empty markdown is returned.
@@ -96,14 +87,19 @@ def test_semantic_parse_pdf_markdown_with_simple_page_break_and_images(request,t
     if request.config.getoption("--test-model-evaluation"):
         evaluate_response = True
 
-    pdf_paths = make_test_pdf_paths(basic_text_content,
+    if pdf_chunk_size > 0:
+        # Mock PDF_MAX_PAGES_CHUNK
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", pdf_chunk_size)
+
+    local_session = _setup_session_with_vlm(test_model_class=test_model_class, model_name=test_model_name)
+    pdf_paths = _make_test_pdf_paths(basic_text_content,
                                     temp_dir_just_one_file,
                                     pdf_count=pdf_count,
                                     page_count=page_count,
                                     include_images=[True, False],
                                     include_small_images=[True, True])
     try:
-        df = google_genai_session_config.create_dataframe({"pdf_path": pdf_paths})
+        df = local_session.create_dataframe({"pdf_path": pdf_paths})
         markdown_result = df.select(
             semantic.parse_pdf(col("pdf_path"),
                 page_separator="--- PAGE {page} ---",
@@ -128,7 +124,8 @@ def test_semantic_parse_pdf_markdown_with_simple_page_break_and_images(request,t
                 #else:
                 #    assert "Image" in markdown_result.data["markdown_content"][i]
     finally:
-        google_genai_session_config.stop()
+        local_session.stop()
+
 
 def test_semantic_parse_pdf_without_models():
     """Test that an error is raised if no language models are configured."""
@@ -139,3 +136,57 @@ def test_semantic_parse_pdf_without_models():
     with pytest.raises(ValidationError, match="No language models configured."):
         session.create_dataframe({"pdf_path": ["test.pdf"]}).select(semantic.parse_pdf(col("pdf_path")).alias("markdown_content"))
     session.stop()
+
+def _make_test_pdf_paths(text_content: list[str],
+                        temp_dir: str,
+                        pdf_count: int,
+                        page_count: int,
+                        include_images:Optional[List[bool]] = None,
+                        include_small_images: Optional[List[bool]] = None,
+                        include_signatures: Optional[List[bool]] = None):
+    """Create PDFs with varying content in the given temporary directory."""
+    pdf_paths = []
+    for i in range(pdf_count):
+        path = os.path.join(temp_dir, f"file{i}.pdf")
+        _save_pdf_file(Path(path),
+                   title=f"File {i} Title", author=f"File {i} Author", page_count=page_count,
+                   text_content=text_content,
+                   include_headers_and_footers=True,
+                   include_images=False if not include_images else include_images[i],
+                   include_small_images=False if not include_small_images else include_small_images[i],
+                   include_signatures=False if not include_signatures else include_signatures[i])
+        pdf_paths.append(path)
+
+    return pdf_paths
+
+# Test Utility Functions
+def _setup_session_with_vlm(test_model_class: BaseModel, model_name: str):
+    # Lookup the model provider and parameters
+
+    model_parameters = model_catalog.get_completion_model_parameters(
+        ModelProvider("openai" if test_model_class == OpenAILanguageModel else "google-developer"), model_name
+    )
+    # Set up the profile with the lowest reasoning effort allowed by the model
+    if test_model_class == GoogleDeveloperLanguageModel:
+        if model_parameters.supports_disabled_reasoning:
+            profile = test_model_class.Profile(thinking_token_budget=0)
+        else:
+            # gemini-2.5-pro doesn't support disabled reasoning and needs a minimum of 128 tokens
+            profile = test_model_class.Profile(thinking_token_budget=128)
+    elif test_model_class == OpenAILanguageModel and model_parameters.supports_profiles:
+        if model_parameters.supports_minimal_reasoning:
+            profile = test_model_class.Profile(reasoning_effort="minimal")
+        else:
+            profile = test_model_class.Profile(reasoning_effort="low")
+    config = SessionConfig(
+        app_name="test_app_google",
+        semantic=SemanticConfig(
+            language_models={"vlm": test_model_class(
+                model_name=model_name,
+                rpm=500,
+                tpm=1_000_000,
+                profiles={"low_reasoning": profile} if model_parameters.supports_profiles else None,
+            )}
+        ),
+    )
+    return Session.get_or_create(config)

--- a/tests/_backends/local/semantic_operators/test_parse_pdf.py
+++ b/tests/_backends/local/semantic_operators/test_parse_pdf.py
@@ -1,5 +1,9 @@
+import base64
+import math
 import os
+import re
 from textwrap import dedent
+from unittest.mock import MagicMock
 
 import jinja2
 import polars as pl
@@ -8,7 +12,100 @@ import pytest
 from fenic._backends.local.semantic_operators.parse_pdf import ParsePDF
 from fenic._inference.common_openai.openai_utils import convert_messages
 from fenic.core.error import FileLoaderError
+from tests.conftest import _save_pdf_file
 
+
+def _check_base64_string(s):
+    """Check if a string is valid base64 encoded content."""
+    if not isinstance(s, str):
+        return False
+    
+    # Check if it starts with data:application/pdf;base64, pattern
+    assert s.startswith("data:application/pdf;base64,")
+    base64_part = s.split(",", 1)[1]
+    
+    # Check if it's valid base64
+    base64.b64decode(base64_part, validate=True)
+
+def compare_openai_converted_messages(actual, expected):
+    """
+    Compare two lists of converted messages.
+
+    For the file_data field, just verify it's base64 encoded content.
+    Args:
+        actual: List of actual message dictionaries
+        expected: List of expected message dictionaries  
+    """
+    assert len(actual) == len(expected)
+    for actual_messages, expected_messages in zip(actual, expected, strict=False):
+        for actual_msg, expected_msg in zip(actual_messages, expected_messages, strict=False):
+            # Compare all fields except file_data
+            assert "content" in actual_msg
+            assert "role" in actual_msg
+            assert actual_msg["role"] == expected_msg["role"]
+            if actual_msg["role"] == "system":
+                assert actual_msg["content"] == expected_msg["content"]
+            elif actual_msg["role"] == "user":
+                actual_content = actual_msg["content"][0]
+                expected_content = expected_msg["content"][0]
+                assert "file" in actual_msg["content"][0]
+                assert "type" in actual_content
+                assert actual_content["type"] == expected_content["type"]
+                assert "filename" in actual_content["file"]
+                assert "file_data" in actual_content["file"]
+                assert actual_content["file"]["filename"] == expected_content["file"]["filename"]
+                _check_base64_string(actual_content["file"]["file_data"])
+    return True
+
+
+
+
+@pytest.fixture
+def mock_language_model():
+    """Pytest fixture to create a mock LanguageModel object."""
+    mock_language_model = MagicMock()
+    mock_language_model.max_context_window_length = 3000
+    model_parameters = MagicMock()
+    model_parameters.max_context_window_length = 3000
+    model_parameters.max_output_tokens = 1000
+    mock_language_model.model_parameters = model_parameters
+    mock_language_model.count_tokens.return_value = 10
+    return mock_language_model
+
+def mock_get_completions(messages, **kwargs):
+    completions = [MagicMock(completion=f"Semantic Parse Output: start_page:'{message.user_file.page_range[0]}'") for message in messages]
+    return completions
+
+def check_chunk_content_and_order(result, chunks, chunk_max_size):
+    # Extract all start_page numbers using regex
+    pattern = r"Semantic Parse Output: start_page:'(\d+)'"
+    matches = re.findall(pattern, result)
+
+    # Convert to integers and check order
+    start_page_numbers = [int(match) for match in matches]
+
+    # Verify we have the expected number of chunks
+    assert len(start_page_numbers) == chunks, f"Expected {chunks} chunks, got {len(start_page_numbers)}"
+
+    # Check that pages follow the pattern: 0, chunk_max_size, chunk_max_size*2, ...
+    expected_order = [i * chunk_max_size for i in range(chunks)]
+    assert start_page_numbers == expected_order, f"Expected order {expected_order}, got {start_page_numbers}"
+
+    return start_page_numbers
+
+def check_chunk_page_separators(result, pages, chunk_max_size):
+    pattern = r"--- PAGE (\d+) ---"
+    end_page_numbers = re.findall(pattern, result)
+
+    chunk_count = math.ceil(pages / chunk_max_size)
+
+    assert len(end_page_numbers) == chunk_count - 1
+
+    if chunk_count == 1:
+        return
+
+    expected_pages = [str(chunk_max_size * (i+1)) for i in range(chunk_count - 1)]
+    assert end_page_numbers == expected_pages
 
 class TestParsePDF:
     """Test cases for the ParsePDF operator."""
@@ -19,10 +116,12 @@ class TestParsePDF:
          - Preserve the structure, formatting, headings, lists, and any tables to the best of your ability
          - Format tables as github markdown tables, however:
              - for table headings, immediately add ' |' after the table heading
+        {% if multiple_pages %}
         {% if page_separator and '{page}' in page_separator %}
          - Insert the page separator '{{ page_separator }}' as a markdown line for each page break, replacing the '{{ '{page}' }}' pattern with the current page number. If the document contains page numbers, do not include them in the output, instead replace them with this page separator.
         {% elif page_separator %}
          - Don't include the page numbers in the output, instead insert the page separator '{{ page_separator }}' as a markdown line for each page break
+        {% endif %}
         {% endif %}
         {% if describe_images %}
          - For each image, describe them briefly in a markdown section with 'Image' in the title, preserving the output order.
@@ -44,24 +143,23 @@ class TestParsePDF:
         result = list(
             map(
                 lambda x: convert_messages(x) if x else None,
-                parse_pdf.build_request_messages_batch(),
+                parse_pdf.build_request_messages_batch()[0],
             )
         )
-
         expected = [
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=None),
+                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=False, multiple_pages=False),
                 },
                 {
                     "role": "user",
                     "content": [
                     {
                         "type": "file",
-                        "content": {
+                        "file": {
                             "filename": file_path_1,
-                            "file_data": file_path_1,
+                            "file_data": "dummy_value", # checked separately in _check_base64_string
                         },
                     }
                 ]}
@@ -69,28 +167,34 @@ class TestParsePDF:
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=None),
+                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=False, multiple_pages=False),
                 },
                 {
                     "role": "user",
                     "content": [
                     {
                         "type": "file",
-                        "content": {
+                        "file": {
                             "filename": file_path_2,
-                            "file_data": file_path_2,
+                            "file_data": "dummy_value", # checked separately in _check_base64_string
                         },
                     }
                 ]}
             ],
         ]
+        compare_openai_converted_messages(result, expected)
 
-        assert result == expected
-
-    def test_build_prompts_with_page_separator(self, local_session, temp_dir_with_test_files):
+    def test_build_prompts_with_page_separator(self, local_session, temp_dir_just_one_file, monkeypatch):
         """Test PDF parsing with page separator."""
-        file_path = os.path.join(temp_dir_with_test_files, "file8.pdf")
-        input = pl.Series("input", [file_path])
+        file_path_1 = os.path.join(temp_dir_just_one_file, "file_one_page.pdf")
+        file_path_2 = os.path.join(temp_dir_just_one_file, "file_two_pages.pdf")
+        _save_pdf_file(os.path.join(temp_dir_just_one_file, "file_one_page.pdf"), page_count=1, text_content="dummy text")
+        _save_pdf_file(os.path.join(temp_dir_just_one_file, "file_two_pages.pdf"), page_count=2, text_content="dummy text")
+
+        # make sure we're chunking with 1 page sizes
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", 1)
+
+        input = pl.Series("input", [file_path_1, file_path_2])
 
         page_separator = "--- PAGE BREAK ---"
         parse_pdf = ParsePDF(
@@ -102,7 +206,7 @@ class TestParsePDF:
         result = list(
             map(
                 lambda x: convert_messages(x) if x else None,
-                parse_pdf.build_request_messages_batch(),
+                parse_pdf.build_request_messages_batch()[0],
             )
         )
 
@@ -110,26 +214,61 @@ class TestParsePDF:
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=None),
+                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=False, multiple_pages=False),
                 },
                 {
                     "role": "user",
                     "content": [
                         {
                             "type": "file",
-                            "content": {
-                                "filename": file_path,
-                                "file_data": file_path,
+                            "file": {
+                                "filename": file_path_1,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
                             },
                         }
                     ],
                 },
-            ]
+            ],
+            [
+                {
+                    "role": "system",
+                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=False, multiple_pages=True),
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "file",
+                            "file": {
+                                "filename": file_path_2,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
+                            },
+                        }
+                    ],
+                },
+            ],
+                        [
+                {
+                    "role": "system",
+                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=False, multiple_pages=True),
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "file",
+                            "file": {
+                                "filename": file_path_2,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
+                            },
+                        }
+                    ],
+                },
+            ],
         ]
+        compare_openai_converted_messages(result, expected)
 
-        assert result == expected
-
-    def test_build_prompts_with_formatted_page_separator(self, local_session, temp_dir_with_test_files):
+    def test_build_prompts_with_page_number_placeholder(self, local_session, temp_dir_with_test_files):
         """Test PDF parsing with page number placeholder in separator."""
         file_path = os.path.join(temp_dir_with_test_files, "file8.pdf")
         input = pl.Series("input", [file_path])
@@ -144,7 +283,7 @@ class TestParsePDF:
         result = list(
             map(
                 lambda x: convert_messages(x) if x else None,
-                parse_pdf.build_request_messages_batch(),
+                parse_pdf.build_request_messages_batch()[0],
             )
         )
 
@@ -152,16 +291,16 @@ class TestParsePDF:
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=None),
+                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=False, multiple_pages=False),
                 },
                 {
                     "role": "user",
                     "content": [
                         {
                             "type": "file",
-                            "content": {
+                            "file": {
                                 "filename": file_path,
-                                "file_data": file_path,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
                             },
                         }
                     ],
@@ -169,7 +308,7 @@ class TestParsePDF:
             ]
         ]
 
-        assert result == expected
+        compare_openai_converted_messages(result, expected)
 
     def test_build_prompts_with_describe_images(self, local_session, temp_dir_with_test_files):
         """Test PDF parsing with image description enabled."""
@@ -185,7 +324,7 @@ class TestParsePDF:
         result = list(
             map(
                 lambda x: convert_messages(x) if x else None,
-                parse_pdf.build_request_messages_batch(),
+                parse_pdf.build_request_messages_batch()[0],
             )
         )
 
@@ -193,16 +332,16 @@ class TestParsePDF:
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=True),
+                    "content": self.expected_system_prompt.render(page_separator=None, describe_images=True, multiple_pages=False),
                 },
                 {
                     "role": "user",
                     "content": [
                         {
                             "type": "file",
-                            "content": {
+                            "file": {
                                 "filename": file_path,
-                                "file_data": file_path,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
                             },
                         }
                     ],
@@ -210,14 +349,21 @@ class TestParsePDF:
             ]
         ]
 
-        assert result == expected
+        compare_openai_converted_messages(result, expected)
 
-    def test_build_prompts_with_all_options(self, local_session, temp_dir_with_test_files):
-        """Test PDF parsing with all options enabled."""
-        file_path = os.path.join(temp_dir_with_test_files, "file8.pdf")
+    def test_build_prompts_with_all_options(self, local_session, temp_dir_just_one_file, monkeypatch):
+        """Test PDF parsing with page number placeholder in separator and image description enabled.
+
+        Create a pdf with 2 pages."""
+        file_path = os.path.join(temp_dir_just_one_file, "file_two_pages.pdf")
+        _save_pdf_file(os.path.join(temp_dir_just_one_file, "file_two_pages.pdf"), page_count=2, text_content="dummy text")
         input = pl.Series("input", [file_path])
 
         page_separator = "--- PAGE {page} ---"
+
+        # make sure we're chunking with 1 page sizes
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", 1)
+
         parse_pdf = ParsePDF(
             input=input,
             model=local_session._session_state.get_language_model(),
@@ -228,7 +374,7 @@ class TestParsePDF:
         result = list(
             map(
                 lambda x: convert_messages(x) if x else None,
-                parse_pdf.build_request_messages_batch(),
+                parse_pdf.build_request_messages_batch()[0],
             )
         )
 
@@ -236,16 +382,34 @@ class TestParsePDF:
             [
                 {
                     "role": "system",
-                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=True),
+                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=True, multiple_pages=True),
                 },
                 {
                     "role": "user",
                     "content": [
                         {
                             "type": "file",
-                            "content": {
+                            "file": {
                                 "filename": file_path,
-                                "file_data": file_path,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
+                            },
+                        }
+                    ],
+                },
+            ],
+            [
+                {
+                    "role": "system",
+                    "content": self.expected_system_prompt.render(page_separator=page_separator, describe_images=True, multiple_pages=True),
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "file",
+                            "file": {
+                                "filename": file_path,
+                                "file_data": "dummy_value", # checked separately in _check_base64_string
                             },
                         }
                     ],
@@ -253,7 +417,7 @@ class TestParsePDF:
             ]
         ]
 
-        assert result == expected
+        compare_openai_converted_messages(result, expected)
 
     def test_handles_invalid_file_extensions(self, local_session, temp_dir_with_test_files):
         """Test handling of invalid file extensions in input."""
@@ -274,3 +438,137 @@ class TestParsePDF:
                 input=input,
                 model=local_session._session_state.get_language_model(),
             )
+
+
+
+    def test_pdf_chunking_based_on_token_limit(self, temp_dir_just_one_file, mock_language_model):
+        #create pdfs of varying page counts.  Mock token count for each page to be 50 tokens.
+        page_counts = [1, 5, 10, 20]
+        pdf_paths = []
+        for i in range(len(page_counts)):
+            path = os.path.join(temp_dir_just_one_file, f"file{i}.pdf")
+            _save_pdf_file(path,
+                   title="File Title {i}", author="File Author {i}", page_count=page_counts[i],
+                   text_content="dummy text")
+            pdf_paths.append(path)
+
+
+        input = pl.Series("input", pdf_paths)
+
+
+        mock_language_model.model_parameters.max_output_tokens = 150
+        mock_language_model.count_tokens.return_value = 50
+        mock_language_model.get_completions.side_effect = mock_get_completions
+
+        parse_pdf = ParsePDF(
+            input=input,
+            model=mock_language_model,
+        )
+
+        result = parse_pdf.execute()
+        assert result.shape == (len(page_counts),)
+
+        check_chunk_content_and_order(result[0], chunks=1, chunk_max_size=2)
+        check_chunk_content_and_order(result[1], chunks=3, chunk_max_size=2)
+        check_chunk_content_and_order(result[2], chunks=5, chunk_max_size=2)
+        check_chunk_content_and_order(result[3], chunks=10, chunk_max_size=2)
+
+    def test_pdf_chunking_based_on_internal_limit(self, temp_dir_just_one_file, mock_language_model, monkeypatch):
+        # create a pdfs with varying page counts.  Mock max_output_tokens to be something larger than the total number of tokens in the pdfs.
+        page_counts = [1, 5, 10, 20]
+        pdf_paths = []
+        for i in range(len(page_counts)):
+            path = os.path.join(temp_dir_just_one_file, f"file{i}.pdf")
+            _save_pdf_file(path,
+                   title="File Title {i}", author="File Author {i}", page_count=page_counts[i],
+                   text_content="dummy text")
+            pdf_paths.append(path)
+
+        mock_language_model.max_output_tokens = 100_000
+        mock_language_model.count_tokens.return_value = 50
+        mock_language_model.get_completions.side_effect = mock_get_completions
+
+        input = pl.Series("input", pdf_paths)
+
+        parse_pdf = ParsePDF(
+            input=input,
+            model=mock_language_model,
+        )
+
+        test_chunk_max_size = 4
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result = parse_pdf.execute()
+        assert result.shape == (len(page_counts),)
+        check_chunk_content_and_order(result[0], chunks=1, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result[1], chunks=2, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result[2], chunks=3, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result[3], chunks=5, chunk_max_size=test_chunk_max_size)
+
+        test_chunk_max_size = 1
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result2 = parse_pdf.execute()
+        assert result2.shape == (len(page_counts),)
+        check_chunk_content_and_order(result2[0], chunks=1, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result2[1], chunks=5, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result2[2], chunks=10, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result2[3], chunks=20, chunk_max_size=test_chunk_max_size)
+
+        test_chunk_max_size = 10
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result3 = parse_pdf.execute()
+        assert result3.shape == (len(page_counts),)
+        check_chunk_content_and_order(result3[0], chunks=1, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result3[1], chunks=1, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result3[2], chunks=1, chunk_max_size=test_chunk_max_size)
+        check_chunk_content_and_order(result3[3], chunks=2, chunk_max_size=test_chunk_max_size)
+
+
+    def test_pdf_chunking_with_page_separator(self, temp_dir_just_one_file, mock_language_model, monkeypatch):
+       # create a pdfs with varying page counts.  Mock max_output_tokens to be something larger than the total number of tokens in the pdfs.
+        page_counts = [1, 5, 10, 20]
+        pdf_paths = []
+        for i in range(len(page_counts)):
+            path = os.path.join(temp_dir_just_one_file, f"file{i}.pdf")
+            _save_pdf_file(path,
+                   title="File Title {i}", author="File Author {i}", page_count=page_counts[i],
+                   text_content="dummy text")
+            pdf_paths.append(path)
+
+        mock_language_model.max_output_tokens = 100_000
+        mock_language_model.count_tokens.return_value = 50
+        mock_language_model.get_completions.side_effect = mock_get_completions
+
+        input = pl.Series("input", pdf_paths)
+
+        parse_pdf = ParsePDF(
+            input=input,
+            model=mock_language_model,
+            page_separator="--- PAGE {page} ---",
+        )
+
+        test_chunk_max_size = 4
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result = parse_pdf.execute()
+        assert result.shape == (len(page_counts),)
+        check_chunk_page_separators(result[0], pages=page_counts[0], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result[1], pages=page_counts[1], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result[2], pages=page_counts[2], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result[3], pages=page_counts[3], chunk_max_size=test_chunk_max_size)
+
+        test_chunk_max_size = 1
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result2 = parse_pdf.execute()
+        assert result2.shape == (len(page_counts),)
+        check_chunk_page_separators(result2[0], pages=page_counts[0], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result2[1], pages=page_counts[1], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result2[2], pages=page_counts[2], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result2[3], pages=page_counts[3], chunk_max_size=test_chunk_max_size)
+
+        test_chunk_max_size = 10
+        monkeypatch.setattr("fenic._backends.local.semantic_operators.parse_pdf.PDF_MAX_PAGES_CHUNK", test_chunk_max_size)
+        result3 = parse_pdf.execute()
+        assert result3.shape == (len(page_counts),)
+        check_chunk_page_separators(result3[0], pages=page_counts[0], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result3[1], pages=page_counts[1], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result3[2], pages=page_counts[2], chunk_max_size=test_chunk_max_size)
+        check_chunk_page_separators(result3[3], pages=page_counts[3], chunk_max_size=test_chunk_max_size)

--- a/tests/_inference/google/test_gemini_token_counter.py
+++ b/tests/_inference/google/test_gemini_token_counter.py
@@ -1,9 +1,13 @@
+import os
+
+import fitz
 import pytest
 
 pytest.importorskip("google.genai")
 
 from fenic._inference.google.gemini_token_counter import GeminiLocalTokenCounter
-from fenic._inference.types import FewShotExample, LMRequestMessages
+from fenic._inference.types import FewShotExample, LMRequestFile, LMRequestMessages
+from tests.conftest import _save_pdf_file
 
 
 def test_local_token_counter_counts_tokens():
@@ -30,3 +34,38 @@ def test_google_tokenizer_counts_tokens_for_message_list():
         user="Summarize: The quick brown fox jumps over the lazy dog.",
     )
     assert counter.count_tokens(messages) == 21
+
+def test_google_tokenizer_counts_tokens_for_pdfs(temp_dir_just_one_file):
+    model = "gemini-2.0-flash"
+    pdf_path1 = os.path.join(temp_dir_just_one_file, "test_pdf_one_page.pdf")
+    pdf_path2 = os.path.join(temp_dir_just_one_file, "test_pdf_three_pages.pdf")
+    _save_pdf_file(pdf_path1, page_count=1, text_content="The quick brown fox jumps over the lazy dog.")
+    _save_pdf_file(pdf_path2, page_count=3, text_content="The quick brown fox jumps over the lazy dog.")
+    counter = GeminiLocalTokenCounter(model_name=model)
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path1, page_range=(0, 0))
+    )
+    # 258 tokens per page.  System message is counted separately.
+    assert counter.count_tokens(messages) == 258
+
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path2, page_range=(0, 2)),
+    )
+    # 258 tokens per page.  System message is counted separately.
+    assert counter.count_tokens(messages) == 258 * 3
+    
+    # Test chunk sized 1 page
+    pdf_2 = fitz.open(pdf_path2)
+    pdf_2_chunk = fitz.open()
+    pdf_2_chunk.insert_pdf(pdf_2, from_page=1, to_page=1)
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path2, pdf_chunk_bytes=pdf_2_chunk.tobytes(), page_range=(1, 1)),
+    )
+    # 258 tokens per page.  System message is counted separately.
+    assert counter.count_tokens(messages) == 258


### PR DESCRIPTION
### TL;DR

Gemini models especially are limited by the output token limit, only 8K tokens (for flash-2.0). Added PDF parsing by implementing chunking-by-page for large documents, based on the models output token limit.

Also refactored file support in LMRequestMessage (added LMRequestFile), and ability for gemini to send chunked pdfs in requests

## What changed?

### Chunks
- Added support for processing PDFs in chunks based on page count and output token limits
   - Chunking happens once, when requests are built
   - These chunks are saved as bytes in the LMRequestMessage, in new LMRequestFile class
   -`ParsePDF` operator will separate long PDFs into chunks with separate requests per chunk, then in postprocess, will concat the responses for each chunk into a single coherent output, honoring the page delimiter option
   - Added internal configuration to force PDF max chunk size (page count): PDF_MAX_PAGES_CHUNK
   - Added unit tests to test_parse_pdf to test various chunk sizes 

### Token estimations and LMRequestFile
- Token estimation optionally uses the pdf chunk bytes in the LMRequestMessages
- Added utility functions for PDF processing: pdf_to_base64, get_pdf_text, and get_pdf_pages
- Added Fixed token estimation for requests with PDF files for Gemini (258 tokens per page)

### Unit tests
1. Added test matrix to semantic_parse_pdf unit tests to run against various gemini  models
2. Added Unit tests for parse_pdf operator - testing various page chunk sizes, page deliminator options, and token limits/output with a mock llm, and validating the output
3. Added unit tests for token estimations
4. Added unit tests for semantic_parse_pdf that internally set the page batch size to 1 before sending requests to various llms and checking the semantic output 

## How to test?

### Run unit tests

### Stress tests
1. Run pdfparsing against hundreds of pages of financial documents using supported gemini models 
  2. With various chunking settings
  3. make sure they return markdown without any errors

## Not in scope of this PR

- OpenAI support
- Test harness for stress/advanced eval testing
- evaluating model accuracy


