### PR TITLE
fix: openrouter batch completions client was broken after changes to LMRequestMessages

### DIFF
--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 from openai import APIConnectionError, APITimeoutError, OpenAIError, RateLimitError
 from pydantic import ValidationError as PydanticValidationError
 
+from fenic._inference.common_openai.openai_utils import convert_messages
 from fenic._inference.common_openai.utils import handle_openai_compatible_response
 from fenic._inference.model_client import (
     FatalException,
@@ -92,7 +93,7 @@ class OpenRouterBatchChatCompletionsClient(
         profile = self._profile_manager.get_profile_by_name(request.model_profile)
         common_params = {
                 "model": self.model,
-                "messages": request.messages.to_message_list(),
+                "messages": convert_messages(request.messages),
                 "max_completion_tokens": self._get_max_output_tokens(request),
                 "n": 1,
             }


### PR DESCRIPTION
### TL;DR

Fixed openrouter client issues -- updated the OpenRouter batch chat completions client to use the common message conversion utility.

### What changed?

- Imported the `convert_messages` function from `fenic._inference.common_openai.openai_utils`
- Replaced the direct call to `request.messages.to_message_list()` with `convert_messages(request.messages)` in the `make_single_request` method