### PR TITLE
fix: off-by-one bug in random pdf content generation for testing

### DIFF
--- a/tests/_backends/local/io/test_reader.py
+++ b/tests/_backends/local/io/test_reader.py
@@ -1436,23 +1436,23 @@ def test_read_large_pdfs_with_fields(local_session, temp_dir_just_one_file):
         mod_date = row["mod_date"]
         creation_dt = datetime.strptime(creation_date, "D:%Y%m%d%H%M%S")
         mod_dt = datetime.strptime(mod_date, "D:%Y%m%d%H%M%S")
-        assert creation_dt >= start_time
-        assert mod_dt >= start_time
-        assert not row["is_encrypted"]
-        assert row["size"] > prev_doc_size
+        assert creation_dt >= start_time, f"PDF {i+1} expected to have a creation date after {start_time}"
+        assert mod_dt >= start_time, f"PDF {i+1} expected to have a modification date after {start_time}"
+        assert not row["is_encrypted"] , "PDF expected to be not encrypted"
+        assert row["size"] > prev_doc_size, f"PDF {i+1} expected to be larger than previous PDF"
         prev_doc_size = row["size"]
         if i == 0:
-            assert not row["has_forms"]
-            assert not row["has_signature_fields"]
-            assert row["image_count"] == 0
-            assert row["page_count"] == file1_pages
+            assert not row["has_forms"] , "PDF 1 expected to have no forms"
+            assert not row["has_signature_fields"] , "PDF 1 expected to have no signature fields"
+            assert row["image_count"] == 0, "PDF 1 expected to have no images"
+            assert row["page_count"] == file1_pages, f"PDF 1 expected to have {file1_pages} pages"
         elif i == 1:
-            assert row["has_forms"]
-            assert not row["has_signature_fields"]
-            assert row["image_count"] > 0
-            assert row["page_count"] == file2_pages
+            assert row["has_forms"] , "PDF 2 expected to have forms"
+            assert not row["has_signature_fields"] , "PDF 2 expected to have no signature fields"
+            assert row["image_count"] > 0, "PDF 2 expected to have images"
+            assert row["page_count"] == file2_pages, f"PDF 2 expected to have {file2_pages} pages"
         elif i == 2:
-            assert row["has_forms"]
-            assert row["has_signature_fields"]
-            assert row["image_count"] > 0
-            assert row["page_count"] == file3_pages
+            assert row["has_forms"] , "PDF 3 expected to have forms"
+            assert row["has_signature_fields"] , "PDF 3 expected to have signature fields"
+            assert row["image_count"] > 0, "PDF 3 expected to have images"
+            assert row["page_count"] == file3_pages, f"PDF 3 expected to have {file3_pages} pages"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,17 +528,17 @@ def _save_pdf_file(
             fontsize=12,
         )
 
-        if include_vectors and (random.choice([True, False]) or (not added_vectors and i == page_count)):
+        if include_vectors and (random.choice([True, False]) or (not added_vectors and i == page_count-1)):
             rect = fitz.Rect(100, 100, 200, 200) # x0, y0, x1, y1
             page.draw_rect(rect, color=(0, 0, 1), fill=(0.8, 0.8, 0.95))
             added_vectors = True
 
-        if include_images and (random.choice([True, False]) or (not added_images and i == page_count)):
+        if include_images and (random.choice([True, False]) or (not added_images and i == page_count-1)):
             rect = fitz.Rect(100, 200, 200, 300) # x0, y0, x1, y1
             page.insert_image(rect, pixmap=fitz.Pixmap(fitz.csRGB, fitz.IRect(0,0,100,100)))
             added_images = True
 
-        if include_forms and (random.choice([True, False]) or (not added_forms and i == page_count)):
+        if include_forms and (random.choice([True, False]) or (not added_forms and i == page_count-1)):
             rect = fitz.Rect(100, 400, 200, 500) # x0, y0, x1, y1
             widget = fitz.Widget()
             widget.field_name = f"field_{i}"
@@ -547,7 +547,7 @@ def _save_pdf_file(
             page.add_widget(widget)
             added_forms = True
 
-        if include_signatures and (random.choice([True, False]) or (not added_signatures and i == page_count)):
+        if include_signatures and (random.choice([True, False]) or (not added_signatures and i == page_count-1)):
             rect = fitz.Rect(100, 500, 200, 600) # x0, y0, x1, y1
             widget = fitz.Widget()
             widget.field_name = f"sig_{i}"
@@ -555,8 +555,6 @@ def _save_pdf_file(
             widget.rect = rect
             page.add_widget(widget)
             added_signatures = True
-
-
 
     # Metadata
     now = datetime.datetime.now().strftime("D:%Y%m%d%H%M%S")


### PR DESCRIPTION
## What changed

- PDF randomized content generation had a bug where sometimes it wouldn't generate the content it was asked to, causing test_read_large_pdfs_with_fields to be flaky
- This PR includes the bugfix, and some improved failure logging in test_read_large_pdfs_with_fields

## How was it tested

Before the fix, failure rate was roughly 5%.  
Ran 1000 tests and made sure they were all green