### PR TITLE
refactor: tighten provider request config types

### DIFF
--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -107,7 +107,7 @@ class OpenAIChatCompletionsCore:
                 else None
             )
             # Temperature is only allowed when reasoning_effort is 'none' for models that support it
-            if request.temperature is not None:
+            if request.temperature:
                 if self._model_parameters.supports_reasoning and reasoning_effort != "none":
                     logger.warning(
                         f"Model {self._model} does not support custom temperature when reasoning is enabled.  Ignoring temperature parameter."

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -107,7 +107,7 @@ class OpenAIChatCompletionsCore:
                 else None
             )
             # Temperature is only allowed when reasoning_effort is 'none' for models that support it
-            if request.temperature:
+            if request.temperature is not None:
                 if self._model_parameters.supports_reasoning and reasoning_effort != "none":
                     logger.warning(
                         f"Model {self._model} does not support custom temperature when reasoning is enabled.  Ignoring temperature parameter."

--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -101,7 +101,11 @@ class OpenAIChatCompletionsCore:
             if max_completion_tokens is not None:
                 common_params["max_completion_tokens"] = max_completion_tokens
 
-            reasoning_effort = profile_configuration.additional_parameters.get("reasoning_effort") if profile_configuration else None
+            reasoning_effort = (
+                profile_configuration.reasoning_effort
+                if profile_configuration
+                else None
+            )
             # Temperature is only allowed when reasoning_effort is 'none' for models that support it
             if request.temperature:
                 if self._model_parameters.supports_reasoning and reasoning_effort != "none":
@@ -124,8 +128,12 @@ class OpenAIChatCompletionsCore:
                             "top_logprobs": request.top_logprobs,
                         }
                     )
-            if profile_configuration:
-                common_params.update(profile_configuration.additional_parameters)
+            if profile_configuration and profile_configuration.reasoning_effort:
+                common_params["reasoning_effort"] = (
+                    profile_configuration.reasoning_effort
+                )
+            if profile_configuration and profile_configuration.verbosity:
+                common_params["verbosity"] = profile_configuration.verbosity
 
             # Choose between parse and create based on structured_output
             if request.structured_output:

--- a/src/fenic/_inference/common_openai/openai_profile_manager.py
+++ b/src/fenic/_inference/common_openai/openai_profile_manager.py
@@ -3,7 +3,10 @@ from typing import Optional
 
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
 from fenic.core._inference.model_catalog import CompletionModelParameters
