### PR TITLE
refactor: have DatasetSpec lazily fetch the dataframe using `session.table` instead of keeping it in memory

### DIFF
--- a/src/fenic/api/mcp/_tool_generation_utils.py
+++ b/src/fenic/api/mcp/_tool_generation_utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import re
 from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional, Union
@@ -34,36 +32,23 @@ class ToolDataset:
     Attributes:
       table_name: name of the table registered in the catalog.
       description: description of the table from the catalog.
-      session: a fenic Session, used to load tables from the catalog using `table_name`
     """
     table_name: str
     description: str
-    session: Session
 
     def __init__(
         self,
         table_name: str,
         description: str,
-        session: Session
     ):
         self.table_name = table_name
         self.description = description
-        self.session = session
 
-    @property
-    def df(self) -> DataFrame:
-        return self.session.table(self.table_name)
+    def df(self, session: Session) -> DataFrame:
+        return session.table(self.table_name)
 
-    @property
-    def schema(self) -> Schema:
-        return self.session.catalog.describe_table(self.table_name).schema
-
-    @property
-    def schema_fingerprint(self) -> str:
-        hasher = hashlib.sha256()
-        for f in self.schema.column_fields:
-            hasher.update(f"{f.name}|{str(f.data_type)}".encode("utf-8"))
-        return hasher.hexdigest()[:12]
+    def schema(self, session: Session) -> Schema:
+        return session.catalog.describe_table(self.table_name).schema
 
 
 def auto_generate_system_tools_from_tables(
@@ -196,7 +181,7 @@ def _build_datasets_from_tables(table_names: List[str], session: Session) -> Lis
         desc = (table_metadata.description or "").strip()
         if not desc:
             missing_desc.append(table_name)
-        specs.append(ToolDataset(table_name=table_name, description=desc, session=session))
+        specs.append(ToolDataset(table_name=table_name, description=desc))
 
     if missing_tables:
         raise ConfigurationError(
@@ -224,18 +209,7 @@ def _auto_generate_read_tool(
     if len(datasets) == 0:
         raise ConfigurationError("Cannot create read tool: no datasets provided.")
 
-    def _validate_columns(
-        available_columns: List[str],
-        original_columns: List[str],
-        filtered_columns: List[str],
-    ) -> None:
-        if not filtered_columns:
-            raise ValidationError(f"Column(s) {original_columns} not found. Available: {', '.join(available_columns)}")
-        if len(filtered_columns) != len(original_columns):
-            invalid_columns = [c for c in original_columns if c not in filtered_columns]
-            raise ValidationError(f"Column(s) {invalid_columns} not found. Available: {', '.join(available_columns)}")
-
-    async def read_func(
+    def read_func(
         df_name: Annotated[str, "Dataset name to read rows from."],
         limit: Annotated[Optional[int], "Max rows to read within a page"] = result_limit,
         offset: Annotated[Optional[int], "Row offset to start from (requires order_by)"] = None,
@@ -247,18 +221,18 @@ def _auto_generate_read_tool(
 
         if df_name not in datasets:
             raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(datasets.keys())}")
-        df = datasets[df_name].df
+        df = datasets[df_name].df(session)
         order_by = [c.strip() for c in order_by.split(",") if c.strip()] if order_by else None
         available_columns = df.columns
         include_columns = [c.strip() for c in include_columns.split(",") if c.strip()] if include_columns else None
         exclude_columns = [c.strip() for c in exclude_columns.split(",") if c.strip()] if exclude_columns else None
+        if include_columns and exclude_columns:
+            raise ValidationError("include_columns and exclude_columns cannot be used together.")
         if include_columns:
             filtered_columns = [c for c in include_columns if c in available_columns]
-            _validate_columns(available_columns, include_columns, filtered_columns)
             df = df.select(*filtered_columns)
         if exclude_columns:
             filtered_columns = [c for c in available_columns if c not in exclude_columns]
-            _validate_columns(available_columns, exclude_columns, filtered_columns)
             df = df.select(*filtered_columns)
         # Apply paging (handles offset+order_by via SQL and optional limit)
         return _apply_paging(
@@ -289,12 +263,12 @@ def _auto_generate_search_summary_tool(
     if len(datasets) == 0:
         raise ValueError("Cannot create search summary tool: no datasets provided.")
 
-    async def search_summary(
+    def search_summary(
         pattern: Annotated[str, "Regex pattern to search for (use (?i) for case-insensitive)."],
     ) -> LogicalPlan:
         rows: List[Dict[str, object]] = []
         for name, dataset in datasets.items():
-            df = dataset.df
+            df = dataset.df(session)
             cols = [f.name for f in df.schema.column_fields if f.data_type == StringType]
             if not cols:
                 rows.append({"dataset": name, "total_matches": 0})
@@ -305,7 +279,7 @@ def _auto_generate_search_summary_tool(
                 predicate = this if predicate is None else (predicate | this)
 
             df = df.filter(predicate)
-            total_count = await asyncio.to_thread(df.count)
+            total_count = df.count()
             rows.append({"dataset": name, "total_matches": total_count})
 
         pl_df = pl.DataFrame(rows)
@@ -339,7 +313,7 @@ def _auto_generate_search_content_tool(
             return selected
         return [f.name for f in df.schema.column_fields if f.data_type == StringType]
 
-    async def search_rows(
+    def search_rows(
         df_name: Annotated[str, "Dataset name to search (single dataset)"],
         pattern: Annotated[str, "Regex pattern to search for (use (?i) for case-insensitive)."],
         limit: Annotated[Optional[int], "Max rows to read within a page of search results"] = result_limit,
@@ -361,7 +335,7 @@ def _auto_generate_search_content_tool(
             raise ValidationError("Query pattern cannot be empty.")
         if df_name not in datasets:
             raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(datasets.keys())}")
-        df = datasets[df_name].df
+        df = datasets[df_name].df(session)
         cols = _string_columns(df, search_columns)
         if not cols:
             return df.limit(0)._logical_plan
@@ -404,7 +378,7 @@ def _auto_generate_schema_tool(
     if len(datasets) == 0:
         raise ValueError("Cannot create schema tool: no datasets provided.")
 
-    async def schema_func(
+    def schema_func(
         df_name: Annotated[
             str | None, "Optional DataFrame name to return a single schema for. To return schemas for all datasets, OMIT this parameter."] = None,
     ) -> LogicalPlan:
@@ -426,7 +400,7 @@ def _auto_generate_schema_tool(
 
         for name, dataset in selected.items():
             # Build a single-row DataFrame with a common list<struct{column,type}> schema column
-            schema_entries = [{"column": f.name, "type": str(f.data_type)} for f in dataset.schema.column_fields]
+            schema_entries = [{"column": f.name, "type": str(f.data_type)} for f in dataset.schema(session).column_fields]
             dataset_names.append(name)
             dataset_schemas.append(schema_entries)
 
@@ -463,11 +437,11 @@ def _auto_generate_sql_tool(
     if len(datasets) == 0:
         raise ConfigurationError("Cannot create SQL tool: no datasets provided.")
 
-    async def analyze_func(
+    def analyze_func(
         full_sql: Annotated[
             str, "Full SELECT SQL. Refer to DataFrames by name in braces, e.g., `SELECT * FROM {orders}`. JOINs between the provided datasets are allowed. SQL dialect: DuckDB. DDL/DML and multiple top-level queries are not allowed"]
     ) -> LogicalPlan:
-        return session.sql(full_sql.strip(), **{spec.table_name: spec.df for spec in datasets.values()})._logical_plan
+        return session.sql(full_sql.strip(), **{spec.table_name: spec.df(session) for spec in datasets.values()})._logical_plan
 
     # Enhanced description with dataset names and descriptions
     lines: List[str] = [tool_description.strip()]
@@ -592,7 +566,7 @@ def _auto_generate_profile_tool(
     if len(datasets) == 0:
         raise ValueError("Cannot create profile tool: no datasets provided.")
 
-    async def profile_func(
+    def profile_func(
         df_name: Annotated[
             str | None, "Optional DataFrame name to return a single profile for. To return profiles for all datasets, omit this parameter."] = None,
     ) -> LogicalPlan:
@@ -601,17 +575,17 @@ def _auto_generate_profile_tool(
             df_name = None
         # Single dataset branch returns the view plan directly
         if df_name is not None:
-            spec = next((d for d in datasets.values() if d.table_name == df_name), None)
+            spec = datasets.get(df_name)
             if spec is None:
                 raise ValidationError(
                     f"Unknown dataset '{df_name}'. Available: {', '.join(datasets.keys())}")
-            profile_df = await _compute_profile_for_dataset(session, spec, topk_distinct)
+            profile_df = _compute_profile_for_dataset(session, spec, topk_distinct)
             return profile_df._logical_plan
 
         # Multi-dataset: concatenate cached views (or compute & cache if missing)
         profile_df = None
         for spec in datasets.values():
-            df = await _compute_profile_for_dataset(session, spec, topk_distinct)
+            df = _compute_profile_for_dataset(session, spec, topk_distinct)
             if not profile_df:
                 profile_df = df
             else:
@@ -626,13 +600,13 @@ def _auto_generate_profile_tool(
         max_result_limit=None,
     )
 
-async def _compute_profile_for_dataset(
+def _compute_profile_for_dataset(
     session: Session,
     spec: ToolDataset,
     topk_distinct: int,
 ) -> DataFrame:
-    profile_rows = await _compute_profile_rows(
-        spec.df,
+    profile_rows = _compute_profile_rows(
+        spec.df(session),
         spec.table_name,
         topk_distinct,
     )
@@ -645,7 +619,7 @@ async def _compute_profile_for_dataset(
     )
 
 
-async def _compute_profile_rows(
+def _compute_profile_rows(
     df: DataFrame,
     dataset_name: str,
     topk_distinct: int,

--- a/src/fenic/api/mcp/_tool_generation_utils.py
+++ b/src/fenic/api/mcp/_tool_generation_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict, dataclass
-from typing import Dict, List, Literal, Optional, Union, Any
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import polars as pl
 from typing_extensions import Annotated
@@ -560,6 +560,7 @@ class ProfileRow:
     data_type: str
     total_rows: int
     sample_size: int
+    sample_percentage_of_original: float
     null_row_count: int
     non_null_row_count: int
     percent_rows_contains_null: float
@@ -781,7 +782,8 @@ def _compute_profile_rows(
             data_type=dtype_str,
             total_rows=total_rows,
             sample_size=sample_size,
-            percent_rows_contains_null=round(((null_count / float(sample_size)) * 100.0) if sample_size > 0 else 0.0,
+            sample_percentage_of_original=round((float(sample_size) / total_rows) * 100, 1),
+            percent_rows_contains_null=round(((null_count / float(sample_size)) * 100) if sample_size > 0 else 0.0,
                                              1),
             null_row_count=null_count,
             non_null_row_count=non_null_count,
@@ -881,8 +883,13 @@ def _compute_profile_rows(
                         n=k,
                         with_replacement=False,
                         shuffle=True
-                    ).str.slice(0, length=256).to_list()
-                    stats.string_stats.example_values = sampled
+                    ).to_list()
+                    # there are very few values in the sample, so it's not too much of a performance hit to truncate them in python instead of polars
+                    stats.string_stats.example_values = [
+                        (v[:LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH] + f"... (truncated {len(v) - LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH} characters)")
+                        if isinstance(v, str) and len(v) > LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH
+                        else v for v in sampled
+                    ]
         stats.hints = list(set(stats.hints))
         rows_list.append(asdict(stats))
     return rows_list

--- a/src/fenic/api/mcp/_tool_generation_utils.py
+++ b/src/fenic/api/mcp/_tool_generation_utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Dict, List, Literal, Optional, Union
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Literal, Optional, Union, Any
 
 import polars as pl
 from typing_extensions import Annotated
@@ -527,6 +527,33 @@ def _apply_paging(
 
 
 @dataclass
+class NumericStats:
+    min: float
+    max: float
+    mean: float
+    std_dev: float
+    median: float
+    quantile_25: float
+    quantile_75: float
+
+@dataclass
+class TopValues:
+    value: str
+    count: int
+
+@dataclass
+class StringStats:
+    avg_length_chars: float
+    distinct_count: int
+    top_values: List[TopValues]
+    example_values: List[str]
+
+@dataclass
+class BooleanStats:
+    true_rows: int
+    false_rows: int
+
+@dataclass
 class ProfileRow:
     dataset_name: str
     column_name: str
@@ -539,17 +566,9 @@ class ProfileRow:
     semantic_type: Literal["identifier", "categorical", "continuous", "text", "boolean", "unknown"]
     cardinality: Literal["unique", "low", "medium", "high", "unknown"]
     hints: List[str]
-    numeric_min: Optional[float]
-    numeric_max: Optional[float]
-    numeric_mean: Optional[float]
-    numeric_std_dev: Optional[float]
-    numeric_median: Optional[float]
-    string_avg_length_chars: Optional[float]
-    string_distinct_count: Optional[int]
-    string_top_values: Optional[List[Dict[str, Union[int, str]]]]
-    string_example_values: Optional[List[str]]
-    boolean_true_rows: Optional[int]
-    boolean_false_rows: Optional[int]
+    numeric_stats: Optional[NumericStats]
+    string_stats: Optional[StringStats]
+    boolean_stats: Optional[BooleanStats]
 
 def _auto_generate_profile_tool(
     datasets: Dict[str, ToolDataset],
@@ -609,16 +628,44 @@ def _compute_profile_for_dataset(
     spec: ToolDataset,
     topk_distinct: int,
 ) -> DataFrame:
-    profile_rows = _compute_profile_rows(
+    df_rows = _compute_profile_rows(
         spec.df(session),
         spec.table_name,
         topk_distinct,
     )
+    # Enforce struct dtypes so columns don't collapse to Null when all values are None
+    top_values_struct = pl.Struct([pl.Field("value", pl.Utf8), pl.Field("count", pl.Int64)])
+    numeric_struct = pl.Struct([
+        pl.Field("min", pl.Float64),
+        pl.Field("max", pl.Float64),
+        pl.Field("mean", pl.Float64),
+        pl.Field("std_dev", pl.Float64),
+        pl.Field("median", pl.Float64),
+        pl.Field("quantile_25", pl.Float64),
+        pl.Field("quantile_75", pl.Float64),
+    ])
+    boolean_struct = pl.Struct([
+        pl.Field("true_rows", pl.Int64),
+        pl.Field("false_rows", pl.Int64),
+    ])
+    string_struct = pl.Struct([
+        pl.Field("avg_length_chars", pl.Float64),
+        pl.Field("distinct_count", pl.Int64),
+        pl.Field("top_values", pl.List(top_values_struct)),
+        pl.Field("example_values", pl.List(pl.Utf8)),
+    ])
+
+    pl_df = pl.DataFrame(
+        df_rows,
+        schema_overrides={
+            "numeric_stats": numeric_struct,
+            "boolean_stats": boolean_struct,
+            "string_stats": string_struct,
+        },
+    )
 
     return DataFrame._from_logical_plan(
-        InMemorySource.from_session_state(
-            pl.DataFrame(profile_rows), session._session_state,
-        ),
+        InMemorySource.from_session_state(pl_df, session._session_state),
         session._session_state,
     )
 
@@ -627,7 +674,7 @@ def _compute_profile_rows(
     df: DataFrame,
     dataset_name: str,
     topk_distinct: int,
-) -> List[ProfileRow]:
+) -> List[dict[str, Any]]:
     pl_df = df.to_polars()
     total_rows = pl_df.height
     sampled_df = pl_df.sample(min(total_rows, PROFILE_MAX_SAMPLE_SIZE))
@@ -664,6 +711,12 @@ def _compute_profile_rows(
     def a_n_unique(name: str) -> str:
         return f"n_unique__{name}"
 
+    def a_quantile_25(name: str) -> str:
+        return f"quantile_25__{name}"
+
+    def a_quantile_75(name: str) -> str:
+        return f"quantile_75__{name}"
+
     for field in df.schema.column_fields:
         col_name = field.name
         # Common null counts
@@ -676,6 +729,8 @@ def _compute_profile_rows(
                 pl.col(col_name).max().alias(a_max(col_name)),
                 pl.col(col_name).median().alias(a_median(col_name)),
                 pl.col(col_name).std().alias(a_std(col_name)),
+                pl.col(col_name).quantile(0.25).alias(a_quantile_25(col_name)),
+                pl.col(col_name).quantile(0.75).alias(a_quantile_75(col_name)),
             ])
         elif field.data_type == BooleanType:
             # Count of true values (nulls treated as False to avoid null sums)
@@ -691,7 +746,7 @@ def _compute_profile_rows(
         agg_df = sampled_df.select(exprs)
         agg_row = agg_df.to_dicts()[0] if agg_df.height > 0 else {}
 
-    rows_list: List[ProfileRow] = []
+    rows_list: List[dict[str, Any]] = []
     sample_size = sampled_df.height
     for field in df.schema.column_fields:
         col_name = field.name
@@ -699,7 +754,27 @@ def _compute_profile_rows(
         null_count_val = agg_row.get(a_nulls(col_name), 0)
         null_count = int(null_count_val) if null_count_val else 0
         non_null_count = sample_size - null_count
+        numeric_stats = NumericStats(
+            min=agg_row.get(a_min(col_name)),
+            max=agg_row.get(a_max(col_name)),
+            mean=agg_row.get(a_mean(col_name)),
+            std_dev=agg_row.get(a_std(col_name)),
+            median=agg_row.get(a_median(col_name)),
+            quantile_25=agg_row.get(a_quantile_25(col_name)),
+            quantile_75=agg_row.get(a_quantile_75(col_name)),
+        )
 
+        string_stats = StringStats(
+            avg_length_chars=agg_row.get(a_strlen_mean(col_name)),
+            distinct_count=agg_row.get(a_n_unique(col_name)),
+            top_values=None,
+            example_values=None,
+        )
+        boolean_stats = BooleanStats(
+            true_rows=agg_row.get(a_true(col_name)) if agg_row.get(a_true(col_name)) is not None else None,
+            false_rows=(sample_size - agg_row.get(a_true(col_name))) if agg_row.get(
+                a_true(col_name)) is not None else None,
+        )
         stats = ProfileRow(
             dataset_name=dataset_name,
             column_name=col_name,
@@ -713,18 +788,9 @@ def _compute_profile_rows(
             hints=[],
             cardinality="unknown",
             semantic_type="unknown",
-            boolean_true_rows=agg_row.get(a_true(col_name)) if agg_row.get(a_true(col_name)) is not None else None,
-            boolean_false_rows=(sample_size - agg_row.get(a_true(col_name))) if agg_row.get(
-                a_true(col_name)) is not None else None,
-            numeric_min=agg_row.get(a_min(col_name)),
-            numeric_max=agg_row.get(a_max(col_name)),
-            numeric_mean=agg_row.get(a_mean(col_name)),
-            numeric_median=agg_row.get(a_median(col_name)),
-            numeric_std_dev=agg_row.get(a_std(col_name)),
-            string_avg_length_chars=agg_row.get(a_strlen_mean(col_name)),
-            string_distinct_count=agg_row.get(a_n_unique(col_name)),
-            string_top_values=None,
-            string_example_values=None,
+            boolean_stats=boolean_stats,
+            numeric_stats=numeric_stats,
+            string_stats=string_stats,
         )
         if field.data_type in numeric_types:
             stats.semantic_type = "continuous"
@@ -738,26 +804,26 @@ def _compute_profile_rows(
             stats.cardinality = "low"
         elif field.data_type == StringType:
             # Determine cardinality and semantic type
-            if stats.string_distinct_count is not None:
-                distinct_ratio = (stats.string_distinct_count / sample_size) if sample_size > 0 else 0
+            if stats.string_stats.distinct_count is not None:
+                distinct_ratio = (stats.string_stats.distinct_count / sample_size) if sample_size > 0 else 0
                 if distinct_ratio > 0.95:
                     stats.cardinality = "unique"
                     stats.semantic_type = "identifier" if (
-                                stats.string_avg_length_chars is not None and stats.string_avg_length_chars < 50) else "text"
-                elif stats.string_distinct_count <= 10:
+                                stats.string_stats.avg_length_chars is not None and stats.string_stats.avg_length_chars < 50) else "text"
+                elif stats.string_stats.distinct_count <= 10:
                     stats.cardinality = "low"
                     stats.semantic_type = "categorical"
-                elif stats.string_distinct_count <= 100:
+                elif stats.string_stats.distinct_count <= 100:
                     stats.cardinality = "medium"
                     stats.semantic_type = "categorical"
                 else:
                     stats.cardinality = "high"
                     stats.semantic_type = "text"
 
-            if stats.string_avg_length_chars is not None and stats.string_avg_length_chars > LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH:
+            if stats.string_stats.avg_length_chars is not None and stats.string_stats.avg_length_chars > LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH:
                 stats.hints.extend([
                     "has_long_text",
-                    "exclude_from_read",
+                    "consider_excluding_from_read",
                     "prefer_search_content",
                     "use_row_limit",
                     "prefer_analyze_regex_match"
@@ -788,35 +854,35 @@ def _compute_profile_rows(
 
             compute_topk = (
                     (
-                                stats.string_avg_length_chars is not None and stats.string_avg_length_chars <= LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH) and
-                    (stats.string_distinct_count is not None and stats.string_distinct_count <= max(topk_distinct * 10,
+                                stats.string_stats.avg_length_chars is not None and stats.string_stats.avg_length_chars <= LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH) and
+                    (stats.string_stats.distinct_count is not None and stats.string_stats.distinct_count <= max(topk_distinct * 10,
                                                                                                     200))
             )
 
             if compute_topk:
                 vc = sampled_df.get_column(col_name).value_counts(sort=True)
                 val_col = col_name if col_name in vc.columns else vc.columns[0]
-                top_vals: List[Dict[str, Union[int, str]]] = []
+                top_vals: List[TopValues] = []
                 for i in range(min(topk_distinct, vc.height)):
                     top_vals.append(
-                        {
-                            "count": vc.get_column("count")[i],
-                            "value": vc.get_column(val_col)[i],
-                        }
+                        TopValues(
+                            value=vc.get_column(val_col)[i],
+                            count=vc.get_column("count")[i],
+                        )
                     )
-                stats.string_top_values = top_vals
+                stats.string_stats.top_values = top_vals
             else:
                 # No top-k: still provide a few sample values when strings aren't too long.
                 # Use a conservative threshold to avoid dumping giant text fields.
-                if stats.percent_rows_contains_null > 0:
+                if stats.percent_rows_contains_null < 100:
                     s_non_null = sampled_df.get_column(col_name).drop_nulls()
                     k = min(3, int(s_non_null.len()))
                     sampled = s_non_null.sample(
                         n=k,
                         with_replacement=False,
                         shuffle=True
-                    ).str.slice(0, length=512).to_list()
-                    stats.string_example_values = sampled
+                    ).str.slice(0, length=256).to_list()
+                    stats.string_stats.example_values = sampled
         stats.hints = list(set(stats.hints))
-        rows_list.append(stats)
+        rows_list.append(asdict(stats))
     return rows_list

--- a/src/fenic/api/mcp/_tool_generation_utils.py
+++ b/src/fenic/api/mcp/_tool_generation_utils.py
@@ -23,6 +23,8 @@ from fenic.core.types.datatypes import (
 )
 from fenic.core.types.schema import Schema
 
+LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH = 1024
+
 PROFILE_MAX_SAMPLE_SIZE = 10_000
 
 
@@ -531,16 +533,18 @@ class ProfileRow:
     data_type: str
     total_rows: int
     sample_size: int
+    null_row_count: int
+    non_null_row_count: int
     percent_rows_contains_null: float
     semantic_type: Literal["identifier", "categorical", "continuous", "text", "boolean", "unknown"]
     cardinality: Literal["unique", "low", "medium", "high", "unknown"]
-    usage_recommendations: List[str]
+    hints: List[str]
     numeric_min: Optional[float]
     numeric_max: Optional[float]
     numeric_mean: Optional[float]
     numeric_std_dev: Optional[float]
     numeric_median: Optional[float]
-    string_avg_length: Optional[float]
+    string_avg_length_chars: Optional[float]
     string_distinct_count: Optional[int]
     string_top_values: Optional[List[Dict[str, Union[int, str]]]]
     string_example_values: Optional[List[str]]
@@ -627,73 +631,119 @@ def _compute_profile_rows(
     pl_df = df.to_polars()
     total_rows = pl_df.height
     sampled_df = pl_df.sample(min(total_rows, PROFILE_MAX_SAMPLE_SIZE))
+
+    # Build a single batched select of aggregations for all columns
+    exprs: List[pl.Expr] = []
+    numeric_types = (IntegerType, FloatType, DoubleType)
+
+    # Alias builders for convenience
+    def a_nulls(name: str) -> str:
+        return f"nulls__{name}"
+
+    def a_mean(name: str) -> str:
+        return f"mean__{name}"
+
+    def a_min(name: str) -> str:
+        return f"min__{name}"
+
+    def a_max(name: str) -> str:
+        return f"max__{name}"
+
+    def a_median(name: str) -> str:
+        return f"median__{name}"
+
+    def a_std(name: str) -> str:
+        return f"std__{name}"
+
+    def a_true(name: str) -> str:
+        return f"true__{name}"
+
+    def a_strlen_mean(name: str) -> str:
+        return f"strlen_mean__{name}"
+
+    def a_n_unique(name: str) -> str:
+        return f"n_unique__{name}"
+
+    for field in df.schema.column_fields:
+        col_name = field.name
+        # Common null counts
+        exprs.append(pl.col(col_name).is_null().sum().alias(a_nulls(col_name)))
+        # type-specific aggregations
+        if field.data_type in numeric_types:
+            exprs.extend([
+                pl.col(col_name).mean().alias(a_mean(col_name)),
+                pl.col(col_name).min().alias(a_min(col_name)),
+                pl.col(col_name).max().alias(a_max(col_name)),
+                pl.col(col_name).median().alias(a_median(col_name)),
+                pl.col(col_name).std().alias(a_std(col_name)),
+            ])
+        elif field.data_type == BooleanType:
+            # Count of true values (nulls treated as False to avoid null sums)
+            exprs.append(pl.col(col_name).drop_nulls().sum().alias(a_true(col_name)))
+        elif field.data_type == StringType:
+            exprs.extend([
+                pl.col(col_name).str.len_chars().mean().alias(a_strlen_mean(col_name)),
+                pl.col(col_name).n_unique().alias(a_n_unique(col_name)),
+            ])
+
+    agg_row: Dict[str, object] = {}
+    if exprs:
+        agg_df = sampled_df.select(exprs)
+        agg_row = agg_df.to_dicts()[0] if agg_df.height > 0 else {}
+
     rows_list: List[ProfileRow] = []
+    sample_size = sampled_df.height
     for field in df.schema.column_fields:
         col_name = field.name
         dtype_str = str(field.data_type)
-        null_count = sampled_df.select(pl.col(col_name).is_null().sum()).item()
-        non_null_count = sampled_df.height - null_count
+        null_count_val = agg_row.get(a_nulls(col_name), 0)
+        null_count = int(null_count_val) if null_count_val else 0
+        non_null_count = sample_size - null_count
+
         stats = ProfileRow(
             dataset_name=dataset_name,
             column_name=col_name,
             data_type=dtype_str,
             total_rows=total_rows,
-            sample_size=sampled_df.height,
-            percent_rows_contains_null=round((non_null_count / float(sampled_df.height) * 100) if sampled_df.height > 0 else 0, 1),
-            usage_recommendations=[],
+            sample_size=sample_size,
+            percent_rows_contains_null=round(((null_count / float(sample_size)) * 100.0) if sample_size > 0 else 0.0,
+                                             1),
+            null_row_count=null_count,
+            non_null_row_count=non_null_count,
+            hints=[],
             cardinality="unknown",
             semantic_type="unknown",
-            boolean_true_rows=None,
-            boolean_false_rows=None,
-            numeric_min=None,
-            numeric_max=None,
-            numeric_mean=None,
-            numeric_median=None,
-            numeric_std_dev=None,
-            string_avg_length=None,
-            string_distinct_count=None,
+            boolean_true_rows=agg_row.get(a_true(col_name)) if agg_row.get(a_true(col_name)) is not None else None,
+            boolean_false_rows=(sample_size - agg_row.get(a_true(col_name))) if agg_row.get(
+                a_true(col_name)) is not None else None,
+            numeric_min=agg_row.get(a_min(col_name)),
+            numeric_max=agg_row.get(a_max(col_name)),
+            numeric_mean=agg_row.get(a_mean(col_name)),
+            numeric_median=agg_row.get(a_median(col_name)),
+            numeric_std_dev=agg_row.get(a_std(col_name)),
+            string_avg_length_chars=agg_row.get(a_strlen_mean(col_name)),
+            string_distinct_count=agg_row.get(a_n_unique(col_name)),
             string_top_values=None,
             string_example_values=None,
         )
-        if field.data_type in (IntegerType, FloatType, DoubleType):
-            stats_df = sampled_df.select(
-                pl.col(col_name).mean().alias("mean"),
-                pl.col(col_name).min().alias("min"),
-                pl.col(col_name).max().alias("max"),
-                pl.col(col_name).median().alias("median"),
-                pl.col(col_name).std().alias("std"),
-            ).to_dicts()
-
-            stats.numeric_min = stats_df[0]["min"]
-            stats.numeric_max = stats_df[0]["max"]
-            stats.numeric_mean = stats_df[0]["mean"]
-            stats.numeric_std_dev = stats_df[0]["std"]
-            stats.numeric_median = stats_df[0]["median"]
-
+        if field.data_type in numeric_types:
             stats.semantic_type = "continuous"
             stats.cardinality = "high"
             # Check if it might be an identifier
             if "id" in col_name.lower() or col_name.lower().endswith("_id"):
                 stats.semantic_type = "identifier"
+
         elif field.data_type == BooleanType:
             stats.semantic_type = "boolean"
             stats.cardinality = "low"
-            s_bool = sampled_df.get_column(col_name)
-            stats.boolean_true_rows = int(s_bool.sum())
-            stats.boolean_false_rows = int((~s_bool).sum())
         elif field.data_type == StringType:
-            s = sampled_df.get_column(col_name)
-            stats.string_avg_length = s.str.len_chars().mean()
-            stats.string_distinct_count = s.n_unique()
-            stats.string_top_values = None
-            stats.string_example_values = None
-
             # Determine cardinality and semantic type
             if stats.string_distinct_count is not None:
-                distinct_ratio = stats.string_distinct_count / len(sampled_df) if len(sampled_df) > 0 else 0
+                distinct_ratio = (stats.string_distinct_count / sample_size) if sample_size > 0 else 0
                 if distinct_ratio > 0.95:
                     stats.cardinality = "unique"
-                    stats.semantic_type = "identifier" if stats.string_avg_length and stats.string_avg_length < 50 else "text"
+                    stats.semantic_type = "identifier" if (
+                                stats.string_avg_length_chars is not None and stats.string_avg_length_chars < 50) else "text"
                 elif stats.string_distinct_count <= 10:
                     stats.cardinality = "low"
                     stats.semantic_type = "categorical"
@@ -704,39 +754,43 @@ def _compute_profile_rows(
                     stats.cardinality = "high"
                     stats.semantic_type = "text"
 
-            # Record the average length for agent awareness
-            if stats.string_avg_length is not None and stats.string_avg_length > 1024:
-                stats.usage_recommendations.append(
-                    "This column appears to contain long text. "
-                    "When using the 'Analyze' tool ensure LIMIT/ORDER BY is set. "
-                    "Exclude this column from `Read` unless the result limit is very low. "
-                    "To find relevant rows based on data from this column, consider the `Search Content` tool."
-                )
+            if stats.string_avg_length_chars is not None and stats.string_avg_length_chars > LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH:
+                stats.hints.extend([
+                    "has_long_text",
+                    "exclude_from_read",
+                    "prefer_search_content",
+                    "use_row_limit",
+                    "prefer_analyze_regex_match"
+                ])
 
             # Add cardinality-based recommendations
             if stats.cardinality == "low":
-                stats.usage_recommendations.append(
-                    f"Low cardinality categorical column ({stats.string_distinct_count} values). "
-                    f"Excellent for GROUP BY, filtering, and aggregations."
-                )
+                stats.hints.extend([
+                    "use_for_aggregations",
+                    "use_for_filtering",
+                ])
             elif stats.cardinality == "medium":
-                stats.usage_recommendations.append(
-                    f"Medium cardinality column ({stats.string_distinct_count} values). "
-                    f"Good for filtering and grouping. Consider using `Search Content` or `Analyze` w/REGEXP_MATCHES for text matching."
-                )
+                stats.hints.extend([
+                    "use_for_aggregations",
+                    "prefer_search_content",
+                    "prefer_row_limit",
+                    "prefer_analyze_regex_match"
+                ])
             elif stats.cardinality == "unique":
-                stats.usage_recommendations.append(
-                    "This column appears to have mostly unique values. "
-                    "May be an identifier or free-text field. Use Search Content for text matching."
-                )
-            else:
-                stats.usage_recommendations.append(
-                    "This column has high cardinality. "
-                    "To find relevant rows based on data from this column, consider the `Search Content` tool."
-                )
+                stats.hints.extend([
+                    "high_cardinality",
+                    "unique_values",
+                ])
+            elif stats.cardinality == "high":
+                stats.hints.extend([
+                    "high_cardinality",
+                ])
+
             compute_topk = (
-                stats.string_avg_length <= 1024 and
-                stats.string_distinct_count <= max(topk_distinct * 10, 200)
+                    (
+                                stats.string_avg_length_chars is not None and stats.string_avg_length_chars <= LONG_TEXT_COLUMN_THRESHOLD_CHAR_LENGTH) and
+                    (stats.string_distinct_count is not None and stats.string_distinct_count <= max(topk_distinct * 10,
+                                                                                                    200))
             )
 
             if compute_topk:
@@ -763,5 +817,6 @@ def _compute_profile_rows(
                         shuffle=True
                     ).str.slice(0, length=512).to_list()
                     stats.string_example_values = sampled
+        stats.hints = list(set(stats.hints))
         rows_list.append(stats)
     return rows_list

--- a/src/fenic/api/mcp/_tool_generation_utils.py
+++ b/src/fenic/api/mcp/_tool_generation_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
 from dataclasses import dataclass
@@ -10,9 +11,6 @@ from typing_extensions import Annotated
 
 from fenic.api import col
 from fenic.api.dataframe import DataFrame
-from fenic.api.functions import avg, stddev
-from fenic.api.functions import max as max_
-from fenic.api.functions import min as min_
 from fenic.api.session import Session
 from fenic.core._logical_plan import LogicalPlan
 from fenic.core._logical_plan.plans import InMemorySource
@@ -25,25 +23,73 @@ from fenic.core.types.datatypes import (
     IntegerType,
     StringType,
 )
+from fenic.core.types.schema import Schema
 
 PROFILE_MAX_SAMPLE_SIZE = 10_000
 
 
-@dataclass
-class DatasetSpec:
+class ToolDataset:
     """Specification for a dataset exposed to a tool.
 
     Attributes:
       table_name: name of the table registered in the catalog.
       description: description of the table from the catalog.
