### PR TITLE
feat: add `with_columns` with parallel execution

### DIFF
--- a/tests/_backends/local/dataframe/test_core.py
+++ b/tests/_backends/local/dataframe/test_core.py
@@ -67,6 +67,120 @@ def test_with_column_replace_existing(local_session):
     assert result["age"].to_list() == [50, 60]
 
 
+def test_with_columns_add_multiple(sample_df):
+    """Test adding multiple new columns."""
+    result = sample_df.with_columns({
+        "age_plus_1": col("age") + lit(1),
+        "double_age": col("age") * 2,
+        "constant": lit(10)
+    }).to_polars()
+
+    assert "age_plus_1" in result.columns
+    assert "double_age" in result.columns
+    assert "constant" in result.columns
+    assert result["age_plus_1"][0] == 26
+    assert result["double_age"][0] == 50
+    assert result["constant"][0] == 10
+
+
+def test_with_columns_replace_and_add(local_session):
+    """Test replacing existing column and adding new ones."""
+    data = {"name": ["Alice", "Bob"], "age": [25, 30]}
+    df = local_session.create_dataframe(data)
+
+    result = df.with_columns({
+        "age": col("age") + 1,
+        "double_age": col("age") * 2
+    }).to_polars()
+
+    # age should be replaced with age + 1
+    assert result["age"].to_list() == [26, 31]
+    # double_age should be computed from the original age (not the replaced age)
+    assert result["double_age"].to_list() == [50, 60]
+
+
+def test_with_columns_literals(local_session):
+    """Test adding columns with literal values."""
+    data = {"name": ["Alice", "Bob"], "age": [25, 30]}
+    df = local_session.create_dataframe(data)
+
+    result = df.with_columns({
+        "constant1": 1,
+        "constant2": "test"
+    }).to_polars()
+
+    assert result["constant1"].to_list() == [1, 1]
+    assert result["constant2"].to_list() == ["test", "test"]
+
+
+def test_with_columns_empty(local_session):
+    """Test calling with_columns with empty dict."""
+    data = {"name": ["Alice", "Bob"], "age": [25, 30]}
+    df = local_session.create_dataframe(data)
+
+    result = df.with_columns({}).to_polars()
+    assert result.equals(df.to_polars())
+
+
+def test_with_columns_preserve_order(local_session):
+    """Test that existing columns maintain their order."""
+    data = {"name": ["Alice", "Bob"], "age": [25, 30], "city": ["NY", "LA"]}
+    df = local_session.create_dataframe(data)
+
+    result = df.with_columns({
+        "double_age": col("age") * 2,
+        "name_length": lit(5)
+    }).to_polars()
+
+    # Original columns should come first in their original order
+    expected_cols = ["name", "age", "city", "double_age", "name_length"]
+    assert list(result.columns) == expected_cols
+
+
+def test_with_columns_pyspark_example(local_session):
+    """Test PySpark-compatible example from documentation."""
+    data = {"age": [2, 5], "name": ["Alice", "Bob"]}
+    df = local_session.create_dataframe(data)
+
+    # Example from PySpark docs: df.withColumns({'age2': df.age + 2, 'age3': df.age + 3})
+    result = df.with_columns({
+        "age2": col("age") + 2,
+        "age3": col("age") + 3
+    }).to_polars()
+
+    assert "age2" in result.columns
+    assert "age3" in result.columns
+    assert result["age2"].to_list() == [4, 7]
+    assert result["age3"].to_list() == [5, 8]
+
+
+def test_with_columns_cannot_reference_new_columns(local_session):
+    """Test that new columns cannot depend on other new columns in the same with_columns call."""
+    import pytest
+
+    data = {"age": [25, 30], "name": ["Alice", "Bob"]}
+    df = local_session.create_dataframe(data)
+
+    # This should fail because age_plus_2 tries to reference age_plus_1,
+    # but age_plus_1 doesn't exist in the original DataFrame
+    with pytest.raises(ValueError, match="Column 'age_plus_1' not found in schema"):
+        df.with_columns({
+            "age_plus_1": col("age") + 1,
+            "age_plus_2": col("age_plus_1") + 1  # age_plus_1 not yet defined
+        }).to_polars()
+
+def test_with_columns_new_column_order(local_session):
+    """Test that new columns maintain their insertion order."""
+    df = local_session.create_dataframe({"a": [1]})
+    result = df.with_columns({
+        "z_col": lit(1),
+        "y_col": lit(2),
+        "x_col": lit(3)
+    }).to_polars()
+
+    # Original column first, then new columns in insertion order
+    assert list(result.columns) == ["a", "z_col", "y_col", "x_col"]
+
 def test_drop_column(sample_df):
     result = sample_df.drop("age").to_polars()
     assert "age" not in result.columns


### PR DESCRIPTION
### TL;DR

Added a new `with_columns()` method to DataFrame that allows adding or replacing multiple columns in a single operation.

### What changed?

- Implemented a new `with_columns()` method that accepts a dictionary mapping column names to expressions
- Added comprehensive documentation with examples showing various use cases
- Added PySpark-compatible alias `withColumns()` for compatibility
- Added validation using `validate_call` decorator
- Implemented proper column ordering (existing columns maintain their order)
- Added automatic wrapping of non-Column values with `lit()` for convenience
- Added comprehensive test cases covering various scenarios

### How to test?

```python
# Create a DataFrame
df = session.create_dataframe({"name": ["Alice", "Bob"], "age": [25, 30]})

# Test adding multiple columns at once
result = df.with_columns({
    "age_plus_1": col("age") + 1,
    "double_age": col("age") * 2,
    "constant": 10
})
result.show()

# Test replacing existing columns
result = df.with_columns({
    "age": col("age") + 5,
    "name": upper(col("name"))
})
result.show()

# Test with literal values
result = df.with_columns({
    "status": "active",
    "score": 100
})
result.show()
```

### Why make this change?

This enhancement improves developer productivity by allowing multiple columns to be added or replaced in a single operation, rather than chaining multiple `with_column()` calls (or using `df.select("*", ...). It also provides better compatibility with PySpark's API which offers a similar method. The implementation maintains the expected behavior where all columns are created at once (new columns cannot reference other new columns in the same call).

### Questions 

I'm not sure of the implicit conversions to `lit` values fits with our general philosophy of explicit over implicit. It is very easy to support code-wise but happy to remove if desired.  