### PR TITLE
fix: regressions from duckdb 1.4.0 behavior changes, use polars methods instead of arrow, minor test fixes

### DIFF
--- a/src/fenic/_backends/local/catalog.py
+++ b/src/fenic/_backends/local/catalog.py
@@ -17,7 +17,7 @@ from fenic._backends.utils.catalog_utils import (
 )
 from fenic.core._interfaces.catalog import BaseCatalog
 from fenic.core._logical_plan.plans.base import LogicalPlan
-from fenic.core._utils.misc import generate_unique_arrow_view_name
+from fenic.core._utils.misc import generate_unique_view_name
 from fenic.core._utils.schema import convert_custom_schema_to_polars_schema
 from fenic.core.error import (
     CatalogError,
@@ -414,7 +414,7 @@ class LocalCatalog(BaseCatalog):
         self, table_name: str, schema: Schema, ignore_if_exists: bool = True, description: Optional[str] = None
     ) -> bool:
         """Create a new table."""
-        temp_view_name = generate_unique_arrow_view_name()
+        temp_view_name = generate_unique_view_name()
         with self.lock:
             table_identifier = TableIdentifier.from_string(table_name).enrich(
                 self.get_current_catalog(),
@@ -551,7 +551,7 @@ class LocalCatalog(BaseCatalog):
 
     def write_df_to_table(self, df: pl.DataFrame, table_name: str, schema: Schema):
         """Write a Polars dataframe to a table in the current database."""
-        temp_view_name = generate_unique_arrow_view_name()
+        temp_view_name = generate_unique_view_name()
         with self.lock:
             table_identifier = TableIdentifier.from_string(table_name).enrich(
                 self.get_current_catalog(),
@@ -587,7 +587,7 @@ class LocalCatalog(BaseCatalog):
 
     def insert_df_to_table(self, df: pl.DataFrame, table_name: str, schema: Schema):
         """Insert a Polars dataframe into a table in the current database."""
-        temp_view_name = generate_unique_arrow_view_name()
+        temp_view_name = generate_unique_view_name()
         table_identifier = TableIdentifier.from_string(table_name).enrich(
             self.get_current_catalog(),
             self.get_current_database())
@@ -629,7 +629,7 @@ class LocalCatalog(BaseCatalog):
 
     def replace_table_with_df(self, df: pl.DataFrame, table_name: str, schema: Schema):
         """Replace a table in the current database with a Polars dataframe."""
-        temp_view_name = generate_unique_arrow_view_name()
+        temp_view_name = generate_unique_view_name()
         table_identifier = TableIdentifier.from_string(table_name).enrich(
             self.get_current_catalog(),
             self.get_current_database())

--- a/src/fenic/_backends/local/temp_df_db_client.py
+++ b/src/fenic/_backends/local/temp_df_db_client.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import polars as pl
 
 import fenic._backends.local.utils.io_utils
-from fenic.core._utils.misc import generate_unique_arrow_view_name
+from fenic.core._utils.misc import generate_unique_view_name
 
 
 class TempDFDBClient:
@@ -24,15 +24,13 @@ class TempDFDBClient:
     def read_df(self, table_name: str) -> pl.DataFrame:
         """Read a Polars dataframe from a DuckDB table in the current DuckDB schema."""
         # trunk-ignore-begin(bandit/B608)
-        result = self.db_conn.cursor().execute(f"SELECT * FROM {table_name}")
-        arrow_table = result.arrow()
-        return pl.from_arrow(arrow_table)
+        return self.db_conn.cursor().execute(f"SELECT * FROM {table_name}").pl()
         # trunk-ignore-end(bandit/B608)
 
     def write_df(self, df: pl.DataFrame, table_name: str):
         """Write a Polars dataframe to a DuckDB table in the current DuckDB schema."""
         # trunk-ignore-begin(bandit/B608)
-        view_name = generate_unique_arrow_view_name()
+        view_name = generate_unique_view_name()
         cursor = self.db_conn.cursor()
         cursor.register(view_name, df)
         cursor.execute(f"CREATE TABLE {table_name} AS SELECT * FROM {view_name}")

--- a/src/fenic/_backends/local/transpiler/plan_converter.py
+++ b/src/fenic/_backends/local/transpiler/plan_converter.py
@@ -432,5 +432,5 @@ class PlanConverter:
                 query=logical.resolved_query,
                 cache_info=logical.cache_info,
                 session_state=self.session_state,
-                arrow_view_names=logical.view_names,
+                view_names=logical.view_names,
             )

--- a/src/fenic/_backends/local/utils/io_utils.py
+++ b/src/fenic/_backends/local/utils/io_utils.py
@@ -78,8 +78,7 @@ def query_files(
     result = build_read_query(paths, file_type, s3_session, **options)
 
     try:
-        arrow_result = duckdb_conn.execute(result.sql).arrow()
-        return pl.from_arrow(arrow_result)
+        return duckdb_conn.execute(result.sql).pl()
     except duckdb.HTTPException as e:
         logger.debug("DuckDB read query failed for paths=%s: %s", paths, e, exc_info=True)
         message = _format_http_read_error(e, result)

--- a/src/fenic/core/_logical_plan/plans/transform.py
+++ b/src/fenic/core/_logical_plan/plans/transform.py
@@ -19,7 +19,7 @@ from fenic.core._logical_plan.expressions import (
 )
 from fenic.core._logical_plan.plans.base import LogicalPlan
 from fenic.core._logical_plan.utils import validate_scalar_expr
-from fenic.core._utils.misc import generate_unique_arrow_view_name
+from fenic.core._utils.misc import generate_unique_view_name
 from fenic.core._utils.schema import (
     convert_custom_schema_to_polars_schema,
     convert_polars_schema_to_custom_schema,
@@ -555,7 +555,7 @@ class SQL(LogicalPlan):
         def replace_placeholder(match: re.Match) -> str:
             placeholder = match.group(1)
             if placeholder not in template_name_to_view_name:
-                view_name = generate_unique_arrow_view_name()
+                view_name = generate_unique_view_name()
                 template_name_to_view_name[placeholder] = view_name
             return template_name_to_view_name[placeholder]
 
@@ -570,8 +570,8 @@ class SQL(LogicalPlan):
             polars_schema = convert_custom_schema_to_polars_schema(input.schema())
             db_conn.register(view_name, pl.DataFrame(schema=polars_schema))
         try:
-            arrow_result = db_conn.execute(self.resolved_query).arrow()
-            return convert_polars_schema_to_custom_schema(pl.from_arrow(arrow_result).schema)
+            pl_result = db_conn.execute(self.resolved_query).pl()
+            return convert_polars_schema_to_custom_schema(pl_result.schema)
         except Exception as e:
             raise PlanError(f"Failed to plan SQL query: {self._templated_query}") from e
 

--- a/src/fenic/core/_utils/misc.py
+++ b/src/fenic/core/_utils/misc.py
@@ -21,7 +21,7 @@ def get_content_hash(content: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, content))[:8]
 
 
-def generate_unique_arrow_view_name() -> str:
+def generate_unique_view_name() -> str:
     """Generate a unique temporary view name for an Arrow table.
 
     This is useful for assigning a one-off name to a view or table when
@@ -31,10 +31,10 @@ def generate_unique_arrow_view_name() -> str:
         A string representing a unique temporary view name.
 
     Example:
-        >>> generate_unique_arrow_view_name()
-        'temp_arrow_view_1a2b3c4d5e6f...'
+        >>> generate_unique_view_name()
+        'temp_view_1a2b3c4d5e6f...'
     """
-    return f"temp_arrow_view_{uuid.uuid4().hex}"
+    return f"temp_view_{uuid.uuid4().hex}"
 
 def to_snake_case(name: str) -> str:
     result = name

--- a/tests/_backends/local/io/test_reader.py
+++ b/tests/_backends/local/io/test_reader.py
@@ -789,22 +789,14 @@ def test_read_queries_with_invalid_huggingface_credentials(local_session_config,
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv(paths[0])
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert (
-        str(exc_info.value.__cause__) ==
-        "File loader error: Failed to read from Hugging Face -- credentials were not found and the dataset is private or gated. "
-        "Set HF_TOKEN environment variable. (Status code: 401)"
-    )
+    assert "401" in str(exc_info.value.__cause__)
 
     # Test with invalid token
     monkeypatch.setenv("HF_TOKEN", "invalid_token")
     with pytest.raises(PlanError, match="Failed to infer schema from CSV files") as exc_info:
         session.read.csv(paths[0])
     assert isinstance(exc_info.value.__cause__, FileLoaderError)
-    assert (
-        str(exc_info.value.__cause__) ==
-        "File loader error: Failed to read from Hugging Face -- the provided credentials do not have the required "
-        "permissions. (Status code: 401)"
-    )
+    assert "401" in str(exc_info.value.__cause__)
 
     session.stop()
 

--- a/tests/_backends/local/physical_plan/test_physical_optimizer.py
+++ b/tests/_backends/local/physical_plan/test_physical_optimizer.py
@@ -37,14 +37,14 @@ class TestMergeDuckDBNodesRule:
             query="SELECT * FROM file_source WHERE x > 10",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view1"]
+            view_names=["view1"]
         )
         sql2 = SQLExec(
             children=[sql1],
             query="SELECT * FROM sql1 GROUP BY y",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view2"]
+            view_names=["view2"]
         )
         duckdb_sink = DuckDBTableSinkExec(
             child=sql2,
@@ -128,7 +128,7 @@ class TestMergeDuckDBNodesRule:
             query="SELECT * FROM filter_exec",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view1"]
+            view_names=["view1"]
         )
 
         # Apply optimization
@@ -174,21 +174,21 @@ class TestMergeDuckDBNodesRule:
             query="SELECT * FROM source_table",
             cache_info=CacheInfo(cache_key="cached_table"),  # Cache here
             session_state=session_state,
-            arrow_view_names=["view1"]
+            view_names=["view1"]
         )
         sql2 = SQLExec(
             children=[sql1],
             query="SELECT * FROM sql1",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view2"]
+            view_names=["view2"]
         )
         sql3 = SQLExec(
             children=[sql2],
             query="SELECT * FROM sql2",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view3"]
+            view_names=["view3"]
         )
 
         # Apply optimization
@@ -223,21 +223,21 @@ class TestMergeDuckDBNodesRule:
             query="SELECT * FROM source_table",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view1"]
+            view_names=["view1"]
         )
         sql2 = SQLExec(
             children=[sql1],
             query="SELECT * FROM sql1",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["view2"]
+            view_names=["view2"]
         )
         sql3 = SQLExec(
             children=[sql2],
             query="SELECT * FROM sql2",
             cache_info=CacheInfo(cache_key="cached_table"),  # Cache here
             session_state=session_state,
-            arrow_view_names=["view3"]
+            view_names=["view3"]
         )
 
         # Apply optimization
