### PR TITLE
feat: support Anthropic effort profiles

### DIFF
--- a/docs/topics/openrouter.md
+++ b/docs/topics/openrouter.md
@@ -58,9 +58,8 @@ config = SessionConfig(
 OpenRouter profiles support the following configuration options:
 
 - **`models`**: List of fallback models to use if the primary model is unavailable
-- **`reasoning_effort`**: For reasoning-capable models, set to `"low"`, `"medium"`, or `"high"` for OpenAI models.
+- **`reasoning_effort`**: For reasoning-capable models, set to `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"`.
 - **`reasoning_max_tokens`**: Token budget for reasoning for Gemini/Anthropic models
-- \*\*`
 - **`provider`**: Provider routing preferences with these options:
   - `sort`: Route by `"price"`, `"throughput"`, or `"latency"`
   - `only`: List of providers to exclusively use (e.g., `["OpenAI", "Anthropic"]`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.52.2"]
+anthropic = ["anthropic>=0.106.0"]
 google = ["google-genai[local-tokenizer]>=1.56.0"]
 cohere = ["cohere>=5.16.1"]
 cloud = [

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -59,6 +59,7 @@ from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core._resolved_session_config import (
     ResolvedAnthropicModelProfile,
 )
+from fenic.core.error import ValidationError
 from fenic.core.metrics import LMMetrics
 
 
@@ -150,11 +151,16 @@ class AnthropicBatchCompletionsClient(
         profile_configuration = self._profile_manager.get_profile_by_name(
             request.model_profile
         )
+        try:
+            request_max_tokens = self._get_max_output_token_request_limit(request)
+        except ValidationError as e:
+            # Deterministic request-construction failure: retrying cannot help.
+            return FatalException(e)
         messages_creation_payload: dict[str, Any] = {
             "model": self.model,
             "system": [system_prompt],
             "messages": message_params,
-            "max_tokens": self._get_max_output_token_request_limit(request),
+            "max_tokens": request_max_tokens,
             "thinking": profile_configuration.thinking_config,
         }
         if profile_configuration.output_config:
@@ -346,14 +352,16 @@ class AnthropicBatchCompletionsClient(
         Returns:
             Maximum output tokens (completion + thinking budget)
         """
+        profile_configuration = self._profile_manager.get_profile_by_name(
+            request.model_profile
+        )
         return validate_effective_output_token_limit(
             model_provider=self.model_provider,
             model_name=self.model,
             model_max_output_tokens=self._model_parameters.max_output_tokens,
             requested_completion_tokens=request.max_completion_tokens,
-            estimated_reasoning_tokens=self._profile_manager.get_profile_by_name(
-                request.model_profile
-            ).thinking_token_budget,
+            estimated_reasoning_tokens=profile_configuration.thinking_token_budget,
+            reasoning_shares_output_window=profile_configuration.uses_adaptive_thinking,
         )
 
     # Override default behavior to account for the fact that Anthropic's encoding is slightly different from OpenAI's.

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -155,6 +155,10 @@ class AnthropicBatchCompletionsClient(
             "max_tokens": request_max_tokens,
             "thinking": profile_configuration.thinking_config,
         }
+        if profile_configuration.output_config:
+            messages_creation_payload["output_config"] = (
+                profile_configuration.output_config
+            )
         if request.structured_output:
             tool_param = self.create_response_format_tool(request.structured_output)
             messages_creation_payload.update({"tools": [tool_param]})

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -145,14 +145,11 @@ class AnthropicBatchCompletionsClient(
         profile_configuration = self._profile_manager.get_profile_by_name(
             request.model_profile
         )
-        request_max_tokens = (
-            request.max_completion_tokens + profile_configuration.thinking_token_budget
-        )
         messages_creation_payload: dict[str, Any] = {
             "model": self.model,
             "system": [system_prompt],
             "messages": message_params,
-            "max_tokens": request_max_tokens,
+            "max_tokens": self._get_max_output_token_request_limit(request),
             "thinking": profile_configuration.thinking_config,
         }
         if profile_configuration.output_config:
@@ -344,12 +341,13 @@ class AnthropicBatchCompletionsClient(
         Returns:
             Maximum output tokens (completion + thinking budget)
         """
-        return (
+        requested_max_tokens = (
             request.max_completion_tokens
             + self._profile_manager.get_profile_by_name(
                 request.model_profile
             ).thinking_token_budget
         )
+        return min(requested_max_tokens, self._model_parameters.max_output_tokens)
 
     # Override default behavior to account for the fact that Anthropic's encoding is slightly different from OpenAI's.
     # This is a rough estimate, but it's good enough for our purposes.

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -50,6 +50,9 @@ from fenic.core._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
+from fenic.core._inference.output_token_limits import (
+    validate_effective_output_token_limit,
+)
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core._resolved_session_config import (
     ResolvedAnthropicModelProfile,
@@ -341,13 +344,15 @@ class AnthropicBatchCompletionsClient(
         Returns:
             Maximum output tokens (completion + thinking budget)
         """
-        requested_max_tokens = (
-            request.max_completion_tokens
-            + self._profile_manager.get_profile_by_name(
+        return validate_effective_output_token_limit(
+            model_provider=self.model_provider,
+            model_name=self.model,
+            model_max_output_tokens=self._model_parameters.max_output_tokens,
+            requested_completion_tokens=request.max_completion_tokens,
+            estimated_reasoning_tokens=self._profile_manager.get_profile_by_name(
                 request.model_profile
-            ).thinking_token_budget
+            ).thinking_token_budget,
         )
-        return min(requested_max_tokens, self._model_parameters.max_output_tokens)
 
     # Override default behavior to account for the fact that Anthropic's encoding is slightly different from OpenAI's.
     # This is a rough estimate, but it's good enough for our purposes.

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -20,6 +20,7 @@ from anthropic.types import (
 
 from fenic._inference.anthropic.anthropic_profile_manager import (
     AnthropicCompletionsProfileManager,
+    AnthropicProfileConfiguration,
 )
 from fenic._inference.anthropic.anthropic_provider import AnthropicModelProvider
 from fenic._inference.anthropic.anthropic_utils import (
@@ -407,7 +408,7 @@ class AnthropicBatchCompletionsClient(
         )
 
     def _estimate_thinking_tokens_for_rate_limit(
-        self, profile_config, completion_tokens: int
+        self, profile_config: AnthropicProfileConfiguration, completion_tokens: int
     ) -> int:
         """Estimate thinking tokens for throttling without using adaptive maxima."""
         if not profile_config.thinking_enabled:

--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -51,6 +51,7 @@ from fenic.core._inference.model_catalog import (
     model_catalog,
 )
 from fenic.core._inference.output_token_limits import (
+    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
     validate_effective_output_token_limit,
 )
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
@@ -386,10 +387,40 @@ class AnthropicBatchCompletionsClient(
         input_tokens = self.count_tokens(request.messages)
         input_tokens += self._count_auxiliary_input_tokens(request)
 
-        # Estimate output tokens
-        output_tokens = self._get_max_output_token_request_limit(request)
+        # Estimate output tokens for rate limiting. This is intentionally
+        # separate from the provider-side max_tokens budget: adaptive thinking
+        # can have a very large maximum window, but reserving that maximum for
+        # throttling would make small-output requests impossible under normal
+        # output TPM limits.
+        output_tokens = self._estimate_output_tokens(request)
 
         return TokenEstimate(input_tokens=input_tokens, output_tokens=output_tokens)
+
+    def _estimate_output_tokens(self, request: FenicCompletionsRequest) -> int:
+        """Estimate output tokens for rate limiting."""
+        completion_tokens = request.max_completion_tokens or 0
+        profile_config = self._profile_manager.get_profile_by_name(
+            request.model_profile
+        )
+        return completion_tokens + self._estimate_thinking_tokens_for_rate_limit(
+            profile_config, completion_tokens
+        )
+
+    def _estimate_thinking_tokens_for_rate_limit(
+        self, profile_config, completion_tokens: int
+    ) -> int:
+        """Estimate thinking tokens for throttling without using adaptive maxima."""
+        if not profile_config.thinking_enabled:
+            return 0
+        if profile_config.uses_adaptive_thinking and profile_config.effort:
+            return min(
+                profile_config.thinking_token_budget,
+                math.ceil(
+                    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS[profile_config.effort]
+                    * completion_tokens
+                ),
+            )
+        return profile_config.thinking_token_budget
 
     def get_metrics(self) -> LMMetrics:
         """Get current metrics.

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -19,11 +19,14 @@ class AnthropicProfileConfiguration(BaseProfileConfiguration):
     Attributes:
         thinking_enabled: Whether thinking/reasoning is enabled for this profile
         thinking_token_budget: Token budget allocated for thinking/reasoning
+        uses_adaptive_thinking: Whether thinking_token_budget is an adaptive maximum rather than a fixed budget
         thinking_config: Anthropic-specific thinking configuration
         output_config: Anthropic output configuration for effort.
     """
     thinking_enabled: bool = False
     thinking_token_budget: int = 0
+    uses_adaptive_thinking: bool = False
+    effort: Optional[str] = None
     thinking_config: anthropic.types.ThinkingConfigParam = field(
         default_factory=lambda: anthropic.types.ThinkingConfigDisabledParam(type="disabled"))
     output_config: Optional[anthropic.types.OutputConfigParam] = None
@@ -72,6 +75,7 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                     type="enabled",
                     budget_tokens=profile.thinking_token_budget
                 ),
+                effort=profile.effort,
                 output_config={"effort": profile.effort} if profile.effort else None,
             )
         elif profile.effort and self.model_parameters.uses_adaptive_thinking:
@@ -84,10 +88,13 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                 thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
                     type="adaptive"
                 ),
+                uses_adaptive_thinking=True,
+                effort=profile.effort,
                 output_config={"effort": profile.effort},
             )
         elif profile.effort:
             return AnthropicProfileConfiguration(
+                effort=profile.effort,
                 output_config={"effort": profile.effort},
             )
         else:

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -6,15 +6,10 @@ import anthropic
 
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
 from fenic.core._inference.model_catalog import CompletionModelParameters
+from fenic.core._inference.output_token_limits import (
+    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
+)
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
-
-ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS = {
-    "low": 0.20,
-    "medium": 0.50,
-    "high": 0.80,
-    "xhigh": 0.95,
-    "max": 1.00,
-}
 
 
 @dataclass

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -5,7 +5,10 @@ from typing import Optional
 import anthropic
 
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
-from fenic.core._inference.model_catalog import CompletionModelParameters
+from fenic.core._inference.model_catalog import (
+    AnthropicReasoningEffortType,
+    CompletionModelParameters,
+)
 from fenic.core._inference.output_token_limits import (
     ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
 )
@@ -26,7 +29,7 @@ class AnthropicProfileConfiguration(BaseProfileConfiguration):
     thinking_enabled: bool = False
     thinking_token_budget: int = 0
     uses_adaptive_thinking: bool = False
-    effort: Optional[str] = None
+    effort: Optional[AnthropicReasoningEffortType] = None
     thinking_config: anthropic.types.ThinkingConfigParam = field(
         default_factory=lambda: anthropic.types.ThinkingConfigDisabledParam(type="disabled"))
     output_config: Optional[anthropic.types.OutputConfigParam] = None

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -6,6 +7,14 @@ import anthropic
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
 from fenic.core._inference.model_catalog import CompletionModelParameters
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
+
+ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS = {
+    "low": 0.20,
+    "medium": 0.50,
+    "high": 0.80,
+    "xhigh": 0.95,
+    "max": 1.00,
+}
 
 
 @dataclass
@@ -73,6 +82,10 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
         elif profile.effort and self.model_parameters.uses_adaptive_thinking:
             return AnthropicProfileConfiguration(
                 thinking_enabled=True,
+                thinking_token_budget=math.ceil(
+                    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS[profile.effort]
+                    * self.model_parameters.max_output_tokens
+                ),
                 thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
                     type="adaptive"
                 ),

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -16,11 +16,13 @@ class AnthropicProfileConfiguration(BaseProfileConfiguration):
         thinking_enabled: Whether thinking/reasoning is enabled for this profile
         thinking_token_budget: Token budget allocated for thinking/reasoning
         thinking_config: Anthropic-specific thinking configuration
+        output_config: Anthropic output configuration for effort.
     """
     thinking_enabled: bool = False
     thinking_token_budget: int = 0
     thinking_config: anthropic.types.ThinkingConfigParam = field(
         default_factory=lambda: anthropic.types.ThinkingConfigDisabledParam(type="disabled"))
+    output_config: Optional[anthropic.types.OutputConfigParam] = None
 
 
 class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelProfile, AnthropicProfileConfiguration]):
@@ -65,7 +67,20 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                 thinking_config=anthropic.types.ThinkingConfigEnabledParam(
                     type="enabled",
                     budget_tokens=profile.thinking_token_budget
-                )
+                ),
+                output_config={"effort": profile.effort} if profile.effort else None,
+            )
+        elif profile.effort and self.model_parameters.uses_adaptive_thinking:
+            return AnthropicProfileConfiguration(
+                thinking_enabled=True,
+                thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
+                    type="adaptive"
+                ),
+                output_config={"effort": profile.effort},
+            )
+        elif profile.effort:
+            return AnthropicProfileConfiguration(
+                output_config={"effort": profile.effort},
             )
         else:
             return AnthropicProfileConfiguration()

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -33,6 +33,9 @@ from fenic.core._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
+from fenic.core._inference.output_token_limits import (
+    validate_effective_output_token_limit,
+)
 from fenic.core.metrics import LMMetrics
 
 logger = logging.getLogger(__name__)
@@ -230,7 +233,11 @@ class OpenAIChatCompletionsCore:
         """
         return generate_completion_request_key(request)
 
-    def get_max_output_token_request_limit(self, request: FenicCompletionsRequest, profile_config:OpenAICompletionProfileConfiguration) -> Optional[int]:
+    def get_max_output_token_request_limit(
+        self,
+        request: FenicCompletionsRequest,
+        profile_config: OpenAICompletionProfileConfiguration,
+    ) -> Optional[int]:
         """Return the maximum output token limit for a request.
 
         Returns None if max_completion_tokens is not provided (no limit should be set).
@@ -238,4 +245,10 @@ class OpenAIChatCompletionsCore:
         """
         if request.max_completion_tokens is None:
             return None
-        return request.max_completion_tokens + profile_config.expected_additional_reasoning_tokens
+        return validate_effective_output_token_limit(
+            model_provider=self.model_provider,
+            model_name=self.model,
+            model_max_output_tokens=self._model_parameters.max_output_tokens,
+            requested_completion_tokens=request.max_completion_tokens,
+            estimated_reasoning_tokens=profile_config.expected_additional_reasoning_tokens,
+        )

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -36,6 +36,7 @@ from fenic.core._inference.model_catalog import (
 from fenic.core._inference.output_token_limits import (
     validate_effective_output_token_limit,
 )
+from fenic.core.error import ValidationError
 from fenic.core.metrics import LMMetrics
 
 logger = logging.getLogger(__name__)
@@ -220,6 +221,10 @@ class OpenAIChatCompletionsCore:
                 return FatalException(e)
 
         except OpenAIError as e:
+            return FatalException(e)
+
+        except ValidationError as e:
+            # Deterministic request-construction failure: retrying cannot help.
             return FatalException(e)
 
     def get_request_key(self, request: FenicCompletionsRequest) -> str:

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -246,9 +246,13 @@ class OpenAIChatCompletionsCore:
         if request.max_completion_tokens is None:
             return None
         return validate_effective_output_token_limit(
-            model_provider=self.model_provider,
-            model_name=self.model,
+            model_provider=self._model_provider,
+            model_name=self._model,
             model_max_output_tokens=self._model_parameters.max_output_tokens,
             requested_completion_tokens=request.max_completion_tokens,
-            estimated_reasoning_tokens=profile_config.expected_additional_reasoning_tokens,
+            estimated_reasoning_tokens=(
+                profile_config.expected_additional_reasoning_tokens
+                if profile_config
+                else 0
+            ),
         )

--- a/src/fenic/_inference/common_openai/openai_profile_manager.py
+++ b/src/fenic/_inference/common_openai/openai_profile_manager.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
 from fenic.core._inference.model_catalog import CompletionModelParameters
+from fenic.core._inference.output_token_limits import OPENAI_REASONING_TOKEN_ESTIMATES
 from fenic.core._resolved_session_config import ResolvedOpenAIModelProfile
 
 
@@ -57,19 +58,7 @@ class OpenAICompletionsProfileManager(
 
     def _get_reasoning_tokens(self, reasoning_effort: str) -> int:
         """Get the expected additional reasoning tokens for a given reasoning effort level."""
-        if reasoning_effort == "none":
-            return 0
-        elif reasoning_effort == "minimal":
-            return 2048
-        elif reasoning_effort == "low":
-            return 4096
-        elif reasoning_effort == "medium":
-            return 8192
-        elif reasoning_effort == "high":
-            return 16384
-        elif reasoning_effort == "xhigh":
-            return 32768
-        return 0
+        return OPENAI_REASONING_TOKEN_ESTIMATES[reasoning_effort]
 
     def get_default_profile(self) -> OpenAICompletionProfileConfiguration:
         """Get default OpenAI configuration."""

--- a/src/fenic/_inference/google/gemini_native_chat_completions_client.py
+++ b/src/fenic/_inference/google/gemini_native_chat_completions_client.py
@@ -47,11 +47,12 @@ from fenic.core._inference.model_catalog import (
     model_catalog,
 )
 from fenic.core._inference.output_token_limits import (
+    GOOGLE_REASONING_SAFETY_MARGIN,
     validate_effective_output_token_limit,
 )
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
-from fenic.core.error import ExecutionError
+from fenic.core.error import ExecutionError, ValidationError
 from fenic.core.metrics import LMMetrics
 
 logger = logging.getLogger(__name__)
@@ -197,7 +198,11 @@ class GeminiNativeChatCompletionsClient(
             "system_instruction": request.messages.system,
         }
 
-        max_output_tokens = self._get_max_output_token_request_limit(request)
+        try:
+            max_output_tokens = self._get_max_output_token_request_limit(request)
+        except ValidationError as e:
+            # Deterministic request-construction failure: retrying cannot help.
+            return FatalException(e)
         if max_output_tokens is not None:
             generation_config["max_output_tokens"] = max_output_tokens
 
@@ -398,7 +403,7 @@ class GeminiNativeChatCompletionsClient(
         profile_config = self._profile_manager.get_profile_by_name(
             request.model_profile
         )
-        return int(1.5 * profile_config.thinking_token_budget)
+        return int(GOOGLE_REASONING_SAFETY_MARGIN * profile_config.thinking_token_budget)
 
     def _resolve_profile_for_hash(self, profile_name: Optional[str]) -> GoogleCompletionsProfileConfig:
         return self._profile_manager.get_profile_by_name(profile_name)

--- a/src/fenic/_inference/google/gemini_native_chat_completions_client.py
+++ b/src/fenic/_inference/google/gemini_native_chat_completions_client.py
@@ -46,6 +46,9 @@ from fenic.core._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
+from fenic.core._inference.output_token_limits import (
+    validate_effective_output_token_limit,
+)
 from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
 from fenic.core.error import ExecutionError
@@ -380,9 +383,12 @@ class GeminiNativeChatCompletionsClient(
         If max_completion_tokens is provided, includes the thinking token budget with a safety margin."""
         if request.max_completion_tokens is None:
             return None
-        return (
-            request.max_completion_tokens
-            + self._get_expected_additional_reasoning_tokens(request)
+        return validate_effective_output_token_limit(
+            model_provider=self.model_provider,
+            model_name=self.model,
+            model_max_output_tokens=self._model_parameters.max_output_tokens,
+            requested_completion_tokens=request.max_completion_tokens,
+            estimated_reasoning_tokens=self._get_expected_additional_reasoning_tokens(request),
         )
 
     def _get_expected_additional_reasoning_tokens(

--- a/src/fenic/_inference/google/google_profile_manager.py
+++ b/src/fenic/_inference/google/google_profile_manager.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Final, Optional
+from typing import Optional
 
 from google.genai.types import (
     EmbedContentConfigDict,
@@ -18,11 +18,6 @@ from fenic.core._inference.output_token_limits import (
     GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES,
 )
 from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
-
-# Estimated thinking token budgets for each level (used for cost estimation).
-# These are approximations based on typical model behavior - actual token usage
-# varies based on prompt complexity and model decisions.
-THINKING_TOKEN_ESTIMATES: Final[Dict[str, int]] = GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES
 
 
 @dataclass
@@ -133,7 +128,7 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
                     "minimal": ThinkingLevel.MINIMAL,
                 }
                 thinking_level_enum = thinking_level_map[thinking_level]
-                expected_thinking_tokens = THINKING_TOKEN_ESTIMATES[thinking_level]
+                expected_thinking_tokens = GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES[thinking_level]
                 thinking_config: ThinkingConfigDict = {
                     "thinking_level": thinking_level_enum
                 }

--- a/src/fenic/_inference/google/google_profile_manager.py
+++ b/src/fenic/_inference/google/google_profile_manager.py
@@ -14,17 +14,15 @@ from fenic.core._inference.model_catalog import (
     EmbeddingModelParameters,
     MediaResolutionType,
 )
+from fenic.core._inference.output_token_limits import (
+    GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES,
+)
 from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
 
 # Estimated thinking token budgets for each level (used for cost estimation).
 # These are approximations based on typical model behavior - actual token usage
 # varies based on prompt complexity and model decisions.
-THINKING_TOKEN_ESTIMATES: Final[Dict[str, int]] = {
-    "high": 32768,     # Maximum thinking, most thorough reasoning
-    "medium": 16384,   # Balanced thinking
-    "low": 8192,       # Reduced thinking, faster responses
-    "minimal": 2048,   # Minimal thinking, quickest responses
-}
+THINKING_TOKEN_ESTIMATES: Final[Dict[str, int]] = GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES
 
 
 @dataclass

--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -39,7 +39,7 @@ from fenic.core._inference.output_token_limits import (
     OPENROUTER_REASONING_EFFORT_RATIOS,
     validate_effective_output_token_limit,
 )
-from fenic.core.error import ConfigurationError
+from fenic.core.error import ConfigurationError, ValidationError
 from fenic.core.metrics import LMMetrics
 
 TOOLS = "tools"
@@ -118,7 +118,11 @@ class OpenRouterBatchChatCompletionsClient(
                 "n": 1,
             }
 
-        max_completion_tokens = self._get_max_output_token_request_limit(request)
+        try:
+            max_completion_tokens = self._get_max_output_token_request_limit(request)
+        except ValidationError as e:
+            # Deterministic request-construction failure: retrying cannot help.
+            return FatalException(e)
         if max_completion_tokens is not None:
             common_params["max_completion_tokens"] = max_completion_tokens
 

--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -35,6 +35,10 @@ from fenic._inference.types import (
     ResponseUsage,
 )
 from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.output_token_limits import (
+    OPENROUTER_REASONING_EFFORT_RATIOS,
+    validate_effective_output_token_limit,
+)
 from fenic.core.error import ConfigurationError
 from fenic.core.metrics import LMMetrics
 
@@ -279,7 +283,13 @@ class OpenRouterBatchChatCompletionsClient(
         If max_completion_tokens is provided, includes the thinking token budget with a safety margin."""
         if request.max_completion_tokens is None:
             return None
-        return request.max_completion_tokens + self._get_expected_additional_reasoning_tokens(request)
+        return validate_effective_output_token_limit(
+            model_provider=self.model_provider,
+            model_name=self.model,
+            model_max_output_tokens=self._model_parameters.max_output_tokens,
+            requested_completion_tokens=request.max_completion_tokens,
+            estimated_reasoning_tokens=self._get_expected_additional_reasoning_tokens(request),
+        )
 
     def _estimate_input_tokens(self, request: FenicCompletionsRequest) -> int:
         """Estimate the number of input tokens for a request."""
@@ -304,18 +314,11 @@ class OpenRouterBatchChatCompletionsClient(
         additional_reasoning_tokens = 0
         if profile_config.reasoning_max_tokens:
             additional_reasoning_tokens = profile_config.reasoning_max_tokens
-        elif profile_config.reasoning_effort == "none":
-            additional_reasoning_tokens = 0
-        elif profile_config.reasoning_effort == "minimal":
-            additional_reasoning_tokens = math.ceil(0.10 * self._model_parameters.max_output_tokens)
-        elif profile_config.reasoning_effort == "low":
-            additional_reasoning_tokens = math.ceil(0.20 * self._model_parameters.max_output_tokens)
-        elif profile_config.reasoning_effort == "medium":
-            additional_reasoning_tokens = math.ceil(0.50 * self._model_parameters.max_output_tokens)
-        elif profile_config.reasoning_effort == "high":
-            additional_reasoning_tokens = math.ceil(0.80 * self._model_parameters.max_output_tokens)
-        elif profile_config.reasoning_effort == "xhigh":
-            additional_reasoning_tokens = math.ceil(0.95 * self._model_parameters.max_output_tokens)
+        elif profile_config.reasoning_effort:
+            additional_reasoning_tokens = math.ceil(
+                OPENROUTER_REASONING_EFFORT_RATIOS[profile_config.reasoning_effort]
+                * self._model_parameters.max_output_tokens
+            )
         return additional_reasoning_tokens
 
     def _resolve_profile_for_hash(self, profile_name: Optional[str]) -> OpenRouterCompletionProfileConfiguration:

--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -297,21 +297,25 @@ class OpenRouterBatchChatCompletionsClient(
         # We can estimate by extracting the text and tokenizing it (which is what count_file_output_tokens does)
         return self.token_counter.count_file_output_tokens(messages=request.messages)
 
-    # This is a slightly less conservative estimate than the OpenRouter documentation on how reasoning_effort is used to
-    # generate a reasoning.max_tokens for models that only support reasoning.max_tokens.
-    # These percentages are slightly lower, since our use-cases generally require fewer reasoning tokens.
-    # https://openrouter.ai/docs/use-cases/reasoning-tokens#reasoning-effort-level
+    # OpenRouter documents these effort ratios for models that only support reasoning.max_tokens.
+    # https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#reasoning-effort-level
     def _get_expected_additional_reasoning_tokens(self, request: FenicCompletionsRequest) -> int:
         profile_config = self._profile_manager.get_profile_by_name(request.model_profile)
         additional_reasoning_tokens = 0
         if profile_config.reasoning_max_tokens:
             additional_reasoning_tokens = profile_config.reasoning_max_tokens
+        elif profile_config.reasoning_effort == "none":
+            additional_reasoning_tokens = 0
+        elif profile_config.reasoning_effort == "minimal":
+            additional_reasoning_tokens = math.ceil(0.10 * self._model_parameters.max_output_tokens)
         elif profile_config.reasoning_effort == "low":
-            additional_reasoning_tokens = math.ceil(0.15 * self._model_parameters.max_output_tokens)
+            additional_reasoning_tokens = math.ceil(0.20 * self._model_parameters.max_output_tokens)
         elif profile_config.reasoning_effort == "medium":
-            additional_reasoning_tokens = math.ceil(0.30 * self._model_parameters.max_output_tokens)
+            additional_reasoning_tokens = math.ceil(0.50 * self._model_parameters.max_output_tokens)
         elif profile_config.reasoning_effort == "high":
-            additional_reasoning_tokens = math.ceil(0.60 * self._model_parameters.max_output_tokens)
+            additional_reasoning_tokens = math.ceil(0.80 * self._model_parameters.max_output_tokens)
+        elif profile_config.reasoning_effort == "xhigh":
+            additional_reasoning_tokens = math.ceil(0.95 * self._model_parameters.max_output_tokens)
         return additional_reasoning_tokens
 
     def _resolve_profile_for_hash(self, profile_name: Optional[str]) -> OpenRouterCompletionProfileConfiguration:

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -1764,6 +1764,8 @@ def _validate_language_profile(
         if not completion_model_params.supports_verbosity and profile.verbosity is not None:
             raise ConfigurationError(f"Model '{model_alias}' does not support verbosity. Please remove verbosity from '{profile_alias}'.")
     elif isinstance(language_model, AnthropicLanguageModel):
+        if profile.thinking_token_budget and completion_model_params.uses_adaptive_thinking:
+            raise ConfigurationError(f"Model '{model_alias}' uses adaptive thinking and does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from '{profile_alias}' and set effort instead.")
         if profile.thinking_token_budget and not completion_model_params.supports_reasoning:
             raise ConfigurationError(f"Model '{model_alias}' does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from '{profile_alias}'.")
         if profile.effort is not None:

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from fenic.core._inference.model_catalog import (
     AnthropicLanguageModelName,
+    AnthropicReasoningEffortType,
     CohereEmbeddingModelName,
     CompletionModelParameters,
     EmbeddingModelParameters,
@@ -26,6 +27,7 @@ from fenic.core._inference.model_catalog import (
     model_catalog,
 )
 from fenic.core._resolved_session_config import (
+    OpenRouterReasoningEffort,
     ReasoningEffort,
     ResolvedAnthropicModelConfig,
     ResolvedAnthropicModelProfile,
@@ -701,17 +703,20 @@ class AnthropicLanguageModel(BaseModel):
         """Anthropic-specific profile configurations.
 
         This class defines profile configurations for Anthropic models, allowing
-        different thinking token budget settings to be applied to the same model.
+        different thinking and effort settings to be applied to the same model.
 
         Attributes:
             thinking_token_budget: Provide a default thinking budget in tokens. If not provided,
                 thinking will be disabled for the profile. The minimum token budget supported by Anthropic is 1024 tokens.
+                For Claude models that use adaptive thinking, use `effort` instead.
+            effort: Provider-native Anthropic effort level. Supported values vary by model:
+                low, medium, high, xhigh, and max.
 
         Raises:
             ConfigurationError: If a profile is set with parameters that are not supported by the model.
 
         Note:
-            If `thinking_token_budget` is set, `temperature` cannot be customized -- any changes to `temperature` will be ignored.
+            If `thinking_token_budget` or `effort` enables thinking, `temperature` cannot be customized -- any changes to `temperature` will be ignored.
 
         Example:
             Configuring a profile with a thinking budget:
@@ -725,6 +730,12 @@ class AnthropicLanguageModel(BaseModel):
             ```python
             profile = AnthropicLanguageModel.Profile(thinking_token_budget=8192)
             ```
+
+            Configuring a profile with effort:
+
+            ```python
+            profile = AnthropicLanguageModel.Profile(effort="xhigh")
+            ```
         """
 
         model_config = ConfigDict(extra="forbid")
@@ -733,6 +744,10 @@ class AnthropicLanguageModel(BaseModel):
             default=None,
             description="The thinking budget in tokens for the profile",
             ge=1024,
+        )
+        effort: Optional[AnthropicReasoningEffortType] = Field(
+            default=None,
+            description="The Anthropic effort level for the profile",
         )
 
 ParsingEngine = Literal["mistral-ocr", "cloudflare-ai", "pdf-text", "native"]
@@ -879,7 +894,7 @@ class OpenRouterLanguageModel(BaseModel):
                 ([OpenRouter Documentation](https://openrouter.ai/docs/features/model-routing#the-models-parameter)).
             provider: Provider routing preferences (include/exclude specific providers, set provider ranking method preference)
                 ([OpenRouter Documentation](https://openrouter.ai/docs/features/provider-routing)).
-            reasoning_effort: OpenAI Style reasoning effort configuration (low, medium, high).
+            reasoning_effort: OpenRouter reasoning effort configuration (none, minimal, low, medium, high, xhigh).
                 If the model does support reasoning, but not `reasoning_effort`, a `reasoning_max_tokens` will be calculated
                 that is roughly equivalent as a percentage of the model's maximum output size
                 ([OpenRouter Documentation](https://openrouter.ai/docs/use-cases/reasoning-tokens#reasoning-effort-level))
@@ -893,7 +908,7 @@ class OpenRouterLanguageModel(BaseModel):
 
         model_config = ConfigDict(extra="forbid")
 
-        reasoning_effort: Optional[Literal["high", "medium", "low"]] = Field(
+        reasoning_effort: Optional[OpenRouterReasoningEffort] = Field(
             default=None, description="OpenAI-style reasoning effort"
         )
         reasoning_max_tokens: Optional[int] = Field(
@@ -1102,12 +1117,8 @@ class SemanticConfig(BaseModel):
                     input_tpm=100,
                     output_tpm=100,
                     profiles={
-                        "fast": AnthropicLanguageModel.Profile(
-                            thinking_token_budget=1024
-                        ),
-                        "thorough": AnthropicLanguageModel.Profile(
-                            thinking_token_budget=4096
-                        ),
+                        "fast": AnthropicLanguageModel.Profile(effort="low"),
+                        "thorough": AnthropicLanguageModel.Profile(effort="high"),
                     },
                     default_profile="fast",
                 ),
@@ -1612,7 +1623,10 @@ class SessionConfig(BaseModel):
                 )
             elif isinstance(model, AnthropicLanguageModel):
                 profiles = {
-                    profile_name: ResolvedAnthropicModelProfile(thinking_token_budget=profile.thinking_token_budget) for
+                    profile_name: ResolvedAnthropicModelProfile(
+                        thinking_token_budget=profile.thinking_token_budget,
+                        effort=profile.effort,
+                    ) for
                     profile_name, profile in model.profiles.items()
                 } if model.profiles else None
                 return ResolvedAnthropicModelConfig(
@@ -1752,6 +1766,16 @@ def _validate_language_profile(
     elif isinstance(language_model, AnthropicLanguageModel):
         if profile.thinking_token_budget and not completion_model_params.supports_reasoning:
             raise ConfigurationError(f"Model '{model_alias}' does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from '{profile_alias}'.")
+        if profile.effort is not None:
+            if not completion_model_params.supported_reasoning_efforts:
+                raise ConfigurationError(
+                    f"Model '{model_alias}' does not support effort profiles. Please remove effort from '{profile_alias}'."
+                )
+            if profile.effort not in completion_model_params.supported_reasoning_efforts:
+                supported_efforts = "', '".join(sorted(completion_model_params.supported_reasoning_efforts))
+                raise ConfigurationError(
+                    f"Model '{model_alias}' does not support effort='{profile.effort}'. Please set effort on '{profile_alias}' to one of '{supported_efforts}' instead."
+                )
     elif isinstance(language_model, GoogleDeveloperLanguageModel) or isinstance(language_model, GoogleVertexLanguageModel):
         if completion_model_params.supported_thinking_levels:
             # For gemini-3+ models, thinking_level must be used instead of thinking_token_budget

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -711,6 +711,9 @@ class AnthropicLanguageModel(BaseModel):
                 For Claude models that use adaptive thinking, use `effort` instead.
             effort: Provider-native Anthropic effort level. Supported values vary by model:
                 low, medium, high, xhigh, and max.
+                On adaptive-thinking models the thinking budget shares the request's
+                output token window rather than being reserved on top of it, so very
+                high effort levels can consume part of the visible completion budget.
 
         Raises:
             ConfigurationError: If a profile is set with parameters that are not supported by the model.

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -716,7 +716,11 @@ class AnthropicLanguageModel(BaseModel):
             ConfigurationError: If a profile is set with parameters that are not supported by the model.
 
         Note:
-            If `thinking_token_budget` or `effort` enables thinking, `temperature` cannot be customized -- any changes to `temperature` will be ignored.
+            If `thinking_token_budget` or adaptive `effort` enables thinking,
+            `temperature` cannot be customized -- any changes to `temperature`
+            will be ignored. Effort-only profiles on non-adaptive models
+            configure Anthropic `output_config` without enabling thinking, so
+            custom `temperature` remains available when the model supports it.
 
         Example:
             Configuring a profile with a thinking budget:

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -90,7 +90,7 @@ class CompletionModelParameters:
         default_reasoning_effort: Optional[str] = None,
         supported_reasoning_efforts: Optional[Set[str]] = None,
         supported_thinking_levels: Optional[Set[ThinkingLevelType]] = None,
-        uses_adaptive_thinking=False,
+        uses_adaptive_thinking: bool = False,
         supports_custom_temperature=True,
         supports_verbosity = False,
         supports_pdf_parsing = False,

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -10,10 +10,14 @@ logger = logging.getLogger(__name__)
 # Type for supported thinking levels (Gemini 3+ models)
 ThinkingLevelType = Literal["high", "medium", "low", "minimal"]
 MediaResolutionType = Literal["low", "medium", "high", "ultra_high"]
+AnthropicReasoningEffortType = Literal["low", "medium", "high", "xhigh", "max"]
 
 # Thinking level sets for Gemini 3.x models
 GEMINI_3X_PRO_THINKING_LEVELS: Final[Set[ThinkingLevelType]] = {"high", "medium", "low"}
 GEMINI_3X_FLASH_THINKING_LEVELS: Final[Set[ThinkingLevelType]] = {"high", "medium", "low", "minimal"}
+ANTHROPIC_OPUS_4_7_PLUS_EFFORTS: Final[Set[AnthropicReasoningEffortType]] = {"low", "medium", "high", "xhigh", "max"}
+ANTHROPIC_4_6_EFFORTS: Final[Set[AnthropicReasoningEffortType]] = {"low", "medium", "high", "max"}
+ANTHROPIC_OPUS_4_5_EFFORTS: Final[Set[AnthropicReasoningEffortType]] = {"low", "medium", "high"}
 
 
 class ModelProvider(Enum):
@@ -58,8 +62,10 @@ class CompletionModelParameters:
         supports_disabled_reasoning: Whether the model supports disabling reasoning.
         supports_xhigh_reasoning: Whether the model supports xhigh reasoning effort.
         default_reasoning_effort: Default reasoning effort when a profile does not specify one.
+        supported_reasoning_efforts: Set of provider-native reasoning efforts supported by the model.
         supported_thinking_levels: Set of thinking levels supported by the model (Gemini 3+).
             None means the model uses thinking_budget instead. Valid values: "high", "medium", "low", "minimal".
+        uses_adaptive_thinking: Whether the model uses Anthropic adaptive thinking rather than manual thinking budgets.
         supports_custom_temperature: Whether the model supports custom temperature.
         supports_verbosity: Whether the model supports verbosity. (Introduced with OpenAI gpt5 models)
         supports_pdf_parsing: Whether fenic can use this model to parse PDFs.
@@ -82,7 +88,9 @@ class CompletionModelParameters:
         supports_disabled_reasoning=True,
         supports_xhigh_reasoning=False,
         default_reasoning_effort: Optional[str] = None,
+        supported_reasoning_efforts: Optional[Set[str]] = None,
         supported_thinking_levels: Optional[Set[ThinkingLevelType]] = None,
+        uses_adaptive_thinking=False,
         supports_custom_temperature=True,
         supports_verbosity = False,
         supports_pdf_parsing = False,
@@ -104,7 +112,9 @@ class CompletionModelParameters:
         self.supports_disabled_reasoning = supports_disabled_reasoning
         self.supports_xhigh_reasoning = supports_xhigh_reasoning
         self.default_reasoning_effort = default_reasoning_effort
+        self.supported_reasoning_efforts = supported_reasoning_efforts
         self.supported_thinking_levels = supported_thinking_levels
+        self.uses_adaptive_thinking = uses_adaptive_thinking
         self.supports_custom_temperature = supports_custom_temperature
         self.supports_verbosity = supports_verbosity
         self.supports_pdf_parsing = supports_pdf_parsing
@@ -364,6 +374,8 @@ class ModelCatalog:
                 context_window_length=1_000_000,
                 max_output_tokens=128_000,
                 supports_reasoning=False,
+                supported_reasoning_efforts=ANTHROPIC_OPUS_4_7_PLUS_EFFORTS,
+                uses_adaptive_thinking=True,
                 supports_custom_temperature=False,
             ),
         )
@@ -379,6 +391,8 @@ class ModelCatalog:
                 context_window_length=1_000_000,
                 max_output_tokens=128_000,
                 supports_reasoning=False,
+                supported_reasoning_efforts=ANTHROPIC_OPUS_4_7_PLUS_EFFORTS,
+                uses_adaptive_thinking=True,
                 supports_custom_temperature=False,
             ),
         )
@@ -395,6 +409,8 @@ class ModelCatalog:
                 context_window_length=200_000,
                 max_output_tokens=128_000,
                 supports_reasoning=True,
+                supported_reasoning_efforts=ANTHROPIC_4_6_EFFORTS,
+                uses_adaptive_thinking=True,
             ),
         )
 
@@ -409,6 +425,8 @@ class ModelCatalog:
                 context_window_length=200_000,
                 max_output_tokens=64_000,
                 supports_reasoning=True,
+                supported_reasoning_efforts=ANTHROPIC_4_6_EFFORTS,
+                uses_adaptive_thinking=True,
             ),
         )
 
@@ -424,6 +442,7 @@ class ModelCatalog:
                 context_window_length=200_000,
                 max_output_tokens=64_000,
                 supports_reasoning=True,
+                supported_reasoning_efforts=ANTHROPIC_OPUS_4_5_EFFORTS,
             ),
             snapshots=["claude-opus-4-5-20251101"],
         )

--- a/src/fenic/core/_inference/output_token_limits.py
+++ b/src/fenic/core/_inference/output_token_limits.py
@@ -1,0 +1,165 @@
+"""Helpers for validating visible completion and reasoning token budgets."""
+
+import math
+from typing import Optional
+
+from fenic.core._inference.model_catalog import CompletionModelParameters, ModelProvider
+from fenic.core._resolved_session_config import (
+    ResolvedAnthropicModelConfig,
+    ResolvedGoogleModelConfig,
+    ResolvedModelConfig,
+    ResolvedOpenAIModelConfig,
+    ResolvedOpenRouterModelConfig,
+)
+from fenic.core.error import ValidationError
+
+OPENAI_REASONING_TOKEN_ESTIMATES = {
+    "none": 0,
+    "minimal": 2048,
+    "low": 4096,
+    "medium": 8192,
+    "high": 16384,
+    "xhigh": 32768,
+}
+
+OPENROUTER_REASONING_EFFORT_RATIOS = {
+    "none": 0.0,
+    "minimal": 0.10,
+    "low": 0.20,
+    "medium": 0.50,
+    "high": 0.80,
+    "xhigh": 0.95,
+}
+
+GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES = {
+    "minimal": 2048,
+    "low": 8192,
+    "medium": 16384,
+    "high": 32768,
+}
+
+ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS = {
+    "low": 0.20,
+    "medium": 0.50,
+    "high": 0.80,
+    "xhigh": 0.95,
+    "max": 1.00,
+}
+
+
+def validate_effective_output_token_limit(
+    *,
+    model_provider: ModelProvider,
+    model_name: str,
+    model_max_output_tokens: int,
+    requested_completion_tokens: Optional[int],
+    estimated_reasoning_tokens: int = 0,
+) -> Optional[int]:
+    """Return the provider request limit after validating reasoning headroom.
+
+    `requested_completion_tokens` is the visible completion budget. Reasoning
+    models often require a larger provider-side output limit to preserve that
+    visible budget. Fail when the combined visible + estimated reasoning budget
+    exceeds the model cap instead of silently shrinking visible output.
+    """
+    if requested_completion_tokens is None:
+        return None
+    if requested_completion_tokens > model_max_output_tokens:
+        raise ValidationError(
+            f"[{model_provider.value}:{model_name}] max_output_tokens must be a positive integer less than or equal to {model_max_output_tokens}"
+        )
+    effective_output_tokens = requested_completion_tokens + estimated_reasoning_tokens
+    if effective_output_tokens > model_max_output_tokens:
+        max_visible_tokens = max(model_max_output_tokens - estimated_reasoning_tokens, 0)
+        raise ValidationError(
+            f"[{model_provider.value}:{model_name}] max_output_tokens={requested_completion_tokens} "
+            f"plus estimated reasoning tokens={estimated_reasoning_tokens} requires "
+            f"{effective_output_tokens} total output tokens, exceeding the model limit "
+            f"of {model_max_output_tokens}. Lower max_output_tokens to at most "
+            f"{max_visible_tokens}, lower reasoning effort, or use a model with a larger output limit."
+        )
+    return effective_output_tokens
+
+
+def estimate_reasoning_tokens_for_resolved_profile(
+    *,
+    model_config: ResolvedModelConfig,
+    completion_parameters: CompletionModelParameters,
+    profile_name: Optional[str],
+) -> int:
+    """Estimate provider-side reasoning tokens for a resolved model profile."""
+    selected_profile_name = profile_name or getattr(model_config, "default_profile", None)
+    profiles = getattr(model_config, "profiles", None) or {}
+    profile = profiles.get(selected_profile_name) if selected_profile_name else None
+
+    if isinstance(model_config, ResolvedOpenAIModelConfig):
+        return _estimate_openai_reasoning_tokens(completion_parameters, profile)
+    if isinstance(model_config, ResolvedGoogleModelConfig):
+        return _estimate_google_reasoning_tokens(completion_parameters, profile)
+    if isinstance(model_config, ResolvedAnthropicModelConfig):
+        return _estimate_anthropic_reasoning_tokens(completion_parameters, profile)
+    if isinstance(model_config, ResolvedOpenRouterModelConfig):
+        return _estimate_openrouter_reasoning_tokens(completion_parameters, profile)
+    return 0
+
+
+def _estimate_openai_reasoning_tokens(completion_parameters, profile) -> int:
+    if not completion_parameters.supports_reasoning:
+        return 0
+    reasoning_effort = getattr(profile, "reasoning_effort", None)
+    if not reasoning_effort:
+        if completion_parameters.default_reasoning_effort:
+            reasoning_effort = completion_parameters.default_reasoning_effort
+        elif completion_parameters.supports_disabled_reasoning:
+            reasoning_effort = "none"
+        elif completion_parameters.supports_minimal_reasoning:
+            reasoning_effort = "minimal"
+        else:
+            reasoning_effort = "low"
+    return OPENAI_REASONING_TOKEN_ESTIMATES[reasoning_effort]
+
+
+def _estimate_google_reasoning_tokens(completion_parameters, profile) -> int:
+    if not completion_parameters.supports_reasoning:
+        return 0
+    if completion_parameters.supported_thinking_levels:
+        thinking_level = getattr(profile, "thinking_level", None) or "low"
+        return GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES[thinking_level]
+    if profile is None:
+        if completion_parameters.supports_disabled_reasoning:
+            return 0
+        return 1024
+    thinking_token_budget = getattr(profile, "thinking_token_budget", None)
+    if thinking_token_budget is None or thinking_token_budget == 0:
+        return 0
+    if thinking_token_budget > 0:
+        return thinking_token_budget
+    return 16384
+
+
+def _estimate_anthropic_reasoning_tokens(completion_parameters, profile) -> int:
+    if profile is None:
+        return 0
+    thinking_token_budget = getattr(profile, "thinking_token_budget", None)
+    if thinking_token_budget and completion_parameters.supports_reasoning:
+        return thinking_token_budget
+    effort = getattr(profile, "effort", None)
+    if effort and completion_parameters.uses_adaptive_thinking:
+        return math.ceil(
+            ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS[effort]
+            * completion_parameters.max_output_tokens
+        )
+    return 0
+
+
+def _estimate_openrouter_reasoning_tokens(completion_parameters, profile) -> int:
+    if not completion_parameters.supports_reasoning:
+        return 0
+    reasoning_max_tokens = getattr(profile, "reasoning_max_tokens", None)
+    if reasoning_max_tokens:
+        return reasoning_max_tokens
+    reasoning_effort = getattr(profile, "reasoning_effort", None) or "low"
+    return math.ceil(
+        OPENROUTER_REASONING_EFFORT_RATIOS[reasoning_effort]
+        * completion_parameters.max_output_tokens
+    )

--- a/src/fenic/core/_inference/output_token_limits.py
+++ b/src/fenic/core/_inference/output_token_limits.py
@@ -1,17 +1,28 @@
 """Helpers for validating visible completion and reasoning token budgets."""
 
 import math
-from typing import Final, Optional
+from typing import Final, Optional, Union
 
 from fenic.core._inference.model_catalog import CompletionModelParameters, ModelProvider
 from fenic.core._resolved_session_config import (
     ResolvedAnthropicModelConfig,
+    ResolvedAnthropicModelProfile,
     ResolvedGoogleModelConfig,
+    ResolvedGoogleModelProfile,
     ResolvedModelConfig,
     ResolvedOpenAIModelConfig,
+    ResolvedOpenAIModelProfile,
     ResolvedOpenRouterModelConfig,
+    ResolvedOpenRouterModelProfile,
 )
 from fenic.core.error import ValidationError
+
+ResolvedModelProfile = Union[
+    ResolvedAnthropicModelProfile,
+    ResolvedGoogleModelProfile,
+    ResolvedOpenAIModelProfile,
+    ResolvedOpenRouterModelProfile,
+]
 
 OPENAI_REASONING_TOKEN_ESTIMATES: Final[dict[str, int]] = {
     "none": 0,
@@ -38,6 +49,13 @@ GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES: Final[dict[str, int]] = {
     "high": 32768,
 }
 
+# Gemini thinking budgets are suggestions, not hard limits. The provider-side
+# request limit applies this margin on top of the expected thinking budget so
+# overruns do not eat into the visible completion budget. The plan-time
+# estimate must apply the same margin so plan validation is exactly as strict
+# as the runtime request construction.
+GOOGLE_REASONING_SAFETY_MARGIN: Final[float] = 1.5
+
 ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS: Final[dict[str, float]] = {
     "low": 0.20,
     "medium": 0.50,
@@ -54,6 +72,7 @@ def validate_effective_output_token_limit(
     model_max_output_tokens: int,
     requested_completion_tokens: Optional[int],
     estimated_reasoning_tokens: int = 0,
+    reasoning_shares_output_window: bool = False,
 ) -> Optional[int]:
     """Return the provider request limit after validating reasoning headroom.
 
@@ -61,6 +80,13 @@ def validate_effective_output_token_limit(
     models often require a larger provider-side output limit to preserve that
     visible budget. Fail when the combined visible + estimated reasoning budget
     exceeds the model cap instead of silently shrinking visible output.
+
+    When `reasoning_shares_output_window` is True (Anthropic adaptive
+    thinking), the reasoning budget is not a fixed reservation: the provider
+    decides how much to think within `max_tokens`. In that mode only the
+    visible budget is validated against the model cap, and the returned
+    request limit is capped at the model maximum instead of failing, since
+    high effort levels intentionally allow thinking up to the full window.
     """
     if requested_completion_tokens is None:
         return None
@@ -69,6 +95,8 @@ def validate_effective_output_token_limit(
             f"[{model_provider.value}:{model_name}] max_output_tokens must be a positive integer less than or equal to {model_max_output_tokens}"
         )
     effective_output_tokens = requested_completion_tokens + estimated_reasoning_tokens
+    if reasoning_shares_output_window:
+        return min(effective_output_tokens, model_max_output_tokens)
     if effective_output_tokens > model_max_output_tokens:
         max_visible_tokens = max(model_max_output_tokens - estimated_reasoning_tokens, 0)
         raise ValidationError(
@@ -81,6 +109,29 @@ def validate_effective_output_token_limit(
     return effective_output_tokens
 
 
+def resolve_openai_reasoning_effort(
+    completion_parameters: CompletionModelParameters,
+    reasoning_effort: Optional[str],
+) -> str:
+    """Resolve the effective OpenAI reasoning effort for a profile.
+
+    Reasoning effort behavior varies by model:
+    - o-series/gpt-5 models: do not support disabling reasoning, default to
+      the lowest supported effort (minimal or low)
+    - gpt-5.1+ models: support 'none' to disable reasoning, default to 'none'
+    - models with a catalog-level default use that default
+    """
+    if reasoning_effort:
+        return reasoning_effort
+    if completion_parameters.default_reasoning_effort:
+        return completion_parameters.default_reasoning_effort
+    if completion_parameters.supports_disabled_reasoning:
+        return "none"
+    if completion_parameters.supports_minimal_reasoning:
+        return "minimal"
+    return "low"
+
+
 def estimate_reasoning_tokens_for_resolved_profile(
     *,
     model_config: ResolvedModelConfig,
@@ -88,9 +139,7 @@ def estimate_reasoning_tokens_for_resolved_profile(
     profile_name: Optional[str],
 ) -> int:
     """Estimate provider-side reasoning tokens for a resolved model profile."""
-    selected_profile_name = profile_name or getattr(model_config, "default_profile", None)
-    profiles = getattr(model_config, "profiles", None) or {}
-    profile = profiles.get(selected_profile_name) if selected_profile_name else None
+    profile = _resolve_profile(model_config, profile_name)
 
     if isinstance(model_config, ResolvedOpenAIModelConfig):
         return _estimate_openai_reasoning_tokens(completion_parameters, profile)
@@ -103,62 +152,98 @@ def estimate_reasoning_tokens_for_resolved_profile(
     return 0
 
 
-def _estimate_openai_reasoning_tokens(completion_parameters, profile) -> int:
+def reasoning_shares_output_window_for_resolved_profile(
+    *,
+    model_config: ResolvedModelConfig,
+    completion_parameters: CompletionModelParameters,
+    profile_name: Optional[str],
+) -> bool:
+    """Whether the resolved profile uses a reasoning budget that shares the output window.
+
+    True only for Anthropic adaptive-thinking effort profiles, where the
+    thinking budget is an adaptive maximum inside `max_tokens` rather than a
+    fixed reservation on top of the visible completion budget.
+    """
+    if not isinstance(model_config, ResolvedAnthropicModelConfig):
+        return False
+    if not completion_parameters.uses_adaptive_thinking:
+        return False
+    profile = _resolve_profile(model_config, profile_name)
+    return isinstance(profile, ResolvedAnthropicModelProfile) and bool(profile.effort)
+
+
+def _resolve_profile(
+    model_config: ResolvedModelConfig, profile_name: Optional[str]
+) -> Optional[ResolvedModelProfile]:
+    selected_profile_name = profile_name or getattr(model_config, "default_profile", None)
+    profiles = getattr(model_config, "profiles", None) or {}
+    return profiles.get(selected_profile_name) if selected_profile_name else None
+
+
+def _estimate_openai_reasoning_tokens(
+    completion_parameters: CompletionModelParameters,
+    profile: Optional[ResolvedOpenAIModelProfile],
+) -> int:
     if not completion_parameters.supports_reasoning:
         return 0
-    reasoning_effort = getattr(profile, "reasoning_effort", None)
-    if not reasoning_effort:
-        if completion_parameters.default_reasoning_effort:
-            reasoning_effort = completion_parameters.default_reasoning_effort
-        elif completion_parameters.supports_disabled_reasoning:
-            reasoning_effort = "none"
-        elif completion_parameters.supports_minimal_reasoning:
-            reasoning_effort = "minimal"
-        else:
-            reasoning_effort = "low"
+    reasoning_effort = resolve_openai_reasoning_effort(
+        completion_parameters, profile.reasoning_effort if profile else None
+    )
     return OPENAI_REASONING_TOKEN_ESTIMATES[reasoning_effort]
 
 
-def _estimate_google_reasoning_tokens(completion_parameters, profile) -> int:
+def _estimate_google_reasoning_tokens(
+    completion_parameters: CompletionModelParameters,
+    profile: Optional[ResolvedGoogleModelProfile],
+) -> int:
     if not completion_parameters.supports_reasoning:
         return 0
     if completion_parameters.supported_thinking_levels:
-        thinking_level = getattr(profile, "thinking_level", None) or "low"
-        return GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES[thinking_level]
+        thinking_level = (profile.thinking_level if profile else None) or "low"
+        return _with_google_safety_margin(
+            GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES[thinking_level]
+        )
     if profile is None:
         if completion_parameters.supports_disabled_reasoning:
             return 0
-        return 1024
-    thinking_token_budget = getattr(profile, "thinking_token_budget", None)
+        return _with_google_safety_margin(1024)
+    thinking_token_budget = profile.thinking_token_budget
     if thinking_token_budget is None or thinking_token_budget == 0:
         return 0
     if thinking_token_budget > 0:
-        return thinking_token_budget
-    return 16384
+        return _with_google_safety_margin(thinking_token_budget)
+    return _with_google_safety_margin(16384)
 
 
-def _estimate_anthropic_reasoning_tokens(completion_parameters, profile) -> int:
+def _with_google_safety_margin(expected_thinking_tokens: int) -> int:
+    return int(GOOGLE_REASONING_SAFETY_MARGIN * expected_thinking_tokens)
+
+
+def _estimate_anthropic_reasoning_tokens(
+    completion_parameters: CompletionModelParameters,
+    profile: Optional[ResolvedAnthropicModelProfile],
+) -> int:
     if profile is None:
         return 0
-    thinking_token_budget = getattr(profile, "thinking_token_budget", None)
-    if thinking_token_budget and completion_parameters.supports_reasoning:
-        return thinking_token_budget
-    effort = getattr(profile, "effort", None)
-    if effort and completion_parameters.uses_adaptive_thinking:
+    if profile.thinking_token_budget and completion_parameters.supports_reasoning:
+        return profile.thinking_token_budget
+    if profile.effort and completion_parameters.uses_adaptive_thinking:
         return math.ceil(
-            ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS[effort]
+            ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS[profile.effort]
             * completion_parameters.max_output_tokens
         )
     return 0
 
 
-def _estimate_openrouter_reasoning_tokens(completion_parameters, profile) -> int:
+def _estimate_openrouter_reasoning_tokens(
+    completion_parameters: CompletionModelParameters,
+    profile: Optional[ResolvedOpenRouterModelProfile],
+) -> int:
     if not completion_parameters.supports_reasoning:
         return 0
-    reasoning_max_tokens = getattr(profile, "reasoning_max_tokens", None)
-    if reasoning_max_tokens:
-        return reasoning_max_tokens
-    reasoning_effort = getattr(profile, "reasoning_effort", None) or "low"
+    if profile is not None and profile.reasoning_max_tokens:
+        return profile.reasoning_max_tokens
+    reasoning_effort = (profile.reasoning_effort if profile else None) or "low"
     return math.ceil(
         OPENROUTER_REASONING_EFFORT_RATIOS[reasoning_effort]
         * completion_parameters.max_output_tokens

--- a/src/fenic/core/_inference/output_token_limits.py
+++ b/src/fenic/core/_inference/output_token_limits.py
@@ -1,7 +1,7 @@
 """Helpers for validating visible completion and reasoning token budgets."""
 
 import math
-from typing import Optional
+from typing import Final, Optional
 
 from fenic.core._inference.model_catalog import CompletionModelParameters, ModelProvider
 from fenic.core._resolved_session_config import (
@@ -13,7 +13,7 @@ from fenic.core._resolved_session_config import (
 )
 from fenic.core.error import ValidationError
 
-OPENAI_REASONING_TOKEN_ESTIMATES = {
+OPENAI_REASONING_TOKEN_ESTIMATES: Final[dict[str, int]] = {
     "none": 0,
     "minimal": 2048,
     "low": 4096,
@@ -22,7 +22,7 @@ OPENAI_REASONING_TOKEN_ESTIMATES = {
     "xhigh": 32768,
 }
 
-OPENROUTER_REASONING_EFFORT_RATIOS = {
+OPENROUTER_REASONING_EFFORT_RATIOS: Final[dict[str, float]] = {
     "none": 0.0,
     "minimal": 0.10,
     "low": 0.20,
@@ -31,14 +31,14 @@ OPENROUTER_REASONING_EFFORT_RATIOS = {
     "xhigh": 0.95,
 }
 
-GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES = {
+GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES: Final[dict[str, int]] = {
     "minimal": 2048,
     "low": 8192,
     "medium": 16384,
     "high": 32768,
 }
 
-ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS = {
+ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS: Final[dict[str, float]] = {
     "low": 0.20,
     "medium": 0.50,
     "high": 0.80,

--- a/src/fenic/core/_logical_plan/utils.py
+++ b/src/fenic/core/_logical_plan/utils.py
@@ -5,6 +5,10 @@ from fenic.core._inference.model_catalog import (
     ModelProvider,
     model_catalog,
 )
+from fenic.core._inference.output_token_limits import (
+    estimate_reasoning_tokens_for_resolved_profile,
+    validate_effective_output_token_limit,
+)
 from fenic.core._logical_plan.expressions import AggregateExpr, LogicalExpr, SortExpr
 from fenic.core._logical_plan.resolved_types import ResolvedModelAlias
 from fenic.core._resolved_session_config import (
@@ -91,10 +95,22 @@ def validate_completion_parameters(
         ValidationError: If temperature or max_tokens are out of bounds for the model.
     """
     model_config, model_provider, completion_parameters = fetch_model_and_completion_parameters(model_alias, resolved_session_config)
-    if max_tokens is not None and max_tokens > completion_parameters.max_output_tokens:
-        raise ValidationError(
-            f"[{model_provider.value}:{model_config.model_name}] max_output_tokens must be a positive integer less than or equal to {completion_parameters.max_output_tokens}"
+    estimated_reasoning_tokens = (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=completion_parameters,
+            profile_name=model_alias.profile if model_alias else None,
         )
+        if max_tokens is not None
+        else 0
+    )
+    validate_effective_output_token_limit(
+        model_provider=model_provider,
+        model_name=model_config.model_name,
+        model_max_output_tokens=completion_parameters.max_output_tokens,
+        requested_completion_tokens=max_tokens,
+        estimated_reasoning_tokens=estimated_reasoning_tokens,
+    )
     if temperature is not None and (temperature < 0 or temperature > completion_parameters.max_temperature):
         raise ValidationError(
             f"[{model_provider.value}:{model_config.model_name}] temperature must be between 0 and {completion_parameters.max_temperature}"

--- a/src/fenic/core/_logical_plan/utils.py
+++ b/src/fenic/core/_logical_plan/utils.py
@@ -7,6 +7,7 @@ from fenic.core._inference.model_catalog import (
 )
 from fenic.core._inference.output_token_limits import (
     estimate_reasoning_tokens_for_resolved_profile,
+    reasoning_shares_output_window_for_resolved_profile,
     validate_effective_output_token_limit,
 )
 from fenic.core._logical_plan.expressions import AggregateExpr, LogicalExpr, SortExpr
@@ -95,11 +96,12 @@ def validate_completion_parameters(
         ValidationError: If temperature or max_tokens are out of bounds for the model.
     """
     model_config, model_provider, completion_parameters = fetch_model_and_completion_parameters(model_alias, resolved_session_config)
+    profile_name = model_alias.profile if model_alias else None
     estimated_reasoning_tokens = (
         estimate_reasoning_tokens_for_resolved_profile(
             model_config=model_config,
             completion_parameters=completion_parameters,
-            profile_name=model_alias.profile if model_alias else None,
+            profile_name=profile_name,
         )
         if max_tokens is not None
         else 0
@@ -110,6 +112,11 @@ def validate_completion_parameters(
         model_max_output_tokens=completion_parameters.max_output_tokens,
         requested_completion_tokens=max_tokens,
         estimated_reasoning_tokens=estimated_reasoning_tokens,
+        reasoning_shares_output_window=reasoning_shares_output_window_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=completion_parameters,
+            profile_name=profile_name,
+        ),
     )
     if temperature is not None and (temperature < 0 or temperature > completion_parameters.max_temperature):
         raise ValidationError(

--- a/src/fenic/core/_resolved_session_config.py
+++ b/src/fenic/core/_resolved_session_config.py
@@ -12,7 +12,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Literal, Optional, Union
 
-from fenic.core._inference.model_catalog import ModelProvider, ThinkingLevelType
+from fenic.core._inference.model_catalog import (
+    AnthropicReasoningEffortType,
+    ModelProvider,
+    ThinkingLevelType,
+)
 from fenic.core.types.enums import CacheBackend
 from fenic.core.types.provider_routing import (
     DataCollection,
@@ -23,6 +27,7 @@ from fenic.core.types.provider_routing import (
 from fenic.core.types.semantic import ParsingEngine
 
 ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+OpenRouterReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
 Verbosity = Literal["low", "medium", "high"]
 
 # --- Enums ---
@@ -41,6 +46,7 @@ class CloudExecutorSize(str, Enum):
 @dataclass
 class ResolvedAnthropicModelProfile:
     thinking_token_budget: Optional[int] = None
+    effort: Optional[AnthropicReasoningEffortType] = None
 
 
 @dataclass
@@ -78,7 +84,7 @@ class ResolvedOpenRouterProviderRouting:
 
 @dataclass
 class ResolvedOpenRouterModelProfile:
-    reasoning_effort: Optional[Literal["high", "medium", "low"]] = None
+    reasoning_effort: Optional[OpenRouterReasoningEffort] = None
     reasoning_max_tokens: Optional[int] = None
     models: Optional[list[str]] = None
     provider: Optional[ResolvedOpenRouterProviderRouting] = None

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -15,6 +15,29 @@ from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
 from fenic.core.error import ValidationError
 
 
+def _make_anthropic_client(params, profiles, default_profile_name):
+    client = AnthropicBatchCompletionsClient.__new__(AnthropicBatchCompletionsClient)
+    client.model_provider = ModelProvider.ANTHROPIC
+    client.model = "claude-opus-4-8"
+    client._model_parameters = params
+    client._profile_manager = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations=profiles,
+        default_profile_name=default_profile_name,
+    )
+    return client
+
+
+def _make_request(max_completion_tokens):
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=max_completion_tokens,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+
 def test_adaptive_effort_profile_uses_output_config():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-8"
@@ -32,6 +55,8 @@ def test_adaptive_effort_profile_uses_output_config():
         ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS["xhigh"]
         * params.max_output_tokens
     )
+    assert profile.uses_adaptive_thinking
+    assert profile.effort == "xhigh"
     assert profile.thinking_config["type"] == "adaptive"
     assert profile.output_config == {"effort": "xhigh"}
 
@@ -52,6 +77,8 @@ def test_manual_thinking_budget_profile_still_uses_budget_tokens():
 
     assert profile.thinking_enabled
     assert profile.thinking_token_budget == 2048
+    assert not profile.uses_adaptive_thinking
+    assert profile.effort == "high"
     assert profile.thinking_config["type"] == "enabled"
     assert profile.thinking_config["budget_tokens"] == 2048
     assert profile.output_config == {"effort": "high"}
@@ -61,24 +88,49 @@ def test_adaptive_effort_profile_rejects_max_tokens_above_model_limit():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-8"
     )
-    client = AnthropicBatchCompletionsClient.__new__(AnthropicBatchCompletionsClient)
-    client.model_provider = ModelProvider.ANTHROPIC
-    client.model = "claude-opus-4-8"
-    client._model_parameters = params
-    client._profile_manager = AnthropicCompletionsProfileManager(
-        model_parameters=params,
-        profile_configurations={
+    client = _make_anthropic_client(
+        params,
+        profiles={
             "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
         },
-        default_profile_name="deep",
+        default_profile_name="deep"
     )
-    request = FenicCompletionsRequest(
-        messages=LMRequestMessages(system="", examples=[], user="hello"),
-        max_completion_tokens=10_000,
-        top_logprobs=None,
-        structured_output=None,
-        temperature=None,
-    )
+    request = _make_request(max_completion_tokens=10_000)
 
     with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
         client._get_max_output_token_request_limit(request)
+
+
+def test_adaptive_effort_profile_uses_request_sized_rate_limit_estimate():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep"
+    )
+    request = _make_request(max_completion_tokens=512)
+
+    profile = client._profile_manager.get_profile_by_name(None)
+    assert profile.thinking_token_budget == 121_600
+    assert client._get_max_output_token_request_limit(request) == 122_112
+    assert client._estimate_output_tokens(request) == 999
+
+
+def test_manual_thinking_budget_profile_uses_budget_for_rate_limit_estimate():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-5"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "budget": ResolvedAnthropicModelProfile(thinking_token_budget=2048),
+        },
+        default_profile_name="budget"
+    )
+    request = _make_request(max_completion_tokens=512)
+
+    assert client._estimate_output_tokens(request) == 2560

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -1,0 +1,48 @@
+import pytest
+
+pytest.importorskip("anthropic")
+
+from fenic._inference.anthropic.anthropic_profile_manager import (
+    AnthropicCompletionsProfileManager,
+)
+from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
+
+
+def test_adaptive_effort_profile_uses_output_config():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    profile = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep",
+    ).get_profile_by_name(None)
+
+    assert profile.thinking_enabled
+    assert profile.thinking_token_budget == 0
+    assert profile.thinking_config["type"] == "adaptive"
+    assert profile.output_config == {"effort": "xhigh"}
+
+
+def test_manual_thinking_budget_profile_still_uses_budget_tokens():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-5"
+    )
+    profile = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "budget": ResolvedAnthropicModelProfile(
+                thinking_token_budget=2048, effort="high"
+            ),
+        },
+        default_profile_name="budget",
+    ).get_profile_by_name(None)
+
+    assert profile.thinking_enabled
+    assert profile.thinking_token_budget == 2048
+    assert profile.thinking_config["type"] == "enabled"
+    assert profile.thinking_config["budget_tokens"] == 2048
+    assert profile.output_config == {"effort": "high"}

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 pytest.importorskip("anthropic")
@@ -8,6 +10,7 @@ from fenic._inference.anthropic.anthropic_batch_chat_completions_client import (
 from fenic._inference.anthropic.anthropic_profile_manager import (
     AnthropicCompletionsProfileManager,
 )
+from fenic._inference.model_client import FatalException
 from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
 from fenic.core._inference.model_catalog import ModelProvider, model_catalog
 from fenic.core._inference.output_token_limits import (
@@ -86,7 +89,7 @@ def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     assert profile.output_config == {"effort": "high"}
 
 
-def test_adaptive_effort_profile_rejects_max_tokens_above_model_limit():
+def test_adaptive_effort_profile_caps_request_limit_at_model_window():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-8"
     )
@@ -97,10 +100,60 @@ def test_adaptive_effort_profile_rejects_max_tokens_above_model_limit():
         },
         default_profile_name="deep"
     )
+    # Adaptive thinking shares the output window: the request limit is capped
+    # at the model maximum instead of failing when visible + budget overflows.
     request = _make_request(max_completion_tokens=10_000)
+    assert client._get_max_output_token_request_limit(request) == 128_000
 
-    with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
+
+def test_adaptive_effort_max_profile_is_usable():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deepest": ResolvedAnthropicModelProfile(effort="max"),
+        },
+        default_profile_name="deepest"
+    )
+    request = _make_request(max_completion_tokens=512)
+    assert client._get_max_output_token_request_limit(request) == 128_000
+
+
+def test_adaptive_effort_profile_rejects_visible_tokens_above_model_limit():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep"
+    )
+    request = _make_request(max_completion_tokens=200_000)
+
+    with pytest.raises(ValidationError, match="less than or equal to 128000"):
         client._get_max_output_token_request_limit(request)
+
+
+def test_make_single_request_returns_fatal_exception_for_invalid_token_budget():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep"
+    )
+    request = _make_request(max_completion_tokens=200_000)
+
+    result = asyncio.run(client.make_single_request(request))
+    assert isinstance(result, FatalException)
+    assert isinstance(result.exception, ValidationError)
 
 
 def test_adaptive_effort_profile_uses_request_sized_rate_limit_estimate():
@@ -140,6 +193,23 @@ def test_effort_only_profile_on_non_adaptive_model_does_not_enable_thinking():
     assert profile.effort == "high"
     assert profile.thinking_config["type"] == "disabled"
     assert profile.output_config == {"effort": "high"}
+
+
+def test_manual_thinking_budget_profile_still_rejects_reasoning_overflow():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-5"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "budget": ResolvedAnthropicModelProfile(thinking_token_budget=60_000),
+        },
+        default_profile_name="budget"
+    )
+    request = _make_request(max_completion_tokens=10_000)
+
+    with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
+        client._get_max_output_token_request_limit(request)
 
 
 def test_manual_thinking_budget_profile_uses_budget_for_rate_limit_estimate():

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -6,11 +6,13 @@ from fenic._inference.anthropic.anthropic_batch_chat_completions_client import (
     AnthropicBatchCompletionsClient,
 )
 from fenic._inference.anthropic.anthropic_profile_manager import (
-    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
     AnthropicCompletionsProfileManager,
 )
 from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
 from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.output_token_limits import (
+    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
+)
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
 from fenic.core.error import ValidationError
 
@@ -118,6 +120,26 @@ def test_adaptive_effort_profile_uses_request_sized_rate_limit_estimate():
     assert profile.thinking_token_budget == 121_600
     assert client._get_max_output_token_request_limit(request) == 122_112
     assert client._estimate_output_tokens(request) == 999
+
+
+def test_effort_only_profile_on_non_adaptive_model_does_not_enable_thinking():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-5"
+    )
+    profile = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "effort_only": ResolvedAnthropicModelProfile(effort="high"),
+        },
+        default_profile_name="effort_only",
+    ).get_profile_by_name(None)
+
+    assert not profile.thinking_enabled
+    assert profile.thinking_token_budget == 0
+    assert not profile.uses_adaptive_thinking
+    assert profile.effort == "high"
+    assert profile.thinking_config["type"] == "disabled"
+    assert profile.output_config == {"effort": "high"}
 
 
 def test_manual_thinking_budget_profile_uses_budget_for_rate_limit_estimate():

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -2,9 +2,14 @@ import pytest
 
 pytest.importorskip("anthropic")
 
+from fenic._inference.anthropic.anthropic_batch_chat_completions_client import (
+    AnthropicBatchCompletionsClient,
+)
 from fenic._inference.anthropic.anthropic_profile_manager import (
+    ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
     AnthropicCompletionsProfileManager,
 )
+from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
 from fenic.core._inference.model_catalog import ModelProvider, model_catalog
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
 
@@ -22,7 +27,10 @@ def test_adaptive_effort_profile_uses_output_config():
     ).get_profile_by_name(None)
 
     assert profile.thinking_enabled
-    assert profile.thinking_token_budget == 0
+    assert profile.thinking_token_budget == (
+        ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS["xhigh"]
+        * params.max_output_tokens
+    )
     assert profile.thinking_config["type"] == "adaptive"
     assert profile.output_config == {"effort": "xhigh"}
 
@@ -46,3 +54,27 @@ def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     assert profile.thinking_config["type"] == "enabled"
     assert profile.thinking_config["budget_tokens"] == 2048
     assert profile.output_config == {"effort": "high"}
+
+
+def test_adaptive_effort_profile_clamps_max_tokens_to_model_limit():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-8"
+    )
+    client = AnthropicBatchCompletionsClient.__new__(AnthropicBatchCompletionsClient)
+    client._model_parameters = params
+    client._profile_manager = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep",
+    )
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=10_000,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    assert client._get_max_output_token_request_limit(request) == params.max_output_tokens

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -12,6 +12,7 @@ from fenic._inference.anthropic.anthropic_profile_manager import (
 from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
 from fenic.core._inference.model_catalog import ModelProvider, model_catalog
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
+from fenic.core.error import ValidationError
 
 
 def test_adaptive_effort_profile_uses_output_config():
@@ -56,11 +57,13 @@ def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     assert profile.output_config == {"effort": "high"}
 
 
-def test_adaptive_effort_profile_clamps_max_tokens_to_model_limit():
+def test_adaptive_effort_profile_rejects_max_tokens_above_model_limit():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-8"
     )
     client = AnthropicBatchCompletionsClient.__new__(AnthropicBatchCompletionsClient)
+    client.model_provider = ModelProvider.ANTHROPIC
+    client.model = "claude-opus-4-8"
     client._model_parameters = params
     client._profile_manager = AnthropicCompletionsProfileManager(
         model_parameters=params,
@@ -77,4 +80,5 @@ def test_adaptive_effort_profile_clamps_max_tokens_to_model_limit():
         temperature=None,
     )
 
-    assert client._get_max_output_token_request_limit(request) == params.max_output_tokens
+    with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
+        client._get_max_output_token_request_limit(request)

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -1,0 +1,153 @@
+import pytest
+
+from fenic.core._inference.model_catalog import (
+    CompletionModelParameters,
+    ModelProvider,
+)
+from fenic.core._inference.output_token_limits import (
+    estimate_reasoning_tokens_for_resolved_profile,
+    validate_effective_output_token_limit,
+)
+from fenic.core._logical_plan.resolved_types import ResolvedModelAlias
+from fenic.core._logical_plan.utils import validate_completion_parameters
+from fenic.core._resolved_session_config import (
+    ResolvedAnthropicModelConfig,
+    ResolvedAnthropicModelProfile,
+    ResolvedGoogleModelConfig,
+    ResolvedGoogleModelProfile,
+    ResolvedLanguageModelConfig,
+    ResolvedOpenAIModelConfig,
+    ResolvedOpenAIModelProfile,
+    ResolvedOpenRouterModelConfig,
+    ResolvedOpenRouterModelProfile,
+    ResolvedSemanticConfig,
+    ResolvedSessionConfig,
+)
+from fenic.core.error import ValidationError
+
+
+def test_effective_output_token_limit_rejects_reasoning_overflow():
+    with pytest.raises(ValidationError, match="Lower max_output_tokens to at most 60"):
+        validate_effective_output_token_limit(
+            model_provider=ModelProvider.OPENAI,
+            model_name="test-model",
+            model_max_output_tokens=100,
+            requested_completion_tokens=70,
+            estimated_reasoning_tokens=40,
+        )
+
+
+def test_openrouter_effort_estimate_uses_model_output_ratio():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=1000,
+        max_output_tokens=1000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=False,
+    )
+    model_config = ResolvedOpenRouterModelConfig(
+        model_name="openai/gpt-test",
+        profiles={"deep": ResolvedOpenRouterModelProfile(reasoning_effort="xhigh")},
+    )
+
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name="deep",
+        )
+        == 950
+    )
+
+
+def test_google_explicit_empty_budget_profile_estimates_no_reasoning_tokens():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=1000,
+        max_output_tokens=1000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=False,
+    )
+    model_config = ResolvedGoogleModelConfig(
+        model_name="gemini-test",
+        model_provider=ModelProvider.GOOGLE_DEVELOPER,
+        rpm=100,
+        tpm=1000,
+        profiles={"off": ResolvedGoogleModelProfile(thinking_token_budget=None)},
+    )
+
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name="off",
+        )
+        == 0
+    )
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name=None,
+        )
+        == 1024
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_config", "max_tokens"),
+    [
+        (
+            ResolvedOpenAIModelConfig(
+                model_name="gpt-5.5",
+                rpm=100,
+                tpm=1000,
+                profiles={"deep": ResolvedOpenAIModelProfile(reasoning_effort="xhigh")},
+            ),
+            100_000,
+        ),
+        (
+            ResolvedAnthropicModelConfig(
+                model_name="claude-opus-4-8",
+                rpm=100,
+                input_tpm=1000,
+                output_tpm=1000,
+                profiles={"deep": ResolvedAnthropicModelProfile(effort="xhigh")},
+            ),
+            100_000,
+        ),
+        (
+            ResolvedGoogleModelConfig(
+                model_name="gemini-3.1-pro-preview",
+                model_provider=ModelProvider.GOOGLE_DEVELOPER,
+                rpm=100,
+                tpm=1000,
+                profiles={"deep": ResolvedGoogleModelProfile(thinking_level="high")},
+            ),
+            50_000,
+        ),
+    ],
+)
+def test_completion_parameter_validation_rejects_reasoning_overflow(
+    model_config, max_tokens
+):
+    session_config = ResolvedSessionConfig(
+        app_name="test",
+        db_path=None,
+        semantic=ResolvedSemanticConfig(
+            language_models=ResolvedLanguageModelConfig(
+                model_configs={"model": model_config},
+                default_model="model",
+            )
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
+        validate_completion_parameters(
+            ResolvedModelAlias(name="model", profile="deep"),
+            session_config,
+            temperature=0,
+            max_tokens=max_tokens,
+        )

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -184,3 +184,82 @@ def test_completion_parameter_validation_rejects_reasoning_overflow(
             temperature=0,
             max_tokens=max_tokens,
         )
+
+
+def test_openai_default_profile_estimate_disables_reasoning_when_supported():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=1000,
+        max_output_tokens=1000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=True,
+    )
+    model_config = ResolvedOpenAIModelConfig(
+        model_name="gpt-test",
+        rpm=100,
+        tpm=1000,
+    )
+
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name=None,
+        )
+        == 0
+    )
+
+
+def test_anthropic_estimate_without_profile_reserves_no_reasoning_tokens():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=1000,
+        max_output_tokens=1000,
+        supports_reasoning=True,
+    )
+    model_config = ResolvedAnthropicModelConfig(
+        model_name="claude-test",
+        rpm=100,
+        input_tpm=1000,
+        output_tpm=1000,
+    )
+
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name=None,
+        )
+        == 0
+    )
+
+
+def test_openrouter_effort_estimate_rejects_reasoning_overflow():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=100_000,
+        max_output_tokens=100_000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=False,
+    )
+    model_config = ResolvedOpenRouterModelConfig(
+        model_name="openai/gpt-test",
+        profiles={"deep": ResolvedOpenRouterModelProfile(reasoning_effort="high")},
+    )
+    estimated_reasoning_tokens = estimate_reasoning_tokens_for_resolved_profile(
+        model_config=model_config,
+        completion_parameters=params,
+        profile_name="deep",
+    )
+
+    with pytest.raises(ValidationError, match="plus estimated reasoning tokens"):
+        validate_effective_output_token_limit(
+            model_provider=ModelProvider.OPENROUTER,
+            model_name=model_config.model_name,
+            model_max_output_tokens=params.max_output_tokens,
+            requested_completion_tokens=60_000,
+            estimated_reasoning_tokens=estimated_reasoning_tokens,
+        )

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -1,5 +1,12 @@
 import pytest
 
+from fenic._inference.common_openai.openai_chat_completions_core import (
+    OpenAIChatCompletionsCore,
+)
+from fenic._inference.common_openai.openai_profile_manager import (
+    OpenAICompletionProfileConfiguration,
+)
+from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
 from fenic.core._inference.model_catalog import (
     CompletionModelParameters,
     ModelProvider,
@@ -35,6 +42,32 @@ def test_effective_output_token_limit_rejects_reasoning_overflow():
             requested_completion_tokens=70,
             estimated_reasoning_tokens=40,
         )
+
+
+def test_openai_core_output_limit_uses_internal_model_identity():
+    core = OpenAIChatCompletionsCore(
+        model="gpt-4.1-nano",
+        model_provider=ModelProvider.OPENAI,
+        token_counter=None,
+        client=None,
+    )
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    assert (
+        core.get_max_output_token_request_limit(
+            request,
+            OpenAICompletionProfileConfiguration(
+                expected_additional_reasoning_tokens=0
+            ),
+        )
+        == 512
+    )
 
 
 def test_openrouter_effort_estimate_uses_model_output_ratio():

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -12,6 +12,7 @@ from fenic.core._inference.model_catalog import (
     ModelProvider,
 )
 from fenic.core._inference.output_token_limits import (
+    GOOGLE_REASONING_SAFETY_MARGIN,
     estimate_reasoning_tokens_for_resolved_profile,
     validate_effective_output_token_limit,
 )
@@ -125,7 +126,7 @@ def test_google_explicit_empty_budget_profile_estimates_no_reasoning_tokens():
             completion_parameters=params,
             profile_name=None,
         )
-        == 1024
+        == 1536  # 1024 expected thinking tokens with the 1.5x safety margin
     )
 
 
@@ -143,13 +144,13 @@ def test_google_explicit_empty_budget_profile_estimates_no_reasoning_tokens():
         ),
         (
             ResolvedAnthropicModelConfig(
-                model_name="claude-opus-4-8",
+                model_name="claude-opus-4-5",
                 rpm=100,
                 input_tpm=1000,
                 output_tpm=1000,
-                profiles={"deep": ResolvedAnthropicModelProfile(effort="xhigh")},
+                profiles={"deep": ResolvedAnthropicModelProfile(thinking_token_budget=60_000)},
             ),
-            100_000,
+            10_000,
         ),
         (
             ResolvedGoogleModelConfig(
@@ -263,3 +264,62 @@ def test_openrouter_effort_estimate_rejects_reasoning_overflow():
             requested_completion_tokens=60_000,
             estimated_reasoning_tokens=estimated_reasoning_tokens,
         )
+
+
+def test_adaptive_anthropic_profile_passes_completion_parameter_validation():
+    session_config = ResolvedSessionConfig(
+        app_name="test",
+        db_path=None,
+        semantic=ResolvedSemanticConfig(
+            language_models=ResolvedLanguageModelConfig(
+                model_configs={
+                    "model": ResolvedAnthropicModelConfig(
+                        model_name="claude-opus-4-8",
+                        rpm=100,
+                        input_tpm=1000,
+                        output_tpm=1000,
+                        profiles={"deepest": ResolvedAnthropicModelProfile(effort="max")},
+                    )
+                },
+                default_model="model",
+            )
+        ),
+    )
+
+    # Adaptive thinking shares the output window, so even effort="max" admits
+    # any visible budget within the model limit.
+    validate_completion_parameters(
+        ResolvedModelAlias(name="model", profile="deepest"),
+        session_config,
+        temperature=0,
+        max_tokens=100_000,
+    )
+
+
+def test_google_plan_estimate_matches_runtime_safety_margin():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=100_000,
+        max_output_tokens=100_000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=False,
+    )
+    model_config = ResolvedGoogleModelConfig(
+        model_name="gemini-test",
+        model_provider=ModelProvider.GOOGLE_DEVELOPER,
+        rpm=100,
+        tpm=1000,
+        profiles={"budget": ResolvedGoogleModelProfile(thinking_token_budget=20_000)},
+    )
+
+    # Plan-layer estimate must equal the runtime request construction estimate
+    # (expected thinking budget scaled by the shared safety margin).
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name="budget",
+        )
+        == int(GOOGLE_REASONING_SAFETY_MARGIN * 20_000)
+    )

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -17,6 +17,7 @@ from fenic import (
     IntegerType,
     OpenAIEmbeddingModel,
     OpenAILanguageModel,
+    OpenRouterLanguageModel,
     SemanticConfig,
     Session,
     SessionConfig,
@@ -571,6 +572,88 @@ def test_model_profile_validation():
                 language_models={"claude-opus-4-8": AnthropicLanguageModel(model_name="claude-opus-4-8", rpm=100, input_tpm=1000, output_tpm=1000, profiles={"deep": AnthropicLanguageModel.Profile(thinking_token_budget=1024)})}
             )
         )
+    # Test that latest Claude models support effort profiles
+    SessionConfig(
+        app_name="test_model_profile_validation",
+        semantic=SemanticConfig(
+            language_models={
+                "claude-opus-4-8": AnthropicLanguageModel(
+                    model_name="claude-opus-4-8",
+                    rpm=100,
+                    input_tpm=1000,
+                    output_tpm=1000,
+                    profiles={"deep": AnthropicLanguageModel.Profile(effort="xhigh")},
+                )
+            }
+        ),
+    )
+    SessionConfig(
+        app_name="test_model_profile_validation",
+        semantic=SemanticConfig(
+            language_models={
+                "claude-sonnet-4-6": AnthropicLanguageModel(
+                    model_name="claude-sonnet-4-6",
+                    rpm=100,
+                    input_tpm=1000,
+                    output_tpm=1000,
+                    profiles={"deep": AnthropicLanguageModel.Profile(effort="max")},
+                )
+            }
+        ),
+    )
+    SessionConfig(
+        app_name="test_model_profile_validation",
+        semantic=SemanticConfig(
+            language_models={
+                "claude-opus-4-5": AnthropicLanguageModel(
+                    model_name="claude-opus-4-5",
+                    rpm=100,
+                    input_tpm=1000,
+                    output_tpm=1000,
+                    profiles={
+                        "deep": AnthropicLanguageModel.Profile(
+                            thinking_token_budget=4096,
+                            effort="high",
+                        )
+                    },
+                )
+            }
+        ),
+    )
+    with pytest.raises(ConfigurationError, match="Model 'claude-sonnet-4-6' does not support effort='xhigh'."):
+        SessionConfig(
+            app_name="test_model_profile_validation",
+            semantic=SemanticConfig(
+                language_models={
+                    "claude-sonnet-4-6": AnthropicLanguageModel(
+                        model_name="claude-sonnet-4-6",
+                        rpm=100,
+                        input_tpm=1000,
+                        output_tpm=1000,
+                        profiles={"deep": AnthropicLanguageModel.Profile(effort="xhigh")},
+                    )
+                }
+            ),
+        )
+    with pytest.raises(ConfigurationError, match="Model 'claude-haiku-4-5' does not support effort profiles."):
+        SessionConfig(
+            app_name="test_model_profile_validation",
+            semantic=SemanticConfig(
+                language_models={
+                    "claude-haiku-4-5": AnthropicLanguageModel(
+                        model_name="claude-haiku-4-5",
+                        rpm=100,
+                        input_tpm=1000,
+                        output_tpm=1000,
+                        profiles={"fast": AnthropicLanguageModel.Profile(effort="low")},
+                    )
+                }
+            ),
+        )
+    # OpenRouter supports the expanded reasoning.effort enum from its current chat API.
+    OpenRouterLanguageModel.Profile(reasoning_effort="none")
+    OpenRouterLanguageModel.Profile(reasoning_effort="minimal")
+    OpenRouterLanguageModel.Profile(reasoning_effort="xhigh")
 
 def test_session_config_with_invalid_api_keys(tmp_path, monkeypatch):
     """Test that session configuration validation rejects models with invalid API keys."""

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -564,12 +564,19 @@ def test_model_profile_validation():
                 language_models={"gpt-5.2": OpenAILanguageModel(model_name="gpt-5.2", rpm=100, tpm=1000, profiles={"deep": OpenAILanguageModel.Profile(reasoning_effort="xhigh")})}
             )
         )
-    # Test that Claude Opus 4.8 rejects legacy manual thinking budget profiles
-    with pytest.raises(ConfigurationError, match="Model 'claude-opus-4-8' does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from 'deep'."):
+    # Test that adaptive thinking Claude models reject legacy manual thinking budget profiles
+    with pytest.raises(ConfigurationError, match="Model 'claude-opus-4-8' uses adaptive thinking and does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from 'deep' and set effort instead."):
         SessionConfig(
             app_name="test_model_profile_validation",
             semantic=SemanticConfig(
                 language_models={"claude-opus-4-8": AnthropicLanguageModel(model_name="claude-opus-4-8", rpm=100, input_tpm=1000, output_tpm=1000, profiles={"deep": AnthropicLanguageModel.Profile(thinking_token_budget=1024)})}
+            )
+        )
+    with pytest.raises(ConfigurationError, match="Model 'claude-sonnet-4-6' uses adaptive thinking and does not support manual thinking_token_budget profiles. Please remove thinking_token_budget from 'deep' and set effort instead."):
+        SessionConfig(
+            app_name="test_model_profile_validation",
+            semantic=SemanticConfig(
+                language_models={"claude-sonnet-4-6": AnthropicLanguageModel(model_name="claude-sonnet-4-6", rpm=100, input_tpm=1000, output_tpm=1000, profiles={"deep": AnthropicLanguageModel.Profile(thinking_token_budget=1024)})}
             )
         )
     # Test that latest Claude models support effort profiles

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,7 +328,20 @@ def configure_language_model(model_provider: ModelProvider, model_name: str) -> 
                 tpm=100_000,
             )
     elif model_provider == ModelProvider.ANTHROPIC:
-        if model_parameters.supports_reasoning:
+        if model_parameters.uses_adaptive_thinking:
+            language_model = AnthropicLanguageModel(
+                model_name=model_name,
+                rpm=500,
+                input_tpm=100_000,
+                output_tpm=75_000,
+                profiles={
+                    "low": AnthropicLanguageModel.Profile(effort="low"),
+                    "medium": AnthropicLanguageModel.Profile(effort="medium"),
+                    "high": AnthropicLanguageModel.Profile(effort="high"),
+                },
+                default_profile="low",
+            )
+        elif model_parameters.supports_reasoning:
             language_model = AnthropicLanguageModel(
                 model_name=model_name,
                 rpm=500,

--- a/uv.lock
+++ b/uv.lock
@@ -30,20 +30,21 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.54.0"
+version = "0.106.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
+    { name = "docstring-parser" },
     { name = "httpx" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/28/80cb9bb6e7ce77d404145b51da4257455805c17f0a6be528ff3286e3882f/anthropic-0.54.0.tar.gz", hash = "sha256:5e6f997d97ce8e70eac603c3ec2e7f23addeff953fbbb76b19430562bb6ba815", size = 312376, upload-time = "2025-06-11T02:46:27.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/69/f1b6b5918d18ab47193bc7dd316bc208bc98decab5cf69b328d8a3e258dc/anthropic-0.106.0.tar.gz", hash = "sha256:f26e2645e31f66eff526b923f539b80b4b6eda1a918790cd77c0afe5e24a2203", size = 855469, upload-time = "2026-06-05T21:13:26.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/b9/6ffb48e82c5e97b03cecee872d134a6b6666c2767b2d32ed709f3a60a8fe/anthropic-0.54.0-py3-none-any.whl", hash = "sha256:c1062a0a905daeec17ca9c06c401e4b3f24cb0495841d29d752568a1d4018d56", size = 288774, upload-time = "2025-06-11T02:46:25.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7a/8c64e9ba12b16d5d1c64e0fc9da1f32cbf6742f14fe2ad943f83a2ed8639/anthropic-0.106.0-py3-none-any.whl", hash = "sha256:d0e4a7448e54c3942833cee5b3de5f1b31289fd49999bfbcc2ec0c0acaddf75f", size = 838152, upload-time = "2026-06-05T21:13:28.404Z" },
 ]
 
 [[package]]
@@ -692,7 +693,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.52.2" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.106.0" },
     { name = "boto3", specifier = ">=1.38.28" },
     { name = "botocore", specifier = ">=1.38.28" },
     { name = "cloudpickle", specifier = ">=3.1.1" },


### PR DESCRIPTION
## Summary
- add Anthropic profile support for provider-native effort, including adaptive thinking for Claude Opus 4.7/4.8 and Claude 4.6 models
- bump the Anthropic optional dependency to 0.106.0 so fenic can use typed output_config and adaptive thinking params
- widen OpenRouter reasoning_effort support to current documented values and update reasoning token estimates/docs

## Testing
- uv run --env-file .env pytest tests/api/test_session.py -q
- uv run --env-file .env pytest tests/_inference/test_model_catalog.py tests/_inference/test_anthropic_profile_manager.py -q
- uv run --env-file .env --extra anthropic pytest tests/_inference/test_anthropic_profile_manager.py -q

Stacked on #307.