### PR TITLE
refactor: s/get_tool/describe_tool, also add tests for all of the new tool related catalog functions that were missing

### DIFF
--- a/docs/topics/fenic-mcp.md
+++ b/docs/topics/fenic-mcp.md
@@ -132,8 +132,8 @@ List, fetch, or drop tools:
 
 ```python
 all_tools = session.catalog.list_tools()
-age_tool = session.catalog.get_tool("users_by_age_range")
-search_tool = session.catalog.get_tool("users_by_name_regex")
+age_tool = session.catalog.describe_tool("users_by_age_range")
+search_tool = session.catalog.describe_tool("users_by_name_regex")
 session.catalog.drop_tool("users_by_age_range", ignore_if_not_exists=True)
 session.catalog.drop_tool("users_by_name_regex", ignore_if_not_exists=True)
 ```

--- a/src/fenic/_backends/cloud/catalog.py
+++ b/src/fenic/_backends/cloud/catalog.py
@@ -341,11 +341,7 @@ class CloudCatalog(BaseCatalog):
             "Set view description not implemented for cloud catalog"
         )
 
-    def get_tool(
-        self,
-        tool_name: str,
-        ignore_if_not_exists: bool = True,
-    ) -> ParameterizedToolDefinition:
+    def describe_tool(self, tool_name: str) -> ParameterizedToolDefinition:
         """Find and return the tool from the current database."""
         # TODO: Implement get tool for the cloud
         raise NotImplementedError(

--- a/src/fenic/_backends/local/catalog.py
+++ b/src/fenic/_backends/local/catalog.py
@@ -506,13 +506,11 @@ class LocalCatalog(BaseCatalog):
                 ) from e
 
 
-    def get_tool(self, tool_name: str, ignore_if_not_exists: bool = True) -> Optional[ParameterizedToolDefinition]:
+    def describe_tool(self, tool_name: str) -> Optional[ParameterizedToolDefinition]:
         """Get a tool's metadata from the system table."""
         cursor = self.db_conn.cursor()
-        existing_tool = self.system_tables.get_tool(cursor, tool_name)
-        if existing_tool:
-            if ignore_if_not_exists:
-                return None
+        existing_tool = self.system_tables.describe_tool(cursor, tool_name)
+        if not existing_tool:
             raise ToolNotFoundError(tool_name)
         return existing_tool
 
@@ -530,7 +528,7 @@ class LocalCatalog(BaseCatalog):
         with self.lock:
             tool_definition = bind_tool(tool_name, tool_description, tool_params, result_limit, tool_query)
             cursor = self.db_conn.cursor()
-            if self.system_tables.get_tool(cursor, tool_name):
+            if self.system_tables.describe_tool(cursor, tool_name):
                 if ignore_if_exists:
                     return False
                 raise ToolAlreadyExistsError(tool_name)
@@ -546,7 +544,7 @@ class LocalCatalog(BaseCatalog):
         """Drop a tool from the current catalog."""
         with self.lock:
             cursor = self.db_conn.cursor()
-            if not self.system_tables.get_tool(cursor, tool_name):
+            if not self.system_tables.describe_tool(cursor, tool_name):
                 if ignore_if_not_exists:
                     return False
                 raise ToolNotFoundError(tool_name)

--- a/src/fenic/_backends/local/system_table_client.py
+++ b/src/fenic/_backends/local/system_table_client.py
@@ -486,7 +486,7 @@ class SystemTableClient:
                 f"Failed to save tool metadata for {tool.name}"
             ) from e
 
-    def get_tool(self, cursor: duckdb.DuckDBPyConnection, tool_name: str) -> Optional[ParameterizedToolDefinition]:
+    def describe_tool(self, cursor: duckdb.DuckDBPyConnection, tool_name: str) -> Optional[ParameterizedToolDefinition]:
         """Get a tool's metadata from the system table.
         Raises:
             CatalogError: If the tool metadata cannot be retrieved.

--- a/src/fenic/api/catalog.py
+++ b/src/fenic/api/catalog.py
@@ -654,14 +654,11 @@ class Catalog:
         return self.catalog.drop_view(view_name, ignore_if_not_exists)
 
     @validate_call(config=ConfigDict(strict=True))
-    def get_tool(self, tool_name: str, ignore_if_not_exists: bool = True) -> ParameterizedToolDefinition:
+    def describe_tool(self, tool_name: str) -> ParameterizedToolDefinition:
         """Returns the tool with the specified name from the current catalog.
 
         Args:
             tool_name (str): The name of the tool to get.
-            ignore_if_not_exists (bool): If True, return None when the tool doesn't exist.
-                If False, raise an error when the tool doesn't exist.
-                Defaults to True.
 
         Raises:
             ToolNotFoundError: If the tool doesn't exist and ignore_if_not_exists is False
