### PR TITLE
feat: add base_url support for OpenAI and Anthropic model configs

### DIFF
--- a/src/fenic/_backends/local/model_registry.py
+++ b/src/fenic/_backends/local/model_registry.py
@@ -76,7 +76,10 @@ class SessionModelRegistry:
             for alias, model_config in language_model_config.model_configs.items():
                 model = self._initialize_language_model(model_config, cache)
                 models[alias] = model
-                validate_providers.add(model.client.model_provider_class)
+                # Skip API key validation for providers with custom base URLs,
+                # since the proxy may not expose the /models endpoint.
+                if not getattr(model.client.model_provider_class, "_base_url", None):
+                    validate_providers.add(model.client.model_provider_class)
             self.language_model_registry = LanguageModelRegistry(
                 models=models,
                 default_model=models[language_model_config.default_model],
@@ -88,7 +91,8 @@ class SessionModelRegistry:
             for alias, model_config in embedding_model_config.model_configs.items():
                 model = self._initialize_embedding_model(model_config)
                 models[alias] = model
-                validate_providers.add(model.client.model_provider_class)
+                if not getattr(model.client.model_provider_class, "_base_url", None):
+                    validate_providers.add(model.client.model_provider_class)
             self.embedding_model_registry = EmbeddingModelRegistry(
                 models=models,
                 default_model=models[embedding_model_config.default_model],
@@ -235,6 +239,7 @@ class SessionModelRegistry:
                 client = OpenAIBatchEmbeddingsClient(
                     rate_limit_strategy=rate_limit_strategy,
                     model=model_config.model_name,
+                    base_url=model_config.base_url,
                 )
             elif isinstance(model_config, ResolvedGoogleModelConfig):
                 try:
@@ -311,6 +316,7 @@ class SessionModelRegistry:
                     profiles=model_config.profiles,
                     default_profile_name=model_config.default_profile,
                     cache=cache,
+                    base_url=model_config.base_url,
                 )
 
             elif isinstance(model_config, ResolvedAnthropicModelConfig):
@@ -333,6 +339,7 @@ class SessionModelRegistry:
                     profiles=model_config.profiles,
                     default_profile_name=model_config.default_profile,
                     cache=cache,
+                    base_url=model_config.base_url,
                 )
 
             elif isinstance(model_config, ResolvedGoogleModelConfig):

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -78,6 +78,7 @@ class AnthropicBatchCompletionsClient(
         profiles: Optional[dict[str, ResolvedAnthropicModelProfile]] = None,
         default_profile_name: Optional[str] = None,
         cache: Optional["LLMResponseCache"] = None,
+        base_url: Optional[str] = None,
     ):
         """Initialize the Anthropic batch completions client.
 
@@ -89,11 +90,13 @@ class AnthropicBatchCompletionsClient(
             profiles: Dictionary of profile configurations
             default_profile_name: Name of the default profile to use
             cache: Optional LLM response cache
+            base_url: Custom base URL for the Anthropic API
         """
+        model_provider_class = AnthropicModelProvider(base_url=base_url)
         super().__init__(
             model=model,
             model_provider=ModelProvider.ANTHROPIC,
-            model_provider_class=AnthropicModelProvider(),
+            model_provider_class=model_provider_class,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,

--- a/src/fenic/_inference/anthropic/anthropic_provider.py
+++ b/src/fenic/_inference/anthropic/anthropic_provider.py
@@ -14,17 +14,26 @@ logger = logging.getLogger(__name__)
 class AnthropicModelProvider(ModelProviderClass):
     """Anthropic implementation of ModelProvider."""
 
+    def __init__(self, base_url: str | None = None):
+        self._base_url = base_url
+
     @property
     def name(self) -> str:
         return "anthropic"
-    
+
     def create_client(self):
         """Create an Anthropic sync client instance."""
-        return anthropic.Client(http_client=httpx.Client(timeout=MAX_MODEL_CLIENT_TIMEOUT))
+        return anthropic.Client(
+            base_url=self._base_url,
+            http_client=httpx.Client(timeout=MAX_MODEL_CLIENT_TIMEOUT),
+        )
 
     def create_aio_client(self):
         """Create an Anthropic async client instance."""
-        return anthropic.AsyncAnthropic(http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT))
+        return anthropic.AsyncAnthropic(
+            base_url=self._base_url,
+            http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT),
+        )
     
     async def validate_api_key(self) -> None:
         """Validate Anthropic API key by making a minimal completion request."""