-      df: the fenic DataFrame object with the table data.
+      session: a fenic Session, used to load tables from the catalog using `table_name`
     """
     table_name: str
     description: str
-    df: DataFrame
+    session: Session
+
+    def __init__(
+        self,
+        table_name: str,
+        description: str,
+        session: Session
+    ):
+        self.table_name = table_name
+        self.description = description
+        self.session = session
+
+    @property
+    def df(self) -> DataFrame:
+        return self.session.table(self.table_name)
+
+    @property
+    def schema(self) -> Schema:
+        return self.session.catalog.describe_table(self.table_name).schema
+
+    @property
+    def schema_fingerprint(self) -> str:
+        hasher = hashlib.sha256()
+        for f in self.schema.column_fields:
+            hasher.update(f"{f.name}|{str(f.data_type)}".encode("utf-8"))
+        return hasher.hexdigest()[:12]
+
+
+def auto_generate_system_tools_from_tables(
+    table_names: list[str],
+    session: Session,
+    *,
+    tool_namespace: Optional[str],
+    max_result_limit: int = 100,
+) -> List[SystemTool]:
+    """Generate Schema/Profile/Read/Search [Content/Summary]/Analyze tools from catalog tables.
+
+    Validates that each table exists and has a non-empty description in catalog metadata.
+    """
+    if not table_names:
+        raise ConfigurationError("At least one table name must be specified for automated system tool creation.")
+    datasets = _build_datasets_from_tables(table_names, session)
+    return _auto_generate_system_tools(
+        datasets,
+        session,
+        tool_namespace=tool_namespace,
+        max_result_limit=max_result_limit,
+    )
+
 
 def _auto_generate_system_tools(
-    datasets: List[DatasetSpec],
+    datasets: List[ToolDataset],
     session: Session,
     *,
     tool_namespace: Optional[str],
@@ -62,92 +108,85 @@ def _auto_generate_system_tools(
         [f"{d.table_name}: {d.description.strip()}" if d.description else d.table_name for d in datasets]
     )
 
-    schema_tool = _auto_generate_schema_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Schema" if tool_namespace else "Schema",
-        tool_description="\n\n".join([
-            "Show the schema (column names and types) for any or all of the datasets listed below. This call should be the first step in exploring the available datasets.",
-            group_desc,
-        ]),
-    )
+    name_to_spec: Dict[str, ToolDataset] = {spec.table_name: spec for spec in datasets}
+    generated_tools: List[SystemTool] = [
+        _auto_generate_schema_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Schema" if tool_namespace else "Schema",
+            tool_description="\n\n".join([
+                "Show the schema (column names and types) for any or all of the datasets listed below. This call should be the first step in exploring the available datasets.",
+                group_desc,
+            ]),
+        ), _auto_generate_profile_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Profile" if tool_namespace else "Profile",
+            tool_description="\n".join([
+                "Return dataset data profile: row_count and per-column stats for any or all of the datasets listed below.",
+                "This call should be used as a follow up after calling the `Schema` tool."
+                "Numeric stats: min/max/mean/std; Booleans: true/false counts; Strings: distinct_count and top values.",
+                "Profiling statistics are calculated across a sample of the original dataset.",
+                "Available Datasets:",
+                group_desc,
+            ]),
+        ), _auto_generate_read_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Read" if tool_namespace else "Read",
+            tool_description="\n".join([
+                "Read rows from a single dataset. Use to sample data, or to execute simple queries over the data that do not require filtering or grouping.",
+                "Use `include_columns` and `exclude_columns` to filter columns by name -- this is important to conserve token usage. Use the `Profile` tool to understand the columns and their sizes.",
+                "Available datasets:",
+                group_desc,
+            ]),
+            result_limit=max_result_limit,
+        ), _auto_generate_search_summary_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Search Summary" if tool_namespace else "Search Summary",
+            tool_description="\n".join([
+                "Perform a substring/regex search across all datasets and return a summary of the number of matches per dataset.",
+                "Available datasets:",
+                group_desc,
+            ]),
+        ), _auto_generate_search_content_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Search Content" if tool_namespace else "Search Content",
+            tool_description="\n".join([
+                "Return matching rows from a single dataset using substring/regex across string columns.",
+                "Available datasets:",
+                group_desc,
+            ]),
+            result_limit=max_result_limit,
+        ), _auto_generate_sql_tool(
+            name_to_spec,
+            session,
+            tool_name=f"{tool_namespace} - Analyze" if tool_namespace else "Analyze",
+            tool_description="\n".join([
+                "Execute Read-Only (SELECT) SQL over the provided datasets using fenic's SQL support.",
+                "DDL/DML and multiple top-level queries are not allowed.",
+                "For text search, prefer regular expressions (REGEXP_MATCHES()/REGEXP_EXTRACT()).",
+                "Paging: use ORDER BY to define row order, then LIMIT and OFFSET for pages.",
+                "JOINs between datasets are allowed. Refer to datasets by name in braces, e.g., {orders}.",
+                "Below, the available datasets are listed, by name and description.",
+                group_desc,
+            ]),
+            result_limit=max_result_limit,
+        )]
 
-    profile_tool = _auto_generate_profile_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Profile" if tool_namespace else "Profile",
-        tool_description="\n".join([
-            "Return dataset data profile: row_count and per-column stats for any or all of the datasets listed below.",
-            "This call should be used as a follow up after calling the `Schema` tool."
-            "Numeric stats: min/max/mean/std; Booleans: true/false counts; Strings: distinct_count and top values.",
-            "Profiling statistics are calculated across a sample of the original dataset.",
-            "Available Datasets:",
-            group_desc,
-        ]),
-    )
-
-    read_tool = _auto_generate_read_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Read" if tool_namespace else "Read",
-        tool_description="\n".join([
-            "Read rows from a single dataset. Use to sample data, or to execute simple queries over the data that do not require filtering or grouping.",
-            "Use `include_columns` and `exclude_columns` to filter columns by name -- this is important to conserve token usage. Use the `Profile` tool to understand the columns and their sizes.",
-            "Available datasets:",
-            group_desc,
-        ]),
-        result_limit=max_result_limit,
-    )
-
-    search_summary_tool = _auto_generate_search_summary_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Search Summary" if tool_namespace else "Search Summary",
-        tool_description="\n".join([
-            "Perform a substring/regex search across all datasets and return a summary of the number of matches per dataset.",
-            "Available datasets:",
-            group_desc,
-        ]),
-    )
-    search_content_tool = _auto_generate_search_content_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Search Content" if tool_namespace else "Search Content",
-        tool_description="\n".join([
-            "Return matching rows from a single dataset using substring/regex across string columns.",
-            "Available datasets:",
-            group_desc,
-        ]),
-        result_limit=max_result_limit,
-    )
-
-    analyze_tool = _auto_generate_sql_tool(
-        datasets,
-        session,
-        tool_name=f"{tool_namespace} - Analyze" if tool_namespace else "Analyze",
-        tool_description="\n".join([
-            "Execute Read-Only (SELECT) SQL over the provided datasets using fenic's SQL support.",
-            "DDL/DML and multiple top-level queries are not allowed.",
-            "For text search, prefer regular expressions (REGEXP_MATCHES()/REGEXP_EXTRACT()).",
-            "Paging: use ORDER BY to define row order, then LIMIT and OFFSET for pages.",
-            "JOINs between datasets are allowed. Refer to datasets by name in braces, e.g., {orders}.",
-            "Below, the available datasets are listed, by name and description.",
-            group_desc,
-        ]),
-        result_limit=max_result_limit,
-    )
-
-    return [schema_tool, profile_tool, read_tool, search_summary_tool, search_content_tool, analyze_tool]
+    return generated_tools
 
 
-def _build_datasets_from_tables(table_names: List[str], session: Session) -> List[DatasetSpec]:
+def _build_datasets_from_tables(table_names: List[str], session: Session) -> List[ToolDataset]:
     """Resolve catalog table names into DatasetSpec list with validated descriptions.
 
     Raises ConfigurationError if any table is missing or lacks a non-empty description.
     """
     missing_desc: List[str] = []
     missing_tables: List[str] = []
-    specs: List[DatasetSpec] = []
+    specs: List[ToolDataset] = []
 
     for table_name in table_names:
         if not session.catalog.does_table_exist(table_name):
@@ -157,8 +196,7 @@ def _build_datasets_from_tables(table_names: List[str], session: Session) -> Lis
         desc = (table_metadata.description or "").strip()
         if not desc:
             missing_desc.append(table_name)
-        df = session.table(table_name)
-        specs.append(DatasetSpec(table_name=table_name, description=desc, df=df))
+        specs.append(ToolDataset(table_name=table_name, description=desc, session=session))
 
     if missing_tables:
         raise ConfigurationError(
@@ -175,7 +213,7 @@ def _build_datasets_from_tables(table_names: List[str], session: Session) -> Lis
 
 
 def _auto_generate_read_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -185,8 +223,6 @@ def _auto_generate_read_tool(
     """Create a read tool over one or many datasets."""
     if len(datasets) == 0:
         raise ConfigurationError("Cannot create read tool: no datasets provided.")
-
-    name_to_df: Dict[str, DataFrame] = {d.table_name: d.df for d in datasets}
 
     def _validate_columns(
         available_columns: List[str],
@@ -209,9 +245,9 @@ def _auto_generate_read_tool(
         exclude_columns: Annotated[Optional[str], "Comma separated list of columns to exclude from the result"] = None,
     ) -> LogicalPlan:
 
-        if df_name not in name_to_df:
-            raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(name_to_df.keys())}")
-        df = name_to_df[df_name]
+        if df_name not in datasets:
+            raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(datasets.keys())}")
+        df = datasets[df_name].df
         order_by = [c.strip() for c in order_by.split(",") if c.strip()] if order_by else None
         available_columns = df.columns
         include_columns = [c.strip() for c in include_columns.split(",") if c.strip()] if include_columns else None
@@ -244,7 +280,7 @@ def _auto_generate_read_tool(
 
 
 def _auto_generate_search_summary_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -253,14 +289,13 @@ def _auto_generate_search_summary_tool(
     if len(datasets) == 0:
         raise ValueError("Cannot create search summary tool: no datasets provided.")
 
-    name_to_df: Dict[str, DataFrame] = {d.table_name: d.df for d in datasets}
-
     async def search_summary(
         pattern: Annotated[str, "Regex pattern to search for (use (?i) for case-insensitive)."],
     ) -> LogicalPlan:
         rows: List[Dict[str, object]] = []
-        for name, d in name_to_df.items():
-            cols = [f.name for f in d.schema.column_fields if f.data_type == StringType]
+        for name, dataset in datasets.items():
+            df = dataset.df
+            cols = [f.name for f in df.schema.column_fields if f.data_type == StringType]
             if not cols:
                 rows.append({"dataset": name, "total_matches": 0})
                 continue
@@ -268,8 +303,10 @@ def _auto_generate_search_summary_tool(
             for c_name in cols:
                 this = col(c_name).rlike(pattern)
                 predicate = this if predicate is None else (predicate | this)
-            total_count = d.filter(predicate).count()
-            rows.append({"dataset": name, "total_matches": int(total_count)})
+
+            df = df.filter(predicate)
+            total_count = await asyncio.to_thread(df.count)
+            rows.append({"dataset": name, "total_matches": total_count})
 
         pl_df = pl.DataFrame(rows)
         return InMemorySource.from_session_state(pl_df, session._session_state)
@@ -283,7 +320,7 @@ def _auto_generate_search_summary_tool(
 
 
 def _auto_generate_search_content_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -293,8 +330,6 @@ def _auto_generate_search_content_tool(
     """Create a content search tool for a single dataset (string columns)."""
     if len(datasets) == 0:
         raise ValidationError("Cannot create search content tool: no datasets provided.")
-
-    name_to_df: Dict[str, DataFrame] = {d.table_name: d.df for d in datasets}
 
     def _string_columns(df: DataFrame, selected: Optional[List[str]]) -> List[str]:
         if selected:
@@ -324,17 +359,17 @@ def _auto_generate_search_content_tool(
 
         if not pattern:
             raise ValidationError("Query pattern cannot be empty.")
-        if df_name not in name_to_df:
-            raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(name_to_df.keys())}")
-        d = name_to_df[df_name]
-        cols = _string_columns(d, search_columns)
+        if df_name not in datasets:
+            raise ValidationError(f"Unknown DataFrame '{df_name}'. Available: {', '.join(datasets.keys())}")
+        df = datasets[df_name].df
+        cols = _string_columns(df, search_columns)
         if not cols:
-            return d.limit(0)._logical_plan
+            return df.limit(0)._logical_plan
         predicate = None
         for c_name in cols:
             this = col(c_name).rlike(pattern)
             predicate = this if predicate is None else (predicate | this)
-        out = d.filter(predicate)
+        out = df.filter(predicate)
 
         return _apply_paging(
             out,
@@ -355,7 +390,7 @@ def _auto_generate_search_content_tool(
 
 
 def _auto_generate_schema_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -369,8 +404,6 @@ def _auto_generate_schema_tool(
     if len(datasets) == 0:
         raise ValueError("Cannot create schema tool: no datasets provided.")
 
-    name_to_df: Dict[str, DataFrame] = {d.table_name: d.df for d in datasets}
-
     async def schema_func(
         df_name: Annotated[
             str | None, "Optional DataFrame name to return a single schema for. To return schemas for all datasets, OMIT this parameter."] = None,
@@ -380,20 +413,20 @@ def _auto_generate_schema_tool(
             df_name = None
         # Choose subset of datasets
         if df_name is not None:
-            if df_name not in name_to_df:
+            if df_name not in datasets:
                 raise ValidationError(
-                    f"Unknown DataFrame '{df_name}'. Available: {', '.join(name_to_df.keys())}"
+                    f"Unknown DataFrame '{df_name}'. Available: {', '.join(datasets.keys())}"
                 )
-            selected = {df_name: name_to_df[df_name]}
+            selected = {df_name: datasets[df_name]}
         else:
-            selected = name_to_df
+            selected = datasets
 
         dataset_names: List[str] = []
         dataset_schemas: List[List[Dict[str, str]]] = []
 
-        for name, d in selected.items():
+        for name, dataset in selected.items():
             # Build a single-row DataFrame with a common list<struct{column,type}> schema column
-            schema_entries = [{"column": f.name, "type": str(f.data_type)} for f in d.schema.column_fields]
+            schema_entries = [{"column": f.name, "type": str(f.data_type)} for f in dataset.schema.column_fields]
             dataset_names.append(name)
             dataset_schemas.append(schema_entries)
 
@@ -414,7 +447,7 @@ def _auto_generate_schema_tool(
 
 
 def _auto_generate_sql_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -434,12 +467,12 @@ def _auto_generate_sql_tool(
         full_sql: Annotated[
             str, "Full SELECT SQL. Refer to DataFrames by name in braces, e.g., `SELECT * FROM {orders}`. JOINs between the provided datasets are allowed. SQL dialect: DuckDB. DDL/DML and multiple top-level queries are not allowed"]
     ) -> LogicalPlan:
-        return session.sql(full_sql.strip(), **{spec.table_name: spec.df for spec in datasets})._logical_plan
+        return session.sql(full_sql.strip(), **{spec.table_name: spec.df for spec in datasets.values()})._logical_plan
 
     # Enhanced description with dataset names and descriptions
     lines: List[str] = [tool_description.strip()]
     if datasets:
-        example_name = datasets[0].table_name
+        example_name = next(iter(datasets.keys()))
     else:
         example_name = "data"
     lines.extend(
@@ -465,13 +498,6 @@ def _auto_generate_sql_tool(
         add_limit_parameter=False,
     )
     return tool
-
-
-def _schema_fingerprint(df: DataFrame) -> str:
-    hasher = hashlib.sha256()
-    for f in df.schema.column_fields:
-        hasher.update(f"{f.name}|{str(f.data_type)}".encode("utf-8"))
-    return hasher.hexdigest()[:12]
 
 
 def _sanitize_name(name: str) -> str:
@@ -525,11 +551,12 @@ def _apply_paging(
 
 
 @dataclass
-class _ProfileRow:
+class ProfileRow:
     dataset_name: str
     column_name: str
     data_type: str
     total_rows: int
+    sample_size: int
     percent_rows_contains_null: float
     semantic_type: Literal["identifier", "categorical", "continuous", "text", "boolean", "unknown"]
     cardinality: Literal["unique", "low", "medium", "high", "unknown"]
@@ -538,6 +565,7 @@ class _ProfileRow:
     numeric_max: Optional[float]
     numeric_mean: Optional[float]
     numeric_std_dev: Optional[float]
+    numeric_median: Optional[float]
     string_avg_length: Optional[float]
     string_distinct_count: Optional[int]
     string_top_values: Optional[List[Dict[str, Union[int, str]]]]
@@ -545,9 +573,8 @@ class _ProfileRow:
     boolean_true_rows: Optional[int]
     boolean_false_rows: Optional[int]
 
-
 def _auto_generate_profile_tool(
-    datasets: List[DatasetSpec],
+    datasets: Dict[str, ToolDataset],
     session: Session,
     tool_name: str,
     tool_description: str,
@@ -564,7 +591,6 @@ def _auto_generate_profile_tool(
     """
     if len(datasets) == 0:
         raise ValueError("Cannot create profile tool: no datasets provided.")