-from fenic.core._inference.output_token_limits import OPENAI_REASONING_TOKEN_ESTIMATES
+from fenic.core._inference.output_token_limits import (
+    OPENAI_REASONING_TOKEN_ESTIMATES,
+    resolve_openai_reasoning_effort,
+)
 from fenic.core._resolved_session_config import (
     ReasoningEffort,
     ResolvedOpenAIModelProfile,
@@ -33,35 +36,24 @@ class OpenAICompletionsProfileManager(
 
     def _process_profile(self, profile: ResolvedOpenAIModelProfile) -> OpenAICompletionProfileConfiguration:
         """Process OpenAI profile configuration."""
-        resolved_reasoning_effort = None
-        resolved_verbosity = None
-        additional_reasoning_tokens = 0
+        if not self.model_parameters.supports_reasoning:
+            return OpenAICompletionProfileConfiguration(
+                verbosity=self._resolve_verbosity(profile),
+            )
 
-        if self.model_parameters.supports_reasoning:
-            # Reasoning effort behavior varies by model:
-            # - o-series/gpt-5 models: do not support disabling reasoning, default to lowest effort (minimal or low)
-            # - gpt-5.1 models: support 'none' to disable reasoning, default to 'none'
-            reasoning_effort = profile.reasoning_effort
-            if not reasoning_effort:
-                if self.model_parameters.default_reasoning_effort:
-                    reasoning_effort = self.model_parameters.default_reasoning_effort
-                elif self.model_parameters.supports_disabled_reasoning:
-                    reasoning_effort = "none"
-                elif self.model_parameters.supports_minimal_reasoning:
-                    reasoning_effort = "minimal"
-                else:
-                    reasoning_effort = "low"
-            resolved_reasoning_effort = reasoning_effort
-            additional_reasoning_tokens = self._get_reasoning_tokens(reasoning_effort)
-
-        if self.model_parameters.supports_verbosity and profile.verbosity:
-            resolved_verbosity = profile.verbosity
-
-        return OpenAICompletionProfileConfiguration(
-            reasoning_effort=resolved_reasoning_effort,
-            verbosity=resolved_verbosity,
-            expected_additional_reasoning_tokens=additional_reasoning_tokens
+        reasoning_effort = resolve_openai_reasoning_effort(
+            self.model_parameters, profile.reasoning_effort
         )
+        return OpenAICompletionProfileConfiguration(
+            reasoning_effort=reasoning_effort,
+            verbosity=self._resolve_verbosity(profile),
+            expected_additional_reasoning_tokens=self._get_reasoning_tokens(reasoning_effort)
+        )
+
+    def _resolve_verbosity(self, profile: ResolvedOpenAIModelProfile) -> Optional[Verbosity]:
+        if self.model_parameters.supports_verbosity and profile.verbosity:
+            return profile.verbosity
+        return None
 
     def _get_reasoning_tokens(self, reasoning_effort: str) -> int:
         """Get the expected additional reasoning tokens for a given reasoning effort level."""
@@ -69,21 +61,11 @@ class OpenAICompletionsProfileManager(
 
     def get_default_profile(self) -> OpenAICompletionProfileConfiguration:
         """Get default OpenAI configuration."""
-        if self.model_parameters.supports_reasoning:
-            # Reasoning effort behavior varies by model:
-            # - o-series/gpt-5 models: do not support disabling reasoning, default to lowest effort (minimal or low)
-            # - gpt-5.1 models: support 'none' to disable reasoning, default to 'none'
-            if self.model_parameters.default_reasoning_effort:
-                reasoning_effort = self.model_parameters.default_reasoning_effort
-            elif self.model_parameters.supports_disabled_reasoning:
-                reasoning_effort = "none"
-            elif self.model_parameters.supports_minimal_reasoning:
-                reasoning_effort = "minimal"
-            else:
-                reasoning_effort = "low"
-            return OpenAICompletionProfileConfiguration(
-                reasoning_effort=reasoning_effort,
-                expected_additional_reasoning_tokens=self._get_reasoning_tokens(reasoning_effort)
-            )
-        else:
+        if not self.model_parameters.supports_reasoning:
             return OpenAICompletionProfileConfiguration()
+
+        reasoning_effort = resolve_openai_reasoning_effort(self.model_parameters, None)
+        return OpenAICompletionProfileConfiguration(
+            reasoning_effort=reasoning_effort,
+            expected_additional_reasoning_tokens=self._get_reasoning_tokens(reasoning_effort)
+        )

--- a/src/fenic/_inference/common_openai/openai_profile_manager.py
+++ b/src/fenic/_inference/common_openai/openai_profile_manager.py
@@ -1,15 +1,20 @@
-from dataclasses import dataclass, field
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from fenic._inference.profile_manager import BaseProfileConfiguration, ProfileManager
 from fenic.core._inference.model_catalog import CompletionModelParameters
 from fenic.core._inference.output_token_limits import OPENAI_REASONING_TOKEN_ESTIMATES
-from fenic.core._resolved_session_config import ResolvedOpenAIModelProfile
+from fenic.core._resolved_session_config import (
+    ReasoningEffort,
+    ResolvedOpenAIModelProfile,
+    Verbosity,
+)
 
 
 @dataclass
 class OpenAICompletionProfileConfiguration(BaseProfileConfiguration):
-    additional_parameters: dict[str, Any] = field(default_factory=dict)
+    reasoning_effort: Optional[ReasoningEffort] = None
+    verbosity: Optional[Verbosity] = None
     expected_additional_reasoning_tokens: int = 0
 
 
@@ -28,7 +33,8 @@ class OpenAICompletionsProfileManager(
 
     def _process_profile(self, profile: ResolvedOpenAIModelProfile) -> OpenAICompletionProfileConfiguration:
         """Process OpenAI profile configuration."""
-        additional_parameters = {}
+        resolved_reasoning_effort = None
+        resolved_verbosity = None
         additional_reasoning_tokens = 0
 
         if self.model_parameters.supports_reasoning:
@@ -45,14 +51,15 @@ class OpenAICompletionsProfileManager(
                     reasoning_effort = "minimal"
                 else:
                     reasoning_effort = "low"
-            additional_parameters["reasoning_effort"] = reasoning_effort
+            resolved_reasoning_effort = reasoning_effort
             additional_reasoning_tokens = self._get_reasoning_tokens(reasoning_effort)
 
         if self.model_parameters.supports_verbosity and profile.verbosity:
-            additional_parameters["verbosity"] = profile.verbosity
+            resolved_verbosity = profile.verbosity
 
         return OpenAICompletionProfileConfiguration(
-            additional_parameters=additional_parameters,
+            reasoning_effort=resolved_reasoning_effort,
+            verbosity=resolved_verbosity,
             expected_additional_reasoning_tokens=additional_reasoning_tokens
         )
 
@@ -75,9 +82,7 @@ class OpenAICompletionsProfileManager(
             else:
                 reasoning_effort = "low"
             return OpenAICompletionProfileConfiguration(
-                additional_parameters={
-                    "reasoning_effort": reasoning_effort
-                },
+                reasoning_effort=reasoning_effort,
                 expected_additional_reasoning_tokens=self._get_reasoning_tokens(reasoning_effort)
             )
         else:

--- a/src/fenic/_inference/google/gemini_batch_embeddings_client.py
+++ b/src/fenic/_inference/google/gemini_batch_embeddings_client.py
@@ -71,7 +71,7 @@ class GoogleBatchEmbeddingsClient(
             additional_config = self._profile_manager.get_profile_by_name(request.model_profile)
             contents = request.doc
             response = await self._client.models.embed_content(
-                model=self.model, contents=contents, config=additional_config.additional_embedding_config
+                model=self.model, contents=contents, config=additional_config.embedding_config
             )
             if response.embeddings:
                 embedding_data: ContentEmbedding = response.embeddings[0]

--- a/src/fenic/_inference/google/gemini_native_chat_completions_client.py
+++ b/src/fenic/_inference/google/gemini_native_chat_completions_client.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 from google.genai.errors import ClientError, ServerError
 from google.genai.types import (
     FinishReason,
-    GenerateContentConfigDict,
+    GenerateContentConfig,
     GenerateContentResponse,
     MediaResolution,
 )
@@ -191,36 +191,34 @@ class GeminiNativeChatCompletionsClient(
         profile_config = self._profile_manager.get_profile_by_name(
             request.model_profile
         )
-        generation_config: GenerateContentConfigDict = {
-            "temperature": request.temperature,
-            "response_logprobs": request.top_logprobs is not None,
-            "logprobs": request.top_logprobs,
-            "system_instruction": request.messages.system,
-        }
-
         try:
             max_output_tokens = self._get_max_output_token_request_limit(request)
         except ValidationError as e:
             # Deterministic request-construction failure: retrying cannot help.
             return FatalException(e)
-        if max_output_tokens is not None:
-            generation_config["max_output_tokens"] = max_output_tokens
-
-        generation_config.update(profile_config.additional_generation_config)
-
-        # Add media_resolution from profile if specified (for PDF processing)
+        media_resolution = None
         if profile_config.media_resolution is not None:
             media_resolution_map = {
                 "low": MediaResolution.MEDIA_RESOLUTION_LOW,
                 "medium": MediaResolution.MEDIA_RESOLUTION_MEDIUM,
                 "high": MediaResolution.MEDIA_RESOLUTION_HIGH,
             }
-            generation_config["media_resolution"] = media_resolution_map[profile_config.media_resolution]
+            media_resolution = media_resolution_map[profile_config.media_resolution]
+
+        generation_config = GenerateContentConfig(
+            temperature=request.temperature,
+            response_logprobs=request.top_logprobs is not None,
+            logprobs=request.top_logprobs,
+            system_instruction=request.messages.system,
+            max_output_tokens=max_output_tokens,
+            thinking_config=profile_config.thinking_config,
+            media_resolution=media_resolution,
+        )
 
         if request.structured_output is not None:
-            generation_config.update(
-                response_mime_type="application/json",
-                response_schema=request.structured_output.pydantic_model,
+            generation_config.response_mime_type = "application/json"
+            generation_config.response_schema = (
+                request.structured_output.pydantic_model
             )
 
         file_obj = None

--- a/src/fenic/_inference/google/google_profile_manager.py
+++ b/src/fenic/_inference/google/google_profile_manager.py
@@ -2,9 +2,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from google.genai.types import (
-    EmbedContentConfigDict,
-    GenerateContentConfigDict,
-    ThinkingConfigDict,
+    EmbedContentConfig,
+    ThinkingConfig,
     ThinkingLevel,
 )
 
@@ -27,18 +26,18 @@ class GoogleCompletionsProfileConfig(BaseProfileConfiguration):
     Attributes:
         thinking_enabled: Whether thinking/reasoning is enabled for this profile
         thinking_token_budget: Token budget allocated for thinking/reasoning
-        additional_generation_config: Additional Google-specific generation configuration
+        thinking_config: Google thinking configuration
         media_resolution: Media resolution for PDF processing (gemini-3+ models)
     """
     thinking_enabled: bool = False
     thinking_token_budget: int = 0
-    additional_generation_config: GenerateContentConfigDict = field(default_factory=GenerateContentConfigDict)
+    thinking_config: Optional[ThinkingConfig] = None
     media_resolution: Optional[MediaResolutionType] = None
 
 @dataclass
 class GoogleEmbeddingsProfileConfig(BaseProfileConfiguration):
     """Configuration for Google Gemini embeddings model profiles."""
-    additional_embedding_config: EmbedContentConfigDict = field(default_factory=EmbedContentConfigDict)
+    embedding_config: EmbedContentConfig = field(default_factory=EmbedContentConfig)
 
 class GoogleEmbeddingsProfileManager(ProfileManager[ResolvedGoogleModelProfile, GoogleEmbeddingsProfileConfig]):
 
@@ -53,15 +52,11 @@ class GoogleEmbeddingsProfileManager(ProfileManager[ResolvedGoogleModelProfile, 
 
 
     def _process_profile(self, profile: ResolvedGoogleModelProfile) -> GoogleEmbeddingsProfileConfig:
-        config_dict = EmbedContentConfigDict()
-        if profile.embedding_dimensionality:
-            config_dict["output_dimensionality"] = profile.embedding_dimensionality
-
-        if profile.embedding_task_type:
-            config_dict["task_type"] = profile.embedding_task_type
-
         return GoogleEmbeddingsProfileConfig(
-           additional_embedding_config=config_dict,
+           embedding_config=EmbedContentConfig(
+               output_dimensionality=profile.embedding_dimensionality,
+               task_type=profile.embedding_task_type,
+           ),
         )
 
     def get_default_profile(self) -> GoogleEmbeddingsProfileConfig:
@@ -104,7 +99,7 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
         Returns:
             Google-specific profile configuration
         """
-        additional_generation_config: GenerateContentConfigDict = {}
+        thinking_config = None
         thinking_enabled = False
         expected_thinking_tokens = 0
 
@@ -129,26 +124,21 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
                 }
                 thinking_level_enum = thinking_level_map[thinking_level]
                 expected_thinking_tokens = GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES[thinking_level]
-                thinking_config: ThinkingConfigDict = {
-                    "thinking_level": thinking_level_enum
-                }
-                additional_generation_config.update({"thinking_config": thinking_config})
+                thinking_config = ThinkingConfig(thinking_level=thinking_level_enum)
             elif profile.thinking_token_budget is None or profile.thinking_token_budget == 0:
                 # Thinking disabled
                 thinking_enabled = False
-                thinking_config: ThinkingConfigDict = {
-                    "include_thoughts": False,
-                    "thinking_budget": 0
-                }
-                additional_generation_config.update({"thinking_config": thinking_config})
+                thinking_config = ThinkingConfig(
+                    include_thoughts=False,
+                    thinking_budget=0,
+                )
             else:
                 # Thinking enabled with budget
                 thinking_enabled = True
-                thinking_config: ThinkingConfigDict = {
-                    "include_thoughts": False,
-                    "thinking_budget": profile.thinking_token_budget
-                }
-                additional_generation_config.update({"thinking_config": thinking_config})
+                thinking_config = ThinkingConfig(
+                    include_thoughts=False,
+                    thinking_budget=profile.thinking_token_budget,
+                )
 
                 if profile.thinking_token_budget > 0:
                     expected_thinking_tokens = profile.thinking_token_budget
@@ -164,7 +154,7 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
         return GoogleCompletionsProfileConfig(
             thinking_enabled=thinking_enabled,
             thinking_token_budget=expected_thinking_tokens,
-            additional_generation_config=additional_generation_config,
+            thinking_config=thinking_config,
             media_resolution=media_resolution,
         )
 
@@ -183,10 +173,8 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
                 return GoogleCompletionsProfileConfig(
                     thinking_enabled=True,
                     thinking_token_budget=8192,  # Estimated for low
-                    additional_generation_config=GenerateContentConfigDict(
-                        thinking_config=ThinkingConfigDict(
-                            thinking_level=ThinkingLevel.LOW
-                        )
+                    thinking_config=ThinkingConfig(
+                        thinking_level=ThinkingLevel.LOW
                     ),
                     media_resolution=media_resolution,
                 )
@@ -194,11 +182,9 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
                 return GoogleCompletionsProfileConfig(
                     thinking_enabled=False,
                     thinking_token_budget=0,
-                    additional_generation_config=GenerateContentConfigDict(
-                        thinking_config=ThinkingConfigDict(
-                            include_thoughts=False,
-                            thinking_budget=0
-                        )
+                    thinking_config=ThinkingConfig(
+                        include_thoughts=False,
+                        thinking_budget=0,
                     ),
                     media_resolution=media_resolution,
                 )
@@ -207,11 +193,9 @@ class GoogleCompletionsProfileManager(ProfileManager[ResolvedGoogleModelProfile,
                 return GoogleCompletionsProfileConfig(
                     thinking_enabled=True,
                     thinking_token_budget=1024,
-                    additional_generation_config=GenerateContentConfigDict(
-                        thinking_config=ThinkingConfigDict(
-                            include_thoughts=True,
-                            thinking_budget=1024
-                        )
+                    thinking_config=ThinkingConfig(
+                        include_thoughts=True,
+                        thinking_budget=1024,
                     ),
                     media_resolution=media_resolution,
                 )

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -238,7 +238,7 @@ class GoogleDeveloperLanguageModel(BaseModel):
             thinking_level: For gemini-3+ models, set the thinking level to high, medium, low, or minimal.
                 This parameter is mutually exclusive with thinking_token_budget.
             media_resolution: For gemini-3+ models, set the media resolution for PDF processing.
-                Can be "low", "medium", "high", or "ultra_high". Affects token cost per page.
+                Can be "low", "medium", or "high". Affects token cost per page.
 
         Raises:
             ConfigurationError: If a profile is set with parameters that are not supported by the model.
@@ -429,7 +429,7 @@ class GoogleVertexLanguageModel(BaseModel):
             thinking_level: For gemini-3+ models, set the thinking level to high, medium, low, or minimal.
                 This parameter is mutually exclusive with thinking_token_budget.
             media_resolution: For gemini-3+ models, set the media resolution for PDF processing.
-                Can be "low", "medium", "high", or "ultra_high". Affects token cost per page.
+                Can be "low", "medium", or "high". Affects token cost per page.
 
         Raises:
             ConfigurationError: If a profile is set with parameters that are not supported by the model.
@@ -1786,6 +1786,10 @@ def _validate_language_profile(
                     f"Model '{model_alias}' does not support effort='{profile.effort}'. Please set effort on '{profile_alias}' to one of '{supported_efforts}' instead."
                 )
     elif isinstance(language_model, GoogleDeveloperLanguageModel) or isinstance(language_model, GoogleVertexLanguageModel):
+        if profile.media_resolution is not None and not completion_model_params.supports_media_resolution:
+            raise ConfigurationError(
+                f"Model '{model_alias}' does not support media_resolution. Please remove media_resolution from '{profile_alias}'."
+            )
         if completion_model_params.supported_thinking_levels:
             # For gemini-3+ models, thinking_level must be used instead of thinking_token_budget
             if profile.thinking_token_budget is not None:

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 # Type for supported thinking levels (Gemini 3+ models)
 ThinkingLevelType = Literal["high", "medium", "low", "minimal"]
-MediaResolutionType = Literal["low", "medium", "high", "ultra_high"]
+MediaResolutionType = Literal["low", "medium", "high"]
 AnthropicReasoningEffortType = Literal["low", "medium", "high", "xhigh", "max"]
 
 # Thinking level sets for Gemini 3.x models

--- a/tests/_inference/google/test_google_profile_manager.py
+++ b/tests/_inference/google/test_google_profile_manager.py
@@ -1,0 +1,71 @@
+import pytest
+
+pytest.importorskip("google.genai")
+
+from google.genai.types import EmbedContentConfig, ThinkingConfig, ThinkingLevel
+
+from fenic._inference.google.google_profile_manager import (
+    GoogleCompletionsProfileManager,
+    GoogleEmbeddingsProfileManager,
+)
+from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._resolved_session_config import ResolvedGoogleModelProfile
+
+
+def test_gemini_3_thinking_level_profile_uses_typed_config():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.GOOGLE_DEVELOPER, "gemini-3-flash-preview"
+    )
+    profile = GoogleCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "fast": ResolvedGoogleModelProfile(
+                thinking_level="minimal",
+                media_resolution="low",
+            )
+        },
+        default_profile_name="fast",
+    ).get_profile_by_name(None)
+
+    assert isinstance(profile.thinking_config, ThinkingConfig)
+    assert profile.thinking_config.thinking_level == ThinkingLevel.MINIMAL
+    assert profile.thinking_token_budget == 2048
+    assert profile.media_resolution == "low"
+
+
+def test_gemini_25_budget_profile_uses_typed_config():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.GOOGLE_DEVELOPER, "gemini-2.5-flash"
+    )
+    profile = GoogleCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "budget": ResolvedGoogleModelProfile(thinking_token_budget=4096)
+        },
+        default_profile_name="budget",
+    ).get_profile_by_name(None)
+
+    assert isinstance(profile.thinking_config, ThinkingConfig)
+    assert profile.thinking_config.include_thoughts is False
+    assert profile.thinking_config.thinking_budget == 4096
+    assert profile.thinking_token_budget == 4096
+
+
+def test_google_embedding_profile_uses_typed_config():
+    params = model_catalog.get_embedding_model_parameters(
+        ModelProvider.GOOGLE_DEVELOPER, "gemini-embedding-001"
+    )
+    profile = GoogleEmbeddingsProfileManager(
+        model_parameters=params,
+        profiles={
+            "search": ResolvedGoogleModelProfile(
+                embedding_dimensionality=1536,
+                embedding_task_type="RETRIEVAL_DOCUMENT",
+            )
+        },
+        default_profile_name="search",
+    ).get_profile_by_name(None)
+
+    assert isinstance(profile.embedding_config, EmbedContentConfig)
+    assert profile.embedding_config.output_dimensionality == 1536
+    assert profile.embedding_config.task_type == "RETRIEVAL_DOCUMENT"

--- a/tests/_inference/test_model_catalog.py
+++ b/tests/_inference/test_model_catalog.py
@@ -248,7 +248,8 @@ def test_gpt_55_default_profile_uses_provider_default_reasoning():
     params = model_catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.5")
     profile = OpenAICompletionsProfileManager(params).get_default_profile()
 
-    assert profile.additional_parameters["reasoning_effort"] == "medium"
+    assert profile.reasoning_effort == "medium"
+    assert profile.verbosity is None
     assert profile.expected_additional_reasoning_tokens == 8192
 
 def test_openrouter_provider_loads_models(mock_openrouter_models):

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -399,3 +399,39 @@ def test_google_plan_estimate_matches_runtime_safety_margin():
         )
         == int(GOOGLE_REASONING_SAFETY_MARGIN * 20_000)
     )
+
+
+def test_openai_core_sends_verbosity_when_configured():
+    core, fake_completions = _make_openai_core_with_fake_completions()
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    asyncio.run(
+        core.make_single_request(
+            request, OpenAICompletionProfileConfiguration(verbosity="high")
+        )
+    )
+
+    assert fake_completions.kwargs["verbosity"] == "high"
+
+
+def test_openai_core_omits_verbosity_when_unset():
+    core, fake_completions = _make_openai_core_with_fake_completions()
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    asyncio.run(
+        core.make_single_request(request, OpenAICompletionProfileConfiguration())
+    )
+
+    assert "verbosity" not in fake_completions.kwargs

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -1,3 +1,6 @@
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
 from fenic._inference.common_openai.openai_chat_completions_core import (
@@ -69,6 +72,79 @@ def test_openai_core_output_limit_uses_internal_model_identity():
         )
         == 512
     )
+
+
+class FakeOpenAICompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok", refusal=None),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=1,
+                prompt_tokens_details=None,
+                completion_tokens=1,
+                completion_tokens_details=None,
+            ),
+        )
+
+
+def _make_openai_core_with_fake_completions():
+    fake_completions = FakeOpenAICompletions()
+    return (
+        OpenAIChatCompletionsCore(
+            model="gpt-4.1-nano",
+            model_provider=ModelProvider.OPENAI,
+            token_counter=None,
+            client=SimpleNamespace(
+                chat=SimpleNamespace(completions=fake_completions),
+                beta=None,
+            ),
+        ),
+        fake_completions,
+    )
+
+
+def test_openai_core_omits_zero_temperature():
+    core, fake_completions = _make_openai_core_with_fake_completions()
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=0,
+    )
+
+    asyncio.run(
+        core.make_single_request(request, OpenAICompletionProfileConfiguration())
+    )
+
+    assert "temperature" not in fake_completions.kwargs
+
+
+def test_openai_core_sends_nonzero_temperature():
+    core, fake_completions = _make_openai_core_with_fake_completions()
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=0.2,
+    )
+
+    asyncio.run(
+        core.make_single_request(request, OpenAICompletionProfileConfiguration())
+    )
+
+    assert fake_completions.kwargs["temperature"] == 0.2
 
 
 def test_openrouter_effort_estimate_uses_model_output_ratio():

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -532,6 +532,15 @@ def test_model_profile_validation():
                 language_models={"gemini-3.1-pro-preview": GoogleDeveloperLanguageModel(model_name="gemini-3.1-pro-preview", rpm=100, tpm=1000, profiles={"high": GoogleDeveloperLanguageModel.Profile(thinking_token_budget=100)})}
             )
         )
