### PR TITLE
feat: Add openai support for semantic parse_pdf

### DIFF
--- a/src/fenic/_backends/local/semantic_operators/parse_pdf.py
+++ b/src/fenic/_backends/local/semantic_operators/parse_pdf.py
@@ -48,11 +48,13 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
         page_separator: Optional[str] = None,
         describe_images: bool = False,
         model_alias: Optional[ResolvedModelAlias] = None,
+        max_output_tokens: Optional[int] = None,
     ):
         self.page_separator = page_separator
         self.describe_images = describe_images
         self.model = model
         self.model_alias = model_alias
+        self.max_output_tokens = max_output_tokens
 
         DocFolderLoader.check_file_extensions(input.to_list(), "pdf")
 
@@ -62,7 +64,7 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
                 model=model,
                 operator_name="semantic.parse_pdf",
                 inference_config=InferenceConfiguration(
-                    max_output_tokens=None,
+                    max_output_tokens=max_output_tokens,
                     temperature=1.0,  # Use a higher temperature so gemini flash models can handle complex table formatting.  For more info see the conversation here: https://discuss.ai.google.dev/t/gemini-2-0-flash-has-a-weird-bug/65119/26
                     model_profile=model_alias.profile if model_alias else None,
                 ),

--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -712,8 +712,9 @@ class ExprConverter:
                 page_separator=logical.page_separator,
                 describe_images=logical.describe_images,
                 model_alias=logical.model_alias,
+                max_output_tokens=logical.max_output_tokens,
             ).execute()