@@ -669,7 +666,7 @@ class Catalog:
         Returns:
             Tool: The tool with the specified name.
         """
-        return self.catalog.get_tool(tool_name, ignore_if_not_exists)
+        return self.catalog.describe_tool(tool_name)
 
     @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
     def create_tool(
@@ -771,6 +768,6 @@ class Catalog:
     listViews = list_views
     doesViewExist = does_view_exist
     dropView = drop_view
-    getTool = get_tool
+    describeTool = describe_tool
     createTool = create_tool
     dropTool = drop_tool

--- a/src/fenic/core/_interfaces/catalog.py
+++ b/src/fenic/core/_interfaces/catalog.py
@@ -145,11 +145,7 @@ class BaseCatalog(ABC):
         pass
 
     @abstractmethod
-    def get_tool(
-        self,
-        tool_name: str,
-        ignore_if_not_exists: bool = True
-    ) -> ParameterizedToolDefinition:
+    def describe_tool(self, tool_name: str) -> ParameterizedToolDefinition:
         """Find and return the tool from the current catalog."""
         pass
 

--- a/src/fenic/scripts/fenic_serve.py
+++ b/src/fenic/scripts/fenic_serve.py
@@ -95,7 +95,7 @@ def main() -> None:
     tools = []
     if args.tools:
         for tool_name in args.tools:
-            tools.append(session.catalog.get_tool(tool_name))
+            tools.append(session.catalog.describe_tool(tool_name))
     else:
         tools = session.catalog.list_tools()
 

--- a/tools/mcp_demo_setup.py
+++ b/tools/mcp_demo_setup.py
@@ -122,7 +122,7 @@ def main() -> None:
     job_category_match = fc.coalesce(fc.tool_param("job_category_query", StringType).is_in(fc.col("job_category")), fc.lit(True))
     merged_filter = education_match & seniority_match & skills_match & experience_match & job_category_match
     search_candidates = candidates_df.filter(merged_filter).select("candidate_id", "first_name", "last_name", "education", "seniority", "skills", "experience", "job_category")
-    if local_session.catalog.get_tool("search_candidates"):
+    if local_session.catalog.describe_tool("search_candidates"):
         local_session.catalog.drop_tool("search_candidates")
     local_session.catalog.create_tool(
         "search_candidates",
@@ -140,7 +140,7 @@ def main() -> None:
 
     # Tool 2: candidate_resumes_by_candidate_ids -- given a list of candidate ids, return the raw resumes for each candidate
     candidate_resumes = candidates_df.filter(fc.col("candidate_id").is_in(fc.tool_param("candidate_ids", fc.ArrayType(element_type=IntegerType)))).select("candidate_id", "candidate_resume")
-    if local_session.catalog.get_tool("candidate_resumes_by_candidate_ids"):
+    if local_session.catalog.describe_tool("candidate_resumes_by_candidate_ids"):
         local_session.catalog.drop_tool("candidate_resumes_by_candidate_ids")
     local_session.catalog.create_tool(
         "candidate_resumes_by_candidate_ids",
@@ -208,7 +208,7 @@ def main() -> None:
     )
     job_category_match = fc.coalesce(fc.tool_param("job_category_query", StringType).is_in(fc.col("job_category")), fc.lit(True))
     candidates_for_job = candidates_df.filter(job_category_match).filter(fit_pred).select("candidate_id", "first_name", "last_name", "education", "seniority", "skills", "experience", "job_category")
-    if local_session.catalog.get_tool("candidates_for_job_description"):
+    if local_session.catalog.describe_tool("candidates_for_job_description"):
         local_session.catalog.drop_tool("candidates_for_job_description")
     local_session.catalog.create_tool(
         "candidates_for_job_description",
@@ -279,7 +279,7 @@ def main() -> None:
         ).alias("email"),
     )
     # Filter to a single candidate_id at runtime
-    if local_session.catalog.get_tool("create_outreach_for_candidate"):
+    if local_session.catalog.describe_tool("create_outreach_for_candidate"):
         local_session.catalog.drop_tool("create_outreach_for_candidate")
     local_session.catalog.create_tool(
         "create_outreach_for_candidate",


### PR DESCRIPTION
### TL;DR

Renamed `get_tool()` to `describe_tool()` and removed the `ignore_if_not_exists` parameter to make the API more consistent with other catalog methods.

### What changed?

- Renamed `get_tool()` method to `describe_tool()` in all catalog interfaces and implementations
- Removed the `ignore_if_not_exists` parameter from the method
- Updated all references to the method throughout the codebase
- Updated documentation examples to reflect the new method name
- Added comprehensive tests for tool-related catalog operations

### How to test?

1. Run the updated tests to ensure all tool-related catalog operations work correctly

### Why make this change?

This change improves API consistency by aligning the tool-related methods with other catalog methods like `describe_view()`. The removal of the `ignore_if_not_exists` parameter simplifies the API and makes the behavior more predictable - now the method will always raise an exception when a tool doesn't exist, similar to how other "describe" methods work in the catalog.