+    with pytest.raises(PydanticValidationError, match="Input should be 'low', 'medium' or 'high'"):
+        GoogleDeveloperLanguageModel.Profile(media_resolution="ultra_high")
+    with pytest.raises(ConfigurationError, match="Model 'gemini-2.5-flash' does not support media_resolution. Please remove media_resolution from 'high'."):
+        SessionConfig(
+            app_name="test_model_profile_validation",
+            semantic=SemanticConfig(
+                language_models={"gemini-2.5-flash": GoogleDeveloperLanguageModel(model_name="gemini-2.5-flash", rpm=100, tpm=1000, profiles={"high": GoogleDeveloperLanguageModel.Profile(media_resolution="high")})}
+            )
+        )
 
 
     # Test that gpt-5.1 works with 'none' reasoning (default)


### PR DESCRIPTION
## Summary
- replace OpenAI profile passthrough dicts with typed reasoning_effort and verbosity fields
- build Google generation and embedding configs with google-genai typed config classes instead of SDK dict aliases
- add focused Google profile-manager coverage for typed thinking and embedding configs

## Testing
- uv run --env-file .env pytest tests/_inference/test_model_catalog.py -q
- uv run --env-file .env --extra google pytest tests/_inference/google -q
- uvx ruff check src/fenic/_inference/common_openai/openai_chat_completions_core.py src/fenic/_inference/common_openai/openai_profile_manager.py src/fenic/_inference/google/gemini_batch_embeddings_client.py src/fenic/_inference/google/gemini_native_chat_completions_client.py src/fenic/_inference/google/google_profile_manager.py tests/_inference/test_model_catalog.py tests/_inference/google/test_google_profile_manager.py

Stacked on #308.