--- a/src/fenic/_inference/cache/key_builder.py
+++ b/src/fenic/_inference/cache/key_builder.py
@@ -16,6 +16,7 @@ def compute_request_fingerprint(
     request: Union[FenicCompletionsRequest, FenicEmbeddingsRequest],
     model: str,
     profile_hash: Optional[str] = None,
+    base_url: Optional[str] = None,
 ) -> str:
     """Build a deterministic SHA-256 key for the given request.
 
@@ -23,6 +24,7 @@ def compute_request_fingerprint(
         request: The request object to fingerprint.
         model: The model name for the request.
         profile_hash: Optional hash of the resolved profile configuration.
+        base_url: Optional custom base URL for the provider endpoint.
 
     Returns:
         A 64-character hexadecimal string representing the request.
@@ -34,6 +36,7 @@ def compute_request_fingerprint(
     if isinstance(request, FenicCompletionsRequest):
         key_data = {
             "model": model,
+            "base_url": base_url,
             "messages": request.messages.encode().hex(),
             "max_tokens": request.max_completion_tokens,
             "temperature": request.temperature,
@@ -47,6 +50,7 @@ def compute_request_fingerprint(
     elif isinstance(request, FenicEmbeddingsRequest):
         key_data = {
             "model": model,
+            "base_url": base_url,
             "doc_hash": hashlib.sha256(request.doc.encode("utf-8")).hexdigest(),
             "model_profile": request.model_profile,
             "profile_hash": profile_hash,

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -247,7 +247,8 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
     def _build_request_key(self, request: RequestT) -> str:
         """Build the canonical cache/deduplication key for a request."""
         profile_hash = self.get_profile_hash_for_request(request)
-        return compute_request_fingerprint(request, self.model, profile_hash=profile_hash)
+        base_url = getattr(self.model_provider_class, "_base_url", None)
+        return compute_request_fingerprint(request, self.model, profile_hash=profile_hash, base_url=base_url)
 
     def _safe_build_request_key(
         self, request: RequestT, request_index: Optional[int] = None

--- a/src/fenic/_inference/openai/openai_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openai/openai_batch_chat_completions_client.py
@@ -44,6 +44,7 @@ class OpenAIBatchChatCompletionsClient(
         profiles: Optional[dict[str, ResolvedOpenAIModelProfile]] = None,
         default_profile_name: Optional[str] = None,
         cache: Optional["LLMResponseCache"] = None,
+        base_url: Optional[str] = None,
     ):
         """Initialize the OpenAI batch chat completions client.
 
