### PR TITLE
fix: unit test relies on non-deterministic calls in reduce

### DIFF
--- a/tests/_backends/local/semantic_operators/test_reduce.py
+++ b/tests/_backends/local/semantic_operators/test_reduce.py
@@ -337,11 +337,11 @@ def test_group_context_injection(mock_language_model):
 
     # First group should have Sales/North in the instruction
     first_call_messages = calls[0][1]['messages'][0]
-    assert "Sales documents from the North region" in first_call_messages.user
 
     # Second group should have Engineering/West in the instruction
     second_call_messages = calls[1][1]['messages'][0]
-    assert "Engineering documents from the West region" in second_call_messages.user
+    assert "Sales documents from the North region" in first_call_messages.user or "Sales documents from the North region" in second_call_messages.user
+    assert "Engineering documents from the West region" in first_call_messages.user or "Engineering documents from the West region" in second_call_messages.user
 
 
 def test_multi_level_sorting_with_nulls(mock_language_model):


### PR DESCRIPTION
### What changed?

Fixed test assertions in `test_group_context_injection` to handle non-deterministic order of LLM calls.

Test was flaky and failing roughly 1 in 20 times.  Something changed the behavior so that reduce sometimes calls its group batches in a different order.

### What changed?

Modified the assertions in `test_group_context_injection` to check the content in reduce messages in either call order.

### How to test?

Run the test suite 100 times
```
pytest --count 100 tests/_backends/local/semantic_operators/test_reduce.py
```
```
uv pip install pytest-repeat
```