@@ -273,7 +273,7 @@ class TestMergeDuckDBNodesRule:
             query="SELECT * FROM left_source JOIN right_source ON left_source.id = right_source.id",
             cache_info=None,
             session_state=session_state,
-            arrow_view_names=["left", "right"]
+            view_names=["left", "right"]
         )
 
         # Apply optimization

--- a/tests/api/mcp/test_server.py
+++ b/tests/api/mcp/test_server.py
@@ -1,6 +1,8 @@
 import asyncio
 
 import pytest
+
+pytest.importorskip("fastmcp")
 from fastmcp.tools import Tool
 
 from fenic import SystemTool, SystemToolConfig


### PR DESCRIPTION
# context

duckdb 1.4.0 included a changes arrow() method to export a record batch reader instead of an arrow table.  It also includes a bug in HTTPException where status_code is unset

# changes

- We transform everything from duckdb to polars anyway.  Remove the arrow step and use pl.() directly
- Allow unit test to find 401 in error message
- Allow unit tests to run without fastmcp module
- remove _arrow_ from polars/duckdb view variables
- add sql unit test that loads dataframes from python dict (reproduces the bug with arrow())

# Testing

1. pin duckdb to 1.4.0 and run all unit tests
2. After adding a sql test that uses fenic dfs loaded from python dicts