@@ -55,14 +56,16 @@ class OpenAIBatchChatCompletionsClient(
             profiles: Dictionary of profile configurations
             default_profile_name: Default profile to use when none specified
             cache: Optional LLM response cache
+            base_url: Custom base URL for the OpenAI API
         """
         token_counter = TiktokenTokenCounter(
             model_name=model, fallback_encoding="o200k_base"
         )
+        model_provider_class = OpenAIModelProvider(base_url=base_url)
         super().__init__(
             model=model,
             model_provider=ModelProvider.OPENAI,
-            model_provider_class=OpenAIModelProvider(),
+            model_provider_class=model_provider_class,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,

--- a/src/fenic/_inference/openai/openai_batch_embeddings_client.py
+++ b/src/fenic/_inference/openai/openai_batch_embeddings_client.py
@@ -34,6 +34,7 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
         model: str,
         queue_size: int = 500,
         max_backoffs: int = 10,
+        base_url: str | None = None,
     ):
         """Initialize the OpenAI batch embeddings client.
 
@@ -42,11 +43,13 @@ class OpenAIBatchEmbeddingsClient(ModelClient[FenicEmbeddingsRequest, list[float
             queue_size: Size of the request queue
             model: The model to use
             max_backoffs: Maximum number of backoff attempts
+            base_url: Custom base URL for the OpenAI API
         """
+        model_provider_class = OpenAIModelProvider(base_url=base_url)
         super().__init__(
             model=model,
             model_provider=ModelProvider.OPENAI,
-            model_provider_class=OpenAIModelProvider(),
+            model_provider_class=model_provider_class,
             rate_limit_strategy=rate_limit_strategy,
             queue_size=queue_size,
             max_backoffs=max_backoffs,

--- a/src/fenic/_inference/openai/openai_provider.py
+++ b/src/fenic/_inference/openai/openai_provider.py
@@ -14,17 +14,26 @@ logger = logging.getLogger(__name__)
 class OpenAIModelProvider(ModelProviderClass):
     """OpenAI implementation of ModelProvider."""
 
+    def __init__(self, base_url: str | None = None):
+        self._base_url = base_url
+
     @property
     def name(self) -> str:
         return "openai"
 
     def create_client(self):
         """Create an OpenAI client instance."""
-        return OpenAI(http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT))
+        return OpenAI(
+            base_url=self._base_url,
+            http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT),
+        )
 
     def create_aio_client(self):
         """Create an OpenAI async client instance."""
-        return AsyncOpenAI(http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT))
+        return AsyncOpenAI(
+            base_url=self._base_url,
+            http_client=httpx.AsyncClient(timeout=MAX_MODEL_CLIENT_TIMEOUT),
+        )
 
     async def validate_api_key(self) -> None:
         """Validate OpenAI API key by listing models."""

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -539,6 +539,10 @@ class OpenAILanguageModel(BaseModel):
     )
     rpm: int = Field(..., gt=0, description="Requests per minute; must be > 0")
     tpm: int = Field(..., gt=0, description="Tokens per minute; must be > 0")
+    base_url: Optional[str] = Field(
+        default=None,
+        description="Custom base URL for the OpenAI API (e.g., for proxies or gateways)",
+    )
     profiles: Optional[dict[str, Profile]] = Field(
         default=None, description=profiles_desc
     )
@@ -611,6 +615,10 @@ class OpenAIEmbeddingModel(BaseModel):
     )
     rpm: int = Field(..., gt=0, description="Requests per minute; must be > 0")
     tpm: int = Field(..., gt=0, description="Tokens per minute; must be > 0")
+    base_url: Optional[str] = Field(
+        default=None,
+        description="Custom base URL for the OpenAI API (e.g., for proxies or gateways)",
+    )
 
 
 class AnthropicLanguageModel(BaseModel):
@@ -675,6 +683,10 @@ class AnthropicLanguageModel(BaseModel):
     )
     output_tpm: int = Field(
         ..., gt=0, description="Output tokens per minute; must be > 0"
+    )
+    base_url: Optional[str] = Field(
+        default=None,
+        description="Custom base URL for the Anthropic API (e.g., for proxies)",
     )
     profiles: Optional[dict[str, Profile]] = Field(
         default=None, description=profiles_desc
@@ -1548,6 +1560,7 @@ class SessionConfig(BaseModel):
                     model_name=model.model_name,
                     rpm=model.rpm,
                     tpm=model.tpm,
+                    base_url=model.base_url,
                 )
             elif isinstance(model, OpenAILanguageModel):
                 profiles = {
@@ -1560,6 +1573,7 @@ class SessionConfig(BaseModel):
                     tpm=model.tpm,
                     profiles=profiles,
                     default_profile=model.default_profile,
+                    base_url=model.base_url,
                 )
             elif isinstance(model, (GoogleDeveloperLanguageModel, GoogleVertexLanguageModel)):
                 profiles = {
@@ -1606,6 +1620,7 @@ class SessionConfig(BaseModel):
                     output_tpm=model.output_tpm,
                     profiles=profiles,
                     default_profile=model.default_profile,
+                    base_url=model.base_url,
                 )
             elif isinstance(model, CohereEmbeddingModel):
                 profiles = {

--- a/src/fenic/core/_resolved_session_config.py
+++ b/src/fenic/core/_resolved_session_config.py
@@ -94,6 +94,7 @@ class ResolvedOpenAIModelConfig:
     model_provider: ModelProvider = ModelProvider.OPENAI
     profiles: Optional[dict[str, ResolvedOpenAIModelProfile]] = None
     default_profile: Optional[str] = None
+    base_url: Optional[str] = None
 
 
 @dataclass
@@ -105,6 +106,7 @@ class ResolvedAnthropicModelConfig:
     model_provider: ModelProvider = ModelProvider.ANTHROPIC
     profiles: Optional[dict[str, ResolvedAnthropicModelProfile]] = None
     default_profile: Optional[str] = None
+    base_url: Optional[str] = None
 
 
 @dataclass

--- a/tests/_inference/cache/test_request_fingerprint.py
+++ b/tests/_inference/cache/test_request_fingerprint.py
@@ -34,8 +34,9 @@ def _fingerprint(
     request: FenicCompletionsRequest,
     model: str = "gpt-4o-mini",
     profile_hash: str | None = None,
+    base_url: str | None = None,
 ) -> str:
-    return compute_request_fingerprint(request, model, profile_hash=profile_hash)
+    return compute_request_fingerprint(request, model, profile_hash=profile_hash, base_url=base_url)
 
 
 def test_request_fingerprint_is_deterministic():
@@ -174,4 +175,26 @@ def test_request_fingerprint_respects_profile_hash_even_without_profile_name():
     assert _fingerprint(request, profile_hash="hash1") != _fingerprint(
         request, profile_hash="hash2"
     )
+
+
+def test_request_fingerprint_changes_with_base_url():
+    """Different base_url values produce different cache keys."""
+    messages = LMRequestMessages(system="You are helpful", examples=[], user="Hello")
+    request = _build_request(messages=messages)
+
+    key_default = _fingerprint(request)
+    key_proxy = _fingerprint(request, base_url="https://proxy.example.com/v1")
+    key_other = _fingerprint(request, base_url="https://other-proxy.example.com/v1")
+
+    assert key_default != key_proxy
+    assert key_default != key_other
+    assert key_proxy != key_other
+
+
+def test_request_fingerprint_none_base_url_matches_default():
+    """Explicitly passing base_url=None produces the same key as omitting it."""
+    messages = LMRequestMessages(system="You are helpful", examples=[], user="Hello")
+    request = _build_request(messages=messages)
+
+    assert _fingerprint(request) == _fingerprint(request, base_url=None)
 

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -660,3 +660,132 @@ def test_session_config_with_invalid_anthropic_api_key(tmp_path, monkeypatch):
             )
         )
         _ = Session.get_or_create(config)
+
+
+# --- base_url resolution tests ---
+
+
+def test_openai_language_model_base_url_resolves():
+    """Test that base_url on OpenAILanguageModel is threaded through to the resolved config."""
+    config = SessionConfig(
+        app_name="test_openai_base_url",
+        semantic=SemanticConfig(
+            language_models={
+                "gpt": OpenAILanguageModel(
+                    model_name="gpt-4o-mini",
+                    rpm=100,
+                    tpm=100,
+                    base_url="https://my-proxy.example.com/v1",
+                )
+            }
+        ),
+    )
+    resolved = config._to_resolved_config()
+    model_config = resolved.semantic.language_models.model_configs["gpt"]
+    assert model_config.base_url == "https://my-proxy.example.com/v1"
+
+
+def test_openai_language_model_base_url_defaults_to_none():
+    """Test that base_url defaults to None when not provided."""
+    config = SessionConfig(
+        app_name="test_openai_base_url_default",
+        semantic=SemanticConfig(
+            language_models={
+                "gpt": OpenAILanguageModel(
+                    model_name="gpt-4o-mini", rpm=100, tpm=100
+                )
+            }
+        ),
+    )
+    resolved = config._to_resolved_config()
+    model_config = resolved.semantic.language_models.model_configs["gpt"]
+    assert model_config.base_url is None
+
+
+def test_openai_embedding_model_base_url_resolves():
+    """Test that base_url on OpenAIEmbeddingModel is threaded through to the resolved config."""
+    config = SessionConfig(
+        app_name="test_openai_embedding_base_url",
+        semantic=SemanticConfig(
+            embedding_models={
+                "embed": OpenAIEmbeddingModel(
+                    model_name="text-embedding-3-small",
+                    rpm=100,
+                    tpm=100,
+                    base_url="https://my-proxy.example.com/v1",
+                )
+            }
+        ),
+    )
+    resolved = config._to_resolved_config()
+    model_config = resolved.semantic.embedding_models.model_configs["embed"]
+    assert model_config.base_url == "https://my-proxy.example.com/v1"
+
+
+def test_anthropic_language_model_base_url_resolves():
+    """Test that base_url on AnthropicLanguageModel is threaded through to the resolved config."""
+    config = SessionConfig(
+        app_name="test_anthropic_base_url",
+        semantic=SemanticConfig(
+            language_models={
+                "claude": AnthropicLanguageModel(
+                    model_name="claude-sonnet-4-20250514",
+                    rpm=100,
+                    input_tpm=100,
+                    output_tpm=100,
+                    base_url="https://my-proxy.example.com",
+                )
+            }
+        ),
+    )
+    resolved = config._to_resolved_config()
+    model_config = resolved.semantic.language_models.model_configs["claude"]
+    assert model_config.base_url == "https://my-proxy.example.com"
+
+
+def test_anthropic_language_model_base_url_defaults_to_none():
+    """Test that base_url defaults to None on Anthropic when not provided."""
+    config = SessionConfig(
+        app_name="test_anthropic_base_url_default",
+        semantic=SemanticConfig(
+            language_models={
+                "claude": AnthropicLanguageModel(
+                    model_name="claude-sonnet-4-20250514",
+                    rpm=100,
+                    input_tpm=100,
+                    output_tpm=100,
+                )
+            }
+        ),
+    )
+    resolved = config._to_resolved_config()
+    model_config = resolved.semantic.language_models.model_configs["claude"]
+    assert model_config.base_url is None
+
+
+def test_base_url_preserved_in_multi_model_config():
+    """Test that base_url is preserved per-model when mixing models with and without custom URLs."""
+    config = SessionConfig(
+        app_name="test_multi_model_base_url",
+        semantic=SemanticConfig(
+            language_models={
+                "gpt-proxy": OpenAILanguageModel(
+                    model_name="gpt-4o-mini",
+                    rpm=100,
+                    tpm=100,
+                    base_url="https://proxy.example.com/v1",
+                ),
+                "gpt-direct": OpenAILanguageModel(
+                    model_name="gpt-4.1-nano",
+                    rpm=100,
+                    tpm=100,
+                ),
+            },
+            default_language_model="gpt-proxy",
+        ),
+    )
+    resolved = config._to_resolved_config()
+    proxy_config = resolved.semantic.language_models.model_configs["gpt-proxy"]
+    direct_config = resolved.semantic.language_models.model_configs["gpt-direct"]
+    assert proxy_config.base_url == "https://proxy.example.com/v1"
+    assert direct_config.base_url is None


### PR DESCRIPTION
Allow users to point OpenAI and Anthropic models at custom endpoints
(proxies, gateways) via an optional base_url field on model configs.

- Thread base_url through config resolution, providers, and clients
- Include base_url in cache key fingerprint to prevent cross-endpoint
  cache poisoning
- Skip API key validation for providers with custom base URLs since
  proxies may not expose the /models endpoint