-        
+
         return self._convert_expr(logical.expr).map_batches(
             parse_pdf_fn, return_dtype=pl.Utf8
         )

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -275,7 +275,7 @@ class AnthropicBatchCompletionsClient(
         """
         return self.estimate_response_format_tokens(response_format)
 
-    def _get_max_output_tokens(self, request: FenicCompletionsRequest) -> int:
+    def _get_max_output_token_request_limit(self, request: FenicCompletionsRequest) -> int:
         """Get maximum output tokens including thinking budget.
 
         Args:
@@ -329,7 +329,7 @@ class AnthropicBatchCompletionsClient(
         input_tokens += self._count_auxiliary_input_tokens(request)
         
         # Estimate output tokens
-        output_tokens = self._get_max_output_tokens(request)
+        output_tokens = self._get_max_output_token_request_limit(request)
         
         return TokenEstimate(
             input_tokens=input_tokens,

--- a/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
+++ b/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
@@ -171,7 +171,7 @@ class CohereBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
             output_tokens=0
         )
 
-    def _get_max_output_tokens(self, request: FenicEmbeddingsRequest) -> int:
+    def _get_max_output_token_request_limit(self, request: FenicEmbeddingsRequest) -> int:
         """Get maximum output tokens (always 0 for embeddings).
         
         Returns:

--- a/src/fenic/_inference/google/gemini_batch_embeddings_client.py
+++ b/src/fenic/_inference/google/gemini_batch_embeddings_client.py
@@ -121,7 +121,7 @@ class GoogleBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, List[float
             input_tokens=self.token_counter.count_tokens(request.doc), output_tokens=0
         )
 
-    def _get_max_output_tokens(self, request: FenicEmbeddingsRequest) -> int:
+    def _get_max_output_token_request_limit(self, request: FenicEmbeddingsRequest) -> int:
         return 0
 
     def reset_metrics(self):

--- a/src/fenic/_inference/language_model.py
+++ b/src/fenic/_inference/language_model.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class InferenceConfiguration:
-    # If max_output_tokens is not provided, do not include it in the request.
+    # If max_output_tokens is not provided, model_client will add a guardrail based on the estimated output tokens.
     max_output_tokens: Optional[int]
     temperature: float
     top_logprobs: Optional[int] = None

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -245,8 +245,8 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
 
 
     @abstractmethod
-    def _get_max_output_tokens(self, request: RequestT) -> int:
-        """Get conservative output token estimate. Override in subclasses for provider-specific logic."""
+    def _get_max_output_token_request_limit(self, request: RequestT) -> int:
+        """Get the upper limit of output tokens to set on a request."""
         pass
 
     #

--- a/src/fenic/_inference/openai/openai_batch_embeddings_client.py
+++ b/src/fenic/_inference/openai/openai_batch_embeddings_client.py
@@ -107,7 +107,7 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
         """
         return self._core.get_metrics()
 
-    def _get_max_output_tokens(self, request: RequestT) -> int:
+    def _get_max_output_token_request_limit(self, request: RequestT) -> int:
         return 0
 
     async def validate_api_key(self):

--- a/src/fenic/_inference/rate_limit_strategy.py
+++ b/src/fenic/_inference/rate_limit_strategy.py
@@ -10,7 +10,6 @@ from fenic.core.error import ExecutionError, InternalError, ValidationError
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass
 class TokenEstimate:
     input_tokens: int = 0

--- a/src/fenic/api/functions/semantic.py
+++ b/src/fenic/api/functions/semantic.py
@@ -596,6 +596,7 @@ def parse_pdf(
     model_alias: Optional[Union[str, ModelAlias]] = None,
 	page_separator: Optional[str] = None,
 	describe_images: bool = False,  # for images that aren't tables
+	max_output_tokens: Optional[int] = None,
 ) -> Column:
     r"""Parses a column of PDF paths into markdown.
 
@@ -607,6 +608,7 @@ def parse_pdf(
         model_alias: Optional alias for the language model to use for the parsing. If None, will use the language model configured as the default.
         page_separator: Optional page separator to use for the parsing.  If the separator includes the {page} placeholder, the model will replace it with the current page number.
         describe_images:  Flag to describe images in the PDF. If True, the prompt will ask the model to include a description of the image in the markdown output.  If False, the prompt asks the model to ignore images that aren't tables or charts.
+        max_output_tokens: Optional maximum number of output tokens per ~3 pages of PDF (does not include reasoning tokens). If None, don't constrain the model's output.
 
     Note:
         For Gemini models, this function uses the google file API, uploading PDF files to Google's file store and deleting them after each request.
@@ -640,5 +642,6 @@ def parse_pdf(
             model_alias=resolved_model_alias,
             page_separator=page_separator,
             describe_images=describe_images,
+            max_output_tokens=max_output_tokens,
         )
     )

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -504,6 +504,7 @@ class ModelCatalog:
                 max_output_tokens=16_384,
                 max_temperature=2,
                 supports_profiles=False,
+                supports_pdf_parsing=True,
             ),
             snapshots=["gpt-4o-mini-2024-07-18"],
         )
@@ -519,6 +520,7 @@ class ModelCatalog:
                 max_output_tokens=16_384,
                 max_temperature=2,
                 supports_profiles=False,
+                supports_pdf_parsing=True,
             ),
             snapshots=["gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20"],
         )
@@ -595,6 +597,7 @@ class ModelCatalog:
                 max_temperature=2.0,
                 supports_reasoning=True,
                 supports_custom_temperature=False,
+                supports_pdf_parsing=True,
             ),
         )
 
@@ -624,6 +627,7 @@ class ModelCatalog:
                 max_output_tokens=100_000,
                 max_temperature=2.0,
                 supports_reasoning=True,
+                supports_pdf_parsing=True,
             ),
         )
 
@@ -641,6 +645,7 @@ class ModelCatalog:
                 supports_minimal_reasoning=True,
                 supports_custom_temperature=False,
                 supports_verbosity=True,
+                supports_pdf_parsing=True,
             ),
             snapshots=["gpt-5-2025-08-07"],
         )
@@ -658,6 +663,7 @@ class ModelCatalog:
                 supports_minimal_reasoning=True,
                 supports_custom_temperature=False,
                 supports_verbosity=True,
+                supports_pdf_parsing=True,
             ),
             snapshots=["gpt-5-mini-2025-08-07"],
         )
@@ -675,6 +681,7 @@ class ModelCatalog:
                 supports_minimal_reasoning=True,
                 supports_verbosity=True,
                 supports_custom_temperature=False,
+                supports_pdf_parsing=True,
             ),
             snapshots=["gpt-5-nano-2025-08-07"],
         )

--- a/src/fenic/core/_logical_plan/expressions/semantic.py
+++ b/src/fenic/core/_logical_plan/expressions/semantic.py
@@ -631,11 +631,13 @@ class SemanticParsePDFExpr(ValidatedSignature, SemanticExpr):
         model_alias: Optional[ResolvedModelAlias] = None,
         page_separator: Optional[str] = None,
         describe_images: bool = False,
+        max_output_tokens: Optional[int] = None,
     ):
         self.expr = expr
         self.model_alias = model_alias
         self.page_separator = page_separator
         self.describe_images = describe_images
+        self.max_output_tokens = max_output_tokens
 
         # Initialize validator for composition-based type validation
         self._validator = SignatureValidator(self.function_name)
@@ -665,4 +667,5 @@ class SemanticParsePDFExpr(ValidatedSignature, SemanticExpr):
     def _eq_specific(self, other: SemanticParsePDFExpr) -> bool:
         return (self.model_alias == other.model_alias
                 and self.page_separator == other.page_separator
-                and self.describe_images == other.describe_images)
+                and self.describe_images == other.describe_images
+                and self.max_output_tokens == other.max_output_tokens)

--- a/tests/_backends/local/functions/test_semantic_parse_pdf.py
+++ b/tests/_backends/local/functions/test_semantic_parse_pdf.py
@@ -19,12 +19,13 @@ basic_text_content = [
     "Content about war and peace, examining the complex relationship between conflict and harmony throughout human history. This analysis covers major historical conflicts, their causes and consequences, as well as the various peace movements and diplomatic efforts that have shaped our world. The discussion includes philosophical perspectives on violence, justice, and the pursuit of lasting peace.",
 ]
 
+# keeping the more expensive models off by default
 vlms_to_test = [
-    # TODO: add openai tests when adding openai parse_pdf support
-    #(OpenAILanguageModel, "gpt-5-nano"),
-    #(OpenAILanguageModel, "gpt-4o-mini"),
-    #(OpenAILanguageModel, "o3-mini"),
-    (GoogleDeveloperLanguageModel, "gemini-2.5-pro"),
+    (OpenAILanguageModel, "gpt-5-nano"),
+    (OpenAILanguageModel, "gpt-4o-mini"),
+    #(OpenAILanguageModel, "o3"),
+    (OpenAILanguageModel, "o4-mini"),
+    #(GoogleDeveloperLanguageModel, "gemini-2.5-pro"),
     (GoogleDeveloperLanguageModel, "gemini-2.0-flash-lite"),
     (GoogleDeveloperLanguageModel, "gemini-2.5-flash-lite"),
 ]
@@ -184,7 +185,7 @@ def _setup_session_with_vlm(test_model_class: BaseModel, model_name: str):
         else:
             profile = test_model_class.Profile(reasoning_effort="low")
     config = SessionConfig(
-        app_name="test_app_google",
+        app_name="test_app_parse_pdf",
         semantic=SemanticConfig(
             language_models={"vlm": test_model_class(
                 model_name=model_name,

--- a/tests/_inference/test_openai_token_counter.py
+++ b/tests/_inference/test_openai_token_counter.py
@@ -1,0 +1,75 @@
+import os
+
+import fitz
+
+from fenic._inference.token_counter import TiktokenTokenCounter
+from fenic._inference.types import FewShotExample, LMRequestFile, LMRequestMessages
+from tests.conftest import _save_pdf_file
+
+
+def test_local_token_counter_counts_tokens():
+    model = "gpt-4o-mini"
+    counter = TiktokenTokenCounter(model_name=model)
+    assert counter.count_tokens("This is a longer string of text with characters: 那只敏捷的棕色狐狸跳过了懒惰的狗") == 28
+
+    model = "gpt-4o"
+    pro_counter = TiktokenTokenCounter(model_name=model)
+    assert pro_counter.count_tokens("This is a longer string of text with characters: 那只敏捷的棕色狐狸跳过了懒惰的狗") == 28
+
+def test_local_token_counter_falls_back_to_o200k_base():
+    model = "gpt-242342"  # non-existent model
+    counter = TiktokenTokenCounter(model_name=model)
+    assert counter.count_tokens("This is a longer string of text with characters: 那只敏捷的棕色狐狸跳过了懒惰的狗") == 28
+
+def test_openai_tokenizer_counts_tokens_for_message_list():
+    model = "gpt-4o-mini"
+
+    counter = TiktokenTokenCounter(model_name=model)
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[FewShotExample(user="ping", assistant="pong")],
+        user="Summarize: The quick brown fox jumps over the lazy dog.",
+    )
+    # Note: The exact token count may differ from Gemini due to different tokenization
+    # This test verifies the method works and returns a reasonable value
+    token_count = counter.count_tokens(messages)
+    assert token_count == 44  # Actual token count for OpenAI tokenizer
+
+def test_openai_tokenizer_counts_tokens_for_pdfs(temp_dir_just_one_file):
+    model = "gpt-4o-mini"
+    pdf_path1 = os.path.join(temp_dir_just_one_file, "test_pdf_one_page.pdf")
+    pdf_path2 = os.path.join(temp_dir_just_one_file, "test_pdf_three_pages.pdf")
+    _save_pdf_file(pdf_path1, page_count=1, text_content="The quick brown fox jumps over the lazy dog.")
+    _save_pdf_file(pdf_path2, page_count=3, text_content="The quick brown fox jumps over the lazy dog.")
+    counter = TiktokenTokenCounter(model_name=model)
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path1, page_range=(0, 1)),
+    )
+    # OpenAI uses different tokenization for PDFs, including image tokens
+    # Just verify it returns a positive number and processes the PDF
+    token_count = counter.count_tokens(messages)
+    assert token_count > 0
+
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path2, page_range=(0, 3)),
+    )
+    # Verify that 3-page PDF has more tokens than 1-page PDF
+    token_count_3pages = counter.count_tokens(messages)
+    assert token_count_3pages > token_count
+
+    # verify token estimation for chunked PDF works
+    pdf_2 = fitz.open(pdf_path2)
+    pdf_2_chunk = fitz.open()
+    pdf_2_chunk.insert_pdf(pdf_2, from_page=1, to_page=1)
+    messages = LMRequestMessages(
+        system="You are a helpful assistant.",
+        examples=[],
+        user_file=LMRequestFile(path=pdf_path2, pdf_chunk_bytes=pdf_2_chunk.tobytes(), page_range=(1, 2)),
+    )
+    # Verify that a 1-page chunk has the same number of tokens as a 1-page PDF
+    token_count_1_page_chunk = counter.count_tokens(messages)
+    assert token_count_1_page_chunk == token_count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,7 @@ def configure_language_model(model_provider: ModelProvider, model_name: str) -> 
     )
     # these limits are purposely low so we don't consume our entire project limit while running multiple tests in multiple branches
     if model_provider == ModelProvider.OPENAI:
-        if model_parameters.supports_reasoning and model_parameters.supports_verbosity:
+        if model_parameters.supports_minimal_reasoning and model_parameters.supports_verbosity:
             language_model = OpenAILanguageModel(
                 model_name=model_name,
                 rpm=500,


### PR DESCRIPTION
### TL;DR

Added PDF file support for OpenAI models with proper token counting and estimation.

### What changed?

- Made `max_completion_tokens` optional in OpenAI chat completions requests
- Implemented PDF file token counting for OpenAI models:
    - Added methods to count tokens for PDF files in input and output
    - Updated token counter to handle PDF files with proper token estimation
    - Added support for PDF parsing to various OpenAI models in the model catalog
- Refactored openai token counting logic
- Mini refactor - separate `_max_output_tokens` user limit concept from `_estimate_output_tokens` for cost estimation and throttling
    - added to openai and updated gemini
    - Max tokens (put in request)
        - Use max tokens provided by semantic_operator if exists
        **- OR, for page parsing specifically, use an upper limit based on output limit of our smallest VLM supported (8000 tokens)**
        - Add expected reasoning effort
    - Estimate output tokens (for cost estimate and throttling)
        - Use max tokens provided by semantic_operator if exists
        - OR estimate file output tokens
        - Add expected reasoning effort
- Added openai models to semantic_parse_pdf tests

### Out of scope

The token estimation should happen at the semantic operator level, since it has the context of what its expecting from the model.  Currently, semantic operator only passes 'max token' limit to the client and we use that upper limit in our estimates.  As a future improvement we should refactor and have the semantic operator decide on the output token limit for the request

### How to test?

1. Run the new token counter tests: `pytest tests/_inference/test_openai_token_counter.py`
2. Test PDF parsing with OpenAI models: `pytest tests/_backends/local/functions/test_semantic_parse_pdf.py`
3. Verify that token estimation works correctly with PDF files by using a model that supports PDF parsing