-    tool_key = _sanitize_name(tool_name)
 
     async def profile_func(
         df_name: Annotated[
@@ -575,17 +601,17 @@ def _auto_generate_profile_tool(
             df_name = None
         # Single dataset branch returns the view plan directly
         if df_name is not None:
-            spec = next((d for d in datasets if d.table_name == df_name), None)
+            spec = next((d for d in datasets.values() if d.table_name == df_name), None)
             if spec is None:
                 raise ValidationError(
-                    f"Unknown dataset '{df_name}'. Available: {', '.join(d.table_name for d in datasets)}")
-            return await _ensure_profile_view_for_dataset(session, tool_key, spec, topk_distinct)
+                    f"Unknown dataset '{df_name}'. Available: {', '.join(datasets.keys())}")
+            profile_df = await _compute_profile_for_dataset(session, spec, topk_distinct)
+            return profile_df._logical_plan
 
         # Multi-dataset: concatenate cached views (or compute & cache if missing)
         profile_df = None
-        for spec in datasets:
-            plan = await _ensure_profile_view_for_dataset(session, tool_key, spec, topk_distinct)
-            df = DataFrame._from_logical_plan(plan, session_state=session._session_state)
+        for spec in datasets.values():
+            df = await _compute_profile_for_dataset(session, spec, topk_distinct)
             if not profile_df:
                 profile_df = df
             else:
@@ -600,48 +626,45 @@ def _auto_generate_profile_tool(
         max_result_limit=None,
     )
 
-
-async def _ensure_profile_view_for_dataset(
+async def _compute_profile_for_dataset(
     session: Session,
-    tool_key: str,
-    spec: DatasetSpec,
+    spec: ToolDataset,
     topk_distinct: int,
-) -> LogicalPlan:
-    schema_hash = _schema_fingerprint(spec.df)
-    view_name = f"__fenic_profile__{tool_key}__{_sanitize_name(spec.table_name)}__{schema_hash}"
-    catalog = session._session_state.catalog
-    if not catalog.does_view_exist(view_name):
-        profile_rows = await _compute_profile_rows(
-            spec.df,
-            spec.table_name,
-            topk_distinct,
-        )
-        view_plan = InMemorySource.from_session_state(
+) -> DataFrame:
+    profile_rows = await _compute_profile_rows(
+        spec.df,
+        spec.table_name,
+        topk_distinct,
+    )
+
+    return DataFrame._from_logical_plan(
+        InMemorySource.from_session_state(
             pl.DataFrame(profile_rows), session._session_state,
-        )
-        catalog.create_view(view_name, view_plan)
-    return catalog.get_view_plan(view_name)
+        ),
+        session._session_state,
+    )
 
 
 async def _compute_profile_rows(
     df: DataFrame,
     dataset_name: str,
     topk_distinct: int,
-) -> List[_ProfileRow]:
+) -> List[ProfileRow]:
     pl_df = df.to_polars()
     total_rows = pl_df.height
     sampled_df = pl_df.sample(min(total_rows, PROFILE_MAX_SAMPLE_SIZE))
-    rows_list: List[_ProfileRow] = []
+    rows_list: List[ProfileRow] = []
     for field in df.schema.column_fields:
         col_name = field.name
         dtype_str = str(field.data_type)
         null_count = sampled_df.select(pl.col(col_name).is_null().sum()).item()
         non_null_count = sampled_df.height - null_count
-        stats = _ProfileRow(
+        stats = ProfileRow(
             dataset_name=dataset_name,
             column_name=col_name,
             data_type=dtype_str,
             total_rows=total_rows,
+            sample_size=sampled_df.height,
             percent_rows_contains_null=round((non_null_count / float(sampled_df.height) * 100) if sampled_df.height > 0 else 0, 1),
             usage_recommendations=[],
             cardinality="unknown",
@@ -651,6 +674,7 @@ async def _compute_profile_rows(
             numeric_min=None,
             numeric_max=None,
             numeric_mean=None,
+            numeric_median=None,
             numeric_std_dev=None,
             string_avg_length=None,
             string_distinct_count=None,
@@ -658,16 +682,20 @@ async def _compute_profile_rows(
             string_example_values=None,
         )
         if field.data_type in (IntegerType, FloatType, DoubleType):
-            agg_df = df.agg(
-                min_(col(col_name)).alias("min"),
-                max_(col(col_name)).alias("max"),
-                avg(col(col_name)).alias("mean"),
-                stddev(col(col_name)).alias("std"),
-            ).to_pylist()
-            stats.numeric_min = agg_df[0]["min"]
-            stats.numeric_max = agg_df[0]["max"]
-            stats.numeric_mean = agg_df[0]["mean"]
-            stats.numeric_std_dev = agg_df[0]["std"]
+            stats_df = sampled_df.select(
+                pl.col(col_name).mean().alias("mean"),
+                pl.col(col_name).min().alias("min"),
+                pl.col(col_name).max().alias("max"),
+                pl.col(col_name).median().alias("median"),
+                pl.col(col_name).std().alias("std"),
+            ).to_dicts()
+
+            stats.numeric_min = stats_df[0]["min"]
+            stats.numeric_max = stats_df[0]["max"]
+            stats.numeric_mean = stats_df[0]["mean"]
+            stats.numeric_std_dev = stats_df[0]["std"]
+            stats.numeric_median = stats_df[0]["median"]
+
             stats.semantic_type = "continuous"
             stats.cardinality = "high"
             # Check if it might be an identifier
@@ -677,7 +705,7 @@ async def _compute_profile_rows(
             stats.semantic_type = "boolean"
             stats.cardinality = "low"
             s_bool = sampled_df.get_column(col_name)
-            stats.boolean_true_rows = int((s_bool).sum())
+            stats.boolean_true_rows = int(s_bool.sum())
             stats.boolean_false_rows = int((~s_bool).sum())
         elif field.data_type == StringType:
             s = sampled_df.get_column(col_name)
@@ -710,8 +738,30 @@ async def _compute_profile_rows(
                     "Exclude this column from `Read` unless the result limit is very low. "
                     "To find relevant rows based on data from this column, consider the `Search Content` tool."
                 )
+
+            # Add cardinality-based recommendations
+            if stats.cardinality == "low":
+                stats.usage_recommendations.append(
+                    f"Low cardinality categorical column ({stats.string_distinct_count} values). "
+                    f"Excellent for GROUP BY, filtering, and aggregations."
+                )
+            elif stats.cardinality == "medium":
+                stats.usage_recommendations.append(
+                    f"Medium cardinality column ({stats.string_distinct_count} values). "
+                    f"Good for filtering and grouping. Consider using `Search Content` or `Analyze` w/REGEXP_MATCHES for text matching."
+                )
+            elif stats.cardinality == "unique":
+                stats.usage_recommendations.append(
+                    "This column appears to have mostly unique values. "
+                    "May be an identifier or free-text field. Use Search Content for text matching."
+                )
+            else:
+                stats.usage_recommendations.append(
+                    "This column has high cardinality. "
+                    "To find relevant rows based on data from this column, consider the `Search Content` tool."
+                )
             compute_topk = (
-                stats.string_avg_length <= 512 and
+                stats.string_avg_length <= 1024 and
                 stats.string_distinct_count <= max(topk_distinct * 10, 200)
             )
 
@@ -730,27 +780,6 @@ async def _compute_profile_rows(
             else:
                 # No top-k: still provide a few sample values when strings aren't too long.
                 # Use a conservative threshold to avoid dumping giant text fields.
-                # Add cardinality-based recommendations
-                if stats.cardinality == "low":
-                    stats.usage_recommendations.append(
-                        f"Low cardinality categorical column ({stats.string_distinct_count} values). "
-                        f"Excellent for GROUP BY, filtering, and aggregations."
-                    )
-                elif stats.cardinality == "medium":
-                    stats.usage_recommendations.append(
-                        f"Medium cardinality column ({stats.string_distinct_count} values). "
-                        f"Good for filtering and grouping. Consider using `Search Content` or `Analyze` w/REGEXP_MATCHES for text matching."
-                    )
-                elif stats.cardinality == "unique":
-                    stats.usage_recommendations.append(
-                        "This column appears to have mostly unique values. "
-                        "May be an identifier or free-text field. Use Search Content for text matching."
-                    )
-                else:
-                    stats.usage_recommendations.append(
-                        "This column has high cardinality. "
-                        "To find relevant rows based on data from this column, consider the `Search Content` tool."
-                    )
                 if stats.percent_rows_contains_null > 0:
                     s_non_null = sampled_df.get_column(col_name).drop_nulls()
                     k = min(3, int(s_non_null.len()))
@@ -762,25 +791,3 @@ async def _compute_profile_rows(
                     stats.string_example_values = sampled
         rows_list.append(stats)
     return rows_list
-
-
-def auto_generate_system_tools_from_tables(
-    table_names: list[str],
-    session: Session,
-    *,
-    tool_namespace: Optional[str],
-    max_result_limit: int = 100,
-) -> List[SystemTool]:
-    """Generate Schema/Profile/Read/Search [Content/Summary]/Analyze tools from catalog tables.
-
-    Validates that each table exists and has a non-empty description in catalog metadata.
-    """
-    if not table_names:
-        raise ConfigurationError("At least one table name must be specified for automated system tool creation.")
-    datasets = _build_datasets_from_tables(table_names, session)
-    return _auto_generate_system_tools(
-        datasets,
-        session,
-        tool_namespace=tool_namespace,
-        max_result_limit=max_result_limit,
-    )

--- a/src/fenic/api/mcp/server.py
+++ b/src/fenic/api/mcp/server.py
@@ -6,6 +6,8 @@ This module exposes helpers to:
 """
 from typing import List, Optional
 
+from pydantic import ConfigDict, validate_call
+
 from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
 from fenic.api.mcp.tools import (
     SystemToolConfig,
@@ -14,7 +16,6 @@ from fenic.api.session.session import Session
 from fenic.core.error import ConfigurationError
 from fenic.core.mcp._server import FenicMCPServer, MCPTransport
 from fenic.core.mcp.types import UserDefinedTool
-from pydantic import validate_call, ConfigDict
 
 
 @validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))

--- a/src/fenic/api/mcp/server.py
+++ b/src/fenic/api/mcp/server.py
@@ -14,8 +14,10 @@ from fenic.api.session.session import Session
 from fenic.core.error import ConfigurationError
 from fenic.core.mcp._server import FenicMCPServer, MCPTransport
 from fenic.core.mcp.types import UserDefinedTool
+from pydantic import validate_call, ConfigDict
 
 
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
 def create_mcp_server(
     session: Session,
     server_name: str,
@@ -48,6 +50,7 @@ def create_mcp_server(
         raise ConfigurationError("No tools provided. Either provide `user_defined_tools` or set `system_tools` to create system tools for catalog tables.")
     return FenicMCPServer(session._session_state, user_defined_tools, generated_system_tools, server_name, concurrency_limit)
 
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
 def run_mcp_server_asgi(
     server: FenicMCPServer,
     *,
@@ -76,6 +79,7 @@ def run_mcp_server_asgi(
     """
     return server.http_app(stateless_http=stateless_http, port=port, host=host, path=path, **kwargs)
 
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
 def run_mcp_server_sync(
     server: FenicMCPServer,
     *,
@@ -102,6 +106,7 @@ def run_mcp_server_sync(
     server.run(transport=transport, stateless_http=stateless_http, port=port, host=host, path=path, **kwargs)
 
 
+@validate_call(config=ConfigDict(strict=True, arbitrary_types_allowed=True))
 async def run_mcp_server_async(
     server: FenicMCPServer,
     *,

--- a/src/fenic/api/mcp/server.py
+++ b/src/fenic/api/mcp/server.py
@@ -45,7 +45,7 @@ def create_mcp_server(
             )
         )
     if not (user_defined_tools or system_tools):
-        raise ConfigurationError("No tools provided. Either provide tools or set generate_automated_tools=True and provide datasets.")
+        raise ConfigurationError("No tools provided. Either provide `user_defined_tools` or set `system_tools` to create system tools for catalog tables.")
     return FenicMCPServer(session._session_state, user_defined_tools, generated_system_tools, server_name, concurrency_limit)
 
 def run_mcp_server_asgi(

--- a/src/fenic/core/mcp/_server.py
+++ b/src/fenic/core/mcp/_server.py
@@ -289,7 +289,9 @@ class FenicMCPServer:
                 # Collect on a thread to avoid blocking the event loop, and gate concurrent
                 # collections with a semaphore to protect the backend executor.
                 async with self._collect_semaphore:
-                    bound_plan = await tool_definition.func(*args, **kwargs)
+                    bound_plan = await asyncio.to_thread(
+                        lambda: tool_definition.func(*args, **kwargs)
+                    )
                     pl_df, metrics = await asyncio.to_thread(
                         lambda: self.session_state.execution.collect(bound_plan)
                     )

--- a/src/fenic/core/mcp/types.py
+++ b/src/fenic/core/mcp/types.py
@@ -1,7 +1,7 @@
 """Exported Types related to Parameterized View/MCP Tool Generation."""
 from __future__ import annotations
 
-from typing import Annotated, Any, Callable, Coroutine, List, Optional, Union
+from typing import Annotated, Callable, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.dataclasses import dataclass
@@ -80,14 +80,14 @@ class UserDefinedTool:
 class SystemTool:
     """A tool implemented as a regular Python function with explicit parameters.
 
-    The function must be a `Callable[..., Coroutine[Any, Any, LogicalPlan]]` 
+    The function must be a `Callable[..., LogicalPlan]`
     (a function defined with `async def`). Collection/formatting is handled by
     the MCP generator wrapper.
     """
     name: str
     description: str
     max_result_limit: Optional[int]
-    func: Callable[..., Coroutine[Any, Any, LogicalPlan]]
+    func: Callable[..., LogicalPlan]
     add_limit_parameter: bool = True 
     default_table_format: TableFormat = "markdown"
     read_only: Annotated[bool, "A hint to provide to the client that the tool is read-only."] = True

--- a/tests/api/mcp/test_tool_generation.py
+++ b/tests/api/mcp/test_tool_generation.py
@@ -1,6 +1,4 @@
-import asyncio
 import inspect
-from inspect import iscoroutinefunction
 
 import pytest
 
@@ -41,7 +39,6 @@ def test_auto_generate_core_tools_from_tables_builds_tools(local_session):
     for tool in tools:
         assert isinstance(tool, SystemTool)
         assert callable(tool.func)
-        assert iscoroutinefunction(tool.func)
         func_signature = inspect.signature(tool.func)
         # limit and table_format are added by the MCP server wrapper
         assert "table_format" not in func_signature.parameters
@@ -50,7 +47,7 @@ def test_auto_generate_core_tools_from_tables_builds_tools(local_session):
 
     # Sanity check: the Schema tool's callable returns a LogicalPlan we can collect
     schema_tool = next(t for t in tools if t.name.endswith("Schema"))
-    plan = asyncio.run(schema_tool.func())  # type: ignore[call-arg]
+    plan = schema_tool.func()
     pl_df, _ = local_session._session_state.execution.collect(plan)
     assert set(pl_df.columns) == {"dataset", "schema"}
     assert sorted(pl_df.get_column("dataset").to_list()) == ["t1", "t2"]

--- a/tools/automated_mcp_demo_setup.py
+++ b/tools/automated_mcp_demo_setup.py
@@ -22,7 +22,21 @@ def main():
     enriched_profiles_df = local_session.read.parquet("s3://typedef-assets/demo/mcp/enriched_profiles.parquet").select(
         "profile_id", "full_name", "age", "gender", "location", "looking_for", "pets", "occupation", "hobbies",
         "ideal_partner", "bio")
-    moderation_report_df = local_session.read.parquet("s3://typedef-assets/demo/mcp/moderation_report.parquet")
+    moderation_report_df = local_session.read.parquet(
+        "s3://typedef-assets/demo/mcp/moderation_report.parquet"
+    ).select(
+        "conversation_id",
+        "user1_id",
+        "user2_id",
+        "conversation_summary",
+        "primary_concern",
+        "secondary_concerns",
+        "behavior_severity",
+        "escalation_observed",
+        "recommended_action",
+        "primary_bad_actor",
+        "explanation"
+    )
     conversations_df.write.save_as_table(table_name="conversations", mode="overwrite")
     local_session.catalog.set_table_description("conversations", "Raw conversations between users on a dating app.")
     enriched_profiles_df.write.save_as_table(


### PR DESCRIPTION
# Refactor DatasetSpec to lazily load dataframes and improve caching

- Make tool operation functions synchronous
- Have DatasetSpec lazily fetch the dataframe using `session.table` instead of keeping it in memory over the lifespan of the server. 
- Additionally, removed profile caching, and refactored the profile calculation mechanism to parallelize the calculations within polars. 
