### PR TITLE
feat: move heavyweight local features behind extras

### DIFF
--- a/.claude/skills/fenic-mechanics/SKILL.md
+++ b/.claude/skills/fenic-mechanics/SKILL.md
@@ -92,6 +92,10 @@ input_tpm, output_tpm)` — **no single `tpm`**. OpenAI/Google/Cohere use `tpm`.
   `fc.semantic.parse_pdf(fc.col("path"), page_separator="--- PAGE {page} ---")` —
   pass `page_separator` (the `{page}` placeholder is filled per page) when you
   want page breaks; omit it and pages run together.
+- **Local install extras:** `fc.semantic.parse_pdf` and
+  `session.read.pdf_metadata` need `fenic[pdf]`;
+  `df.semantic.with_cluster_labels` needs `fenic[cluster]`;
+  `df.semantic.sim_join` needs `fenic[sim-join]`.
 
 ## 4. ⚠️ The 4 traps `fenic check` can't catch
 

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ cython_debug/
 # fenic specific
 *.duckdb
 *.duckdb.wal
+.codegraph
 
 # Intellij
 .idea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ PySpark/pandas intuition. _(Developing fenic itself? See `CLAUDE.md`.)_
 - **Semantic templates use Jinja2 `{{ var }}` + matching column kwargs:**
   `fc.semantic.predicate("... {{ x }} ...", x=fc.col("x"))`. `parse_pdf` is
   **`fc.semantic.parse_pdf`** (under `semantic`, not `markdown`).
+- **Local extras for heavier operators:** `fc.semantic.parse_pdf` and
+  `session.read.pdf_metadata` need `fenic[pdf]`;
+  `df.semantic.with_cluster_labels` needs `fenic[cluster]`;
+  `df.semantic.sim_join` needs `fenic[sim-join]`.
 
 ## Traps `fenic check` can't catch — get these right by hand
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance Improvements
+
+* reduce the default install footprint by moving PDF parsing, clustering, and similarity join dependencies behind opt-in `pdf`, `cluster`, and `sim-join` extras
+
 ## [0.10.0](https://github.com/typedef-ai/fenic/compare/v0.9.0...v0.10.0) (2026-06-25)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,29 @@ just preview-docs
 uv run --group docs mkdocs serve
 ```
 
+#### Measuring Install Footprint
+
+To compare the installed size of fenic with different extras, run:
+
+```bash
+uv run --env-file .env python tools/package_size_matrix.py
+```
+
+The tool creates temporary `uv` projects that depend on the local checkout, syncs each
+project, and reports the resulting `site-packages` and `.venv` sizes along with the
+largest installed distributions. By default it measures `core`, `pdf`, `cluster`,
+`sim-join`, and `pdf,cluster,sim-join`.
+
+To choose a custom matrix:
+
+```bash
+uv run --env-file .env python tools/package_size_matrix.py \
+  --combo core \
+  --combo google \
+  --combo google,pdf \
+  --combo pdf,cluster,sim-join
+```
+
 ---
 
 ## ✅ Running Tests

--- a/PYPI.rst
+++ b/PYPI.rst
@@ -4,3 +4,17 @@ fenic: The dataframe (re)built for LLM inference
 fenic is an opinionated, PySpark-inspired DataFrame framework for building AI and agentic applications. Transform unstructured and structured data into insights using familiar DataFrame operations enhanced with semantic intelligence. With first-class support for markdown, transcripts, and semantic operators, plus efficient batch inference across any model provider.
 
 See `github.com/typedef-ai/fenic <https://www.github.com/typedef-ai/fenic>`_ for more information
+
+Install optional feature extras only when you need heavier operators:
+
+.. code-block:: bash
+
+   pip install "fenic[pdf]"       # semantic.parse_pdf and PDF metadata loading
+   pip install "fenic[cluster]"   # DataFrame.semantic.with_cluster_labels
+   pip install "fenic[sim-join]"  # semantic.sim_join
+
+Extras can be combined with model provider extras, for example:
+
+.. code-block:: bash
+
+   pip install "fenic[google,pdf,cluster,sim-join]"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ The point is a shift in what your data work _produces_. Humans and agents work o
 pip install fenic
 ```
 
+Optional feature extras install heavier dependencies only when you need them:
+
+```bash
+pip install "fenic[pdf]"       # semantic.parse_pdf and PDF metadata loading
+pip install "fenic[cluster]"   # DataFrame.semantic.with_cluster_labels
+pip install "fenic[sim-join]"  # semantic.sim_join
+```
+
+Extras can be combined with model provider extras, for example:
+
+```bash
+pip install "fenic[google,pdf,cluster,sim-join]"
+```
+
 > **Writing fenic with an AI coding agent?** Run `fenic skill install` so Claude Code / Cursor / Codex write it correctly, and `fenic check` to lint it — [details below](#writing-fenic-with-an-ai-coding-agent).
 
 ---
@@ -325,6 +339,20 @@ Because everything is a typed plan, you can see exactly what happened:
 ```python
 result = df.lineage()
 result.backwards(["<row-id>"])   # which source rows produced this output?
+```
+
+Install optional feature extras when you use heavier operators:
+
+| Extra      | Enables                                       |
+| ---------- | --------------------------------------------- |
+| `pdf`      | `semantic.parse_pdf` and PDF metadata loading |
+| `cluster`  | `DataFrame.semantic.with_cluster_labels`      |
+| `sim-join` | `DataFrame.semantic.sim_join`                 |
+
+```bash
+pip install "fenic[pdf,cluster,sim-join]"
+# or
+uv add "fenic[pdf,cluster,sim-join]"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ The point is a shift in what your data work _produces_. Humans and agents work o
 pip install fenic
 ```
 
-Optional feature extras install heavier dependencies only when you need them:
-
-```bash
-pip install "fenic[pdf]"       # semantic.parse_pdf and PDF metadata loading
-pip install "fenic[cluster]"   # DataFrame.semantic.with_cluster_labels
-pip install "fenic[sim-join]"  # semantic.sim_join
-```
-
-Extras can be combined with model provider extras, for example:
-
-```bash
-pip install "fenic[google,pdf,cluster,sim-join]"
-```
-
 > **Writing fenic with an AI coding agent?** Run `fenic skill install` so Claude Code / Cursor / Codex write it correctly, and `fenic check` to lint it — [details below](#writing-fenic-with-an-ai-coding-agent).
 
 ---
@@ -341,6 +327,10 @@ result = df.lineage()
 result.backwards(["<row-id>"])   # which source rows produced this output?
 ```
 
+---
+
+## Optional Feature Extras
+
 Install optional feature extras when you use heavier operators:
 
 | Extra      | Enables                                       |
@@ -353,6 +343,12 @@ Install optional feature extras when you use heavier operators:
 pip install "fenic[pdf,cluster,sim-join]"
 # or
 uv add "fenic[pdf,cluster,sim-join]"
+```
+
+Extras can be combined with model provider extras, for example:
+
+```bash
+pip install "fenic[google,pdf,cluster,sim-join]"
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,20 @@ fenic supports Python `[3.10, 3.11, 3.12]`
 pip install fenic
 ```
 
+Install optional feature extras when you need operators with heavier dependencies:
+
+```bash
+pip install "fenic[pdf]"       # semantic.parse_pdf and PDF metadata loading
+pip install "fenic[cluster]"   # DataFrame.semantic.with_cluster_labels
+pip install "fenic[sim-join]"  # semantic.sim_join
+```
+
+Extras can be combined with model provider extras:
+
+```bash
+pip install "fenic[google,pdf,cluster,sim-join]"
+```
+
 ### LLM Provider Setup
 
 fenic requires an API key from at least one LLM provider. Set the appropriate environment variable for your chosen provider:

--- a/examples/feedback_clustering/README.md
+++ b/examples/feedback_clustering/README.md
@@ -173,6 +173,9 @@ config = fc.SessionConfig(
 # Ensure you have OpenAI API key configured
 export OPENAI_API_KEY="your-api-key"
 
+# Install the clustering extra for semantic.with_cluster_labels
+pip install "fenic[cluster]"
+
 # Run the feedback clustering analysis
 python feedback_clustering.py
 ```

--- a/examples/feedback_clustering/feedback_clustering.ipynb
+++ b/examples/feedback_clustering/feedback_clustering.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "!pip uninstall -y sklearn-compat ibis-framework imbalanced-learn\n",
-    "!pip install fenic matplotlib seaborn polars==1.30.0"
+    "!pip install \"fenic[cluster]\" matplotlib seaborn polars==1.30.0"
    ]
   },
   {

--- a/examples/fenic_in_120_seconds/03_semantic_similarity_joins.ipynb
+++ b/examples/fenic_in_120_seconds/03_semantic_similarity_joins.ipynb
@@ -27,11 +27,11 @@
     "!pip uninstall -y sklearn-compat ibis-framework imbalanced-learn google-genai\n",
     "!pip install polars==1.30.0\n",
     "# === GOOGLE GEMINI ===\n",
-    "#!pip install fenic[google]\n",
+    "#!pip install \"fenic[google,sim-join]\"\n",
     "# === ANTHROPIC CLAUDE ===\n",
-    "#!pip install fenic[anthropic]\n",
+    "#!pip install \"fenic[anthropic,sim-join]\"\n",
     "# === OPENAI (Default) ===\n",
-    "!pip install fenic"
+    "!pip install \"fenic[sim-join]\""
    ]
   },
   {

--- a/examples/fenic_in_120_seconds/18_pdf_processing.ipynb
+++ b/examples/fenic_in_120_seconds/18_pdf_processing.ipynb
@@ -132,11 +132,11 @@
         "!pip install polars==1.30.0\n",
         "!pip install huggingface_hub\n",
         "# === GOOGLE GEMINI ===\n",
-        "!pip install \"fenic[google]\"\n",
+        "!pip install \"fenic[google,pdf]\"\n",
         "# === ANTHROPIC CLAUDE ===\n",
-        "#!pip install fenic[anthropic]\n",
+        "#!pip install \"fenic[anthropic,pdf]\"\n",
         "# === OPENAI (Default) ===\n",
-        "#!pip install \"fenic[google]\"\n"
+        "#!pip install \"fenic[pdf]\"\n"
       ]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ Issues = "https://github.com/typedef-ai/fenic/issues"
 [dependency-groups]
 dev = [
   "pytest>=8.3.5",
-  "pytest-asyncio>=1.4.0",
   "maturin>=1.8.6",
   "requests>=2.32.0",
   "ipykernel>=6.29.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,19 +25,17 @@ dependencies = [
   "duckdb>=1.1.3,<1.5",
   "numpy>=2.0.0",
   "polars>=1.34.0,<1.36.0",
+  "pyarrow<23.0.2,>=23.0.1",
   "tiktoken>=0.11.0",
-  "lancedb>=0.22.0,<0.25.0",
   "openai>=1.101.0",
   "sqlglot>=29.0.1,<31.0.0",
   "pandas>=2.2.2",
   "cloudpickle>=3.1.1",
   "jinja2>=3.1.6",
-  "scikit-learn>=1.7.1",
   "protobuf>=5.29.5",
   "types-protobuf>=5.29.1.20250403",
   "zstandard>=0.23.0",
   "json-schema-to-pydantic>=0.4.1",
-  "pymupdf>=1.26.4",
 ]
 
 [project.urls]
@@ -50,6 +48,9 @@ dev = [
   "maturin>=1.8.6",
   "requests>=2.32.0",
   "ipykernel>=6.29.0",
+  "lancedb>=0.22.0,<0.25.0",
+  "pymupdf>=1.26.4",
+  "scikit-learn>=1.7.1",
 ]
 docs = [
   "mike>=2.1.3",
@@ -64,6 +65,9 @@ docs = [
 anthropic = ["anthropic>=0.106.0"]
 google = ["google-genai[local-tokenizer]>=1.56.0"]
 cohere = ["cohere>=5.16.1"]
+cluster = ["scikit-learn>=1.7.1"]
+pdf = ["pymupdf>=1.26.4"]
+sim-join = ["lancedb>=0.22.0,<0.25.0"]
 cloud = [
   "pyarrow<23.0.2,>=23.0.1",
   "grpcio>=1.60.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Issues = "https://github.com/typedef-ai/fenic/issues"
 [dependency-groups]
 dev = [
   "pytest>=8.3.5",
+  "pytest-asyncio>=1.4.0",
   "maturin>=1.8.6",
   "requests>=2.32.0",
   "ipykernel>=6.29.0",

--- a/src/fenic/_backends/local/physical_plan/join.py
+++ b/src/fenic/_backends/local/physical_plan/join.py
@@ -7,7 +7,6 @@ import polars as pl
 
 from fenic._backends.local.lineage import OperatorLineage
 from fenic._backends.local.semantic_operators import Join as SemanticJoin
-from fenic._backends.local.semantic_operators import SimJoin as SemanticSimJoin
 from fenic._backends.local.semantic_operators.sim_join import (
     DISTANCE_COL_NAME,
     LEFT_ON_COL_NAME,
@@ -259,6 +258,10 @@ class SemanticSimilarityJoinExec(PhysicalPlan):
         )
 
         # TODO(rohitrastogi): Avoid regenerating embeddings if semantic index already exists
+        from fenic._backends.local.semantic_operators.sim_join import (
+            SimJoin as SemanticSimJoin,
+        )
+
         result = SemanticSimJoin(
             left_df,
             right_df,

--- a/src/fenic/_backends/local/physical_plan/transform.py
+++ b/src/fenic/_backends/local/physical_plan/transform.py
@@ -10,7 +10,6 @@ import polars as pl
 
 from fenic._backends.local.lineage import OperatorLineage
 from fenic._backends.local.physical_plan.utils import apply_ingestion_coercions
-from fenic._backends.local.semantic_operators.cluster import Cluster
 from fenic.core._logical_plan.plans import CacheInfo, CentroidInfo
 from fenic.core.error import ExecutionError, InternalError
 
@@ -557,6 +556,8 @@ class SemanticClusterExec(PhysicalPlan):
         child_df = child_df.with_columns(self.by_expr.alias(self.by_expr_name))
 
         # Perform clustering and add cluster metadata columns
+        from fenic._backends.local.semantic_operators.cluster import Cluster
+
         clustered_df = Cluster(
             child_df,
             self.by_expr_name,

--- a/src/fenic/_backends/local/semantic_operators/__init__.py
+++ b/src/fenic/_backends/local/semantic_operators/__init__.py
@@ -2,15 +2,29 @@ from fenic._backends.local.semantic_operators.analyze_sentiment import (
     AnalyzeSentiment,
 )
 from fenic._backends.local.semantic_operators.classify import Classify
-from fenic._backends.local.semantic_operators.cluster import Cluster
 from fenic._backends.local.semantic_operators.extract import Extract
 from fenic._backends.local.semantic_operators.join import Join
 from fenic._backends.local.semantic_operators.map import Map
-from fenic._backends.local.semantic_operators.parse_pdf import ParsePDF
 from fenic._backends.local.semantic_operators.predicate import Predicate
 from fenic._backends.local.semantic_operators.reduce import Reduce
-from fenic._backends.local.semantic_operators.sim_join import SimJoin
 from fenic._backends.local.semantic_operators.summarize import Summarize
+
+
+def __getattr__(name: str):
+    if name == "Cluster":
+        from fenic._backends.local.semantic_operators.cluster import Cluster
+
+        return Cluster
+    if name == "ParsePDF":
+        from fenic._backends.local.semantic_operators.parse_pdf import ParsePDF
+
+        return ParsePDF
+    if name == "SimJoin":
+        from fenic._backends.local.semantic_operators.sim_join import SimJoin
+
+        return SimJoin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "Classify",

--- a/src/fenic/_backends/local/semantic_operators/cluster.py
+++ b/src/fenic/_backends/local/semantic_operators/cluster.py
@@ -4,11 +4,11 @@ from typing import Optional
 import numpy as np
 import polars as pl
 import pyarrow as pa
-from sklearn.cluster import KMeans
 
 from fenic._backends.local.semantic_operators.utils import (
     filter_invalid_embeddings_expr,
 )
+from fenic._optional_dependencies import import_optional_dependency
 from fenic.core._logical_plan.plans import CentroidInfo
 
 logger = logging.getLogger(__name__)
@@ -49,6 +49,11 @@ class Cluster:
 
         centroids = None
         if not valid_df.is_empty():
+            KMeans = import_optional_dependency(
+                "sklearn.cluster",
+                extra="cluster",
+                feature="semantic clustering",
+            ).KMeans
             embeddings = np.stack(valid_df[self.embedding_column_name])
 
             # Using sklearn KMeans with k-means++ initialization (default)

--- a/src/fenic/_backends/local/semantic_operators/parse_pdf.py
+++ b/src/fenic/_backends/local/semantic_operators/parse_pdf.py
@@ -2,7 +2,6 @@ import logging
 from textwrap import dedent
 from typing import List, Optional, Tuple
 
-import fitz
 import jinja2
 import polars as pl
 
@@ -10,9 +9,9 @@ from fenic._backends.local.semantic_operators.base import (
     BaseSingleColumnFilePathOperator,
     CompletionOnlyRequestSender,
 )
-from fenic._backends.local.utils.doc_loader import DocFolderLoader
 from fenic._inference.language_model import InferenceConfiguration, LanguageModel
 from fenic._inference.types import LMRequestFile, LMRequestMessages
+from fenic._optional_dependencies import import_optional_dependency
 from fenic.core._inference.model_catalog import ModelProvider
 from fenic.core._logical_plan.resolved_types import ResolvedModelAlias
 
@@ -58,6 +57,8 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
         self.model = model
         self.model_alias = model_alias
         self.max_output_tokens = max_output_tokens
+
+        from fenic._backends.local.utils.doc_loader import DocFolderLoader
 
         DocFolderLoader.check_file_extensions(input.to_list(), "pdf")
 
@@ -143,6 +144,11 @@ class ParsePDF(BaseSingleColumnFilePathOperator[str, str]):
             List of LMRequestFile objects
             List of (start_page, end_page) tuples (inclusive, 0-indexed)
         """
+        fitz = import_optional_dependency(
+            "fitz",
+            extra="pdf",
+            feature="PDF parsing",
+        )
         chunks = []
         range_start_page = 0
         range_tokens = 0

--- a/src/fenic/_backends/local/semantic_operators/sim_join.py
+++ b/src/fenic/_backends/local/semantic_operators/sim_join.py
@@ -1,16 +1,19 @@
 import os
 import tempfile
 import uuid
+from typing import TYPE_CHECKING
 
-import lancedb
 import polars as pl
-from lancedb.db import DBConnection, Table
 
 from fenic._backends.local.semantic_operators.utils import (
     filter_invalid_embeddings_expr,
 )
 from fenic._constants import VECTOR_INDEX_DIR
+from fenic._optional_dependencies import import_optional_dependency
 from fenic.core.types.enums import SemanticSimilarityMetric
+
+if TYPE_CHECKING:
+    from lancedb.db import DBConnection, Table
 
 # LanceDB column names
 DISTANCE_COL_NAME = "_distance"
@@ -75,6 +78,11 @@ class SimJoin:
     ) -> pl.DataFrame:
         os.makedirs(VECTOR_INDEX_DIR, exist_ok=True)
         table_name = uuid.uuid4().hex
+        lancedb = import_optional_dependency(
+            "lancedb",
+            extra="sim-join",
+            feature="semantic similarity joins",
+        )
         with tempfile.TemporaryDirectory(
             prefix="sim_join_", dir=VECTOR_INDEX_DIR
         ) as lance_table_dir:

--- a/src/fenic/_backends/local/transpiler/expr_converter.py
+++ b/src/fenic/_backends/local/transpiler/expr_converter.py
@@ -26,7 +26,6 @@ from fenic._backends.local.semantic_operators import (
 from fenic._backends.local.semantic_operators import Classify as SemanticClassify
 from fenic._backends.local.semantic_operators import Extract as SemanticExtract
 from fenic._backends.local.semantic_operators import Map as SemanticMap
-from fenic._backends.local.semantic_operators import ParsePDF as SemanticParsePDF
 from fenic._backends.local.semantic_operators import Predicate as SemanticPredicate
 from fenic._backends.local.semantic_operators import Reduce as SemanticReduce
 from fenic._backends.local.semantic_operators import Summarize as SemanticSummarize
@@ -773,6 +772,10 @@ class ExprConverter:
     @_convert_expr.register(SemanticParsePDFExpr)
     def _convert_parse_pdf_expr(self, logical: SemanticParsePDFExpr) -> pl.Expr:
         def parse_pdf_fn(batch: pl.Series) -> pl.Series:
+            from fenic._backends.local.semantic_operators.parse_pdf import (
+                ParsePDF as SemanticParsePDF,
+            )
+
             return SemanticParsePDF(
                 input=batch,
                 model=self.session_state.get_language_model(logical.model_alias),

--- a/src/fenic/_backends/local/utils/doc_loader.py
+++ b/src/fenic/_backends/local/utils/doc_loader.py
@@ -8,10 +8,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import List, Literal, Optional, Tuple
 
-import fitz  # PyMuPDF
 import polars as pl
 
 from fenic._backends.local.utils.io_utils import PathScheme, get_path_scheme
+from fenic._optional_dependencies import import_optional_dependency
 from fenic.core._utils.schema import convert_custom_schema_to_polars_schema
 from fenic.core.error import FileLoaderError, ValidationError
 from fenic.core.types import ColumnField, Schema
@@ -367,7 +367,12 @@ class DocFolderLoader:
         
         path_scheme = get_path_scheme(file_path)
         logger.debug(f"Processing PDF: {file_path} - {path_scheme}")
-        
+        fitz = import_optional_dependency(
+            "fitz",
+            extra="pdf",
+            feature="PDF document loading",
+        )
+
         # Initialize the flat result dict with default values
         result = {
             "file_path": file_path,

--- a/src/fenic/_inference/request_utils.py
+++ b/src/fenic/_inference/request_utils.py
@@ -5,11 +5,11 @@ import hashlib
 import logging
 from typing import Annotated, Optional
 
-import fitz  # PyMuPDF
 from pydantic import BeforeValidator
 
 from fenic._constants import MAX_MODEL_CLIENT_TIMEOUT
 from fenic._inference.types import FenicCompletionsRequest, LMRequestFile
+from fenic._optional_dependencies import import_optional_dependency
 from fenic.core.error import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -93,6 +93,11 @@ def pdf_to_base64(file: LMRequestFile) -> bytes:
             pdf_content = pdf_file.read()
             return base64.b64encode(pdf_content).decode('utf-8')
     else:
+        fitz = import_optional_dependency(
+            "fitz",
+            extra="pdf",
+            feature="PDF request encoding",
+        )
         pdf_chunk = fitz.open(stream=file.pdf_chunk_bytes, filetype="pdf")
         pdf_bytes = pdf_chunk.tobytes()
         pdf_chunk.close()
@@ -104,6 +109,11 @@ def get_pdf_page_count(file: LMRequestFile) -> int:
 
 def get_pdf_text(file: LMRequestFile) -> str:
     """Extract text content from a PDF file."""
+    fitz = import_optional_dependency(
+        "fitz",
+        extra="pdf",
+        feature="PDF text extraction",
+    )
     text_content = []
     # Open the PDF
     if file.pdf_chunk_bytes is None:

--- a/src/fenic/_optional_dependencies.py
+++ b/src/fenic/_optional_dependencies.py
@@ -1,0 +1,22 @@
+"""Helpers for loading optional dependencies with actionable errors."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
+def import_optional_dependency(
+    module_name: str,
+    *,
+    extra: str,
+    feature: str,
+) -> ModuleType:
+    """Import an optional dependency or raise an install hint for the feature."""
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"To use {feature}, install the '{extra}' extra: "
+            f"pip install \"fenic[{extra}]\""
+        ) from exc

--- a/src/fenic/api/dataframe/semantic_extensions.py
+++ b/src/fenic/api/dataframe/semantic_extensions.py
@@ -51,6 +51,9 @@ class SemanticExtensions:
         It adds a new column with cluster assignments, and optionally includes the centroid embedding
         for each assigned cluster.
 
+        Note:
+            Local execution requires the `cluster` extra: `pip install "fenic[cluster]"`.
+
         Args:
             by: Column or expression producing embeddings to cluster (e.g., `embed(col("text"))`).
             num_clusters: Number of clusters to compute (must be > 0).
@@ -277,6 +280,9 @@ class SemanticExtensions:
 
         For each row in the left DataFrame, returns the top `k` most semantically similar rows
         from the right DataFrame based on the specified similarity metric.
+
+        Note:
+            Local execution requires the `sim-join` extra: `pip install "fenic[sim-join]"`.
 
         Args:
             other: The right-hand DataFrame to join with.

--- a/src/fenic/api/functions/semantic.py
+++ b/src/fenic/api/functions/semantic.py
@@ -616,11 +616,14 @@ def parse_pdf(
     column: ColumnOrName,
     model_alias: Optional[Union[str, ModelAlias]] = None,
     page_separator: Optional[str] = None,
-	describe_images: bool = False,  # for images that aren't tables
-	max_output_tokens: Optional[int] = None,
-	request_timeout: TimeoutParam = None,
+    describe_images: bool = False,  # for images that aren't tables
+    max_output_tokens: Optional[int] = None,
+    request_timeout: TimeoutParam = None,
 ) -> Column:
     r"""Parses a column of PDF paths into markdown.
+
+    Note:
+        Local execution requires the `pdf` extra: `pip install "fenic[pdf]"`.
 
     Returns:
         Dataframe: a dataframe with markdown strings for each PDF file.

--- a/src/fenic/api/io/reader.py
+++ b/src/fenic/api/io/reader.py
@@ -319,6 +319,9 @@ class DataFrameReader:
     ) -> DataFrame:
         r"""Load a DataFrame with metadata of PDF files in a list of paths.
 
+        Note:
+            Local execution requires the `pdf` extra: `pip install "fenic[pdf]"`.
+
         Args:
             paths: Glob pattern (or list of glob patterns) to the folder(s) to load.
             exclude: A regex pattern to exclude files.

--- a/tests/test_optional_extras.py
+++ b/tests/test_optional_extras.py
@@ -1,0 +1,72 @@
+import subprocess
+import sys
+import textwrap
+
+
+def _run_with_blocked_modules(blocked_modules: list[str], body: str):
+    code = f"""
+import importlib.abc
+import sys
+
+blocked = {blocked_modules!r}
+
+
+class Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if any(fullname == name or fullname.startswith(name + ".") for name in blocked):
+            raise ModuleNotFoundError(f"No module named {{fullname!r}}", name=fullname)
+        return None
+
+
+sys.meta_path.insert(0, Blocker())
+
+{textwrap.dedent(body)}
+"""
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_fenic_imports_without_pdf_cluster_or_sim_join_extras():
+    _run_with_blocked_modules(
+        ["fitz", "lancedb", "sklearn"],
+        """
+import fenic
+import fenic._backends.local.physical_plan.join
+import fenic._backends.local.physical_plan.transform
+import fenic._backends.local.semantic_operators.cluster
+import fenic._backends.local.semantic_operators.parse_pdf
+import fenic._backends.local.semantic_operators.sim_join
+import fenic._backends.local.utils.doc_loader
+import fenic._inference.request_utils
+
+assert fenic.Session
+""",
+    )
+
+
+def test_optional_dependency_errors_include_extra_install_hint():
+    result = _run_with_blocked_modules(
+        ["fitz", "lancedb", "sklearn"],
+        """
+from fenic._optional_dependencies import import_optional_dependency
+
+checks = [
+    ("fitz", "pdf", "PDF parsing", "fenic[pdf]"),
+    ("lancedb", "sim-join", "semantic similarity joins", "fenic[sim-join]"),
+    ("sklearn.cluster", "cluster", "semantic clustering", "fenic[cluster]"),
+]
+
+for module_name, extra, feature, expected in checks:
+    try:
+        import_optional_dependency(module_name, extra=extra, feature=feature)
+    except ImportError as exc:
+        assert expected in str(exc)
+    else:
+        raise AssertionError(f"{module_name} unexpectedly imported")
+""",
+    )
+    assert result.returncode == 0

--- a/tests/test_package_size_matrix.py
+++ b/tests/test_package_size_matrix.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_package_size_matrix():
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "package_size_matrix.py"
+    spec = importlib.util.spec_from_file_location("package_size_matrix", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_combo_handles_core_explicit_extras_and_all():
+    package_size_matrix = _load_package_size_matrix()
+
+    assert package_size_matrix.parse_combo("core", ["pdf"]) == ("core", [])
+    assert package_size_matrix.parse_combo("pdf, cluster", ["cloud", "pdf"]) == (
+        "pdf,cluster",
+        ["pdf", "cluster"],
+    )
+    assert package_size_matrix.parse_combo("all", ["cloud", "pdf"]) == (
+        "all",
+        ["cloud", "pdf"],
+    )
+
+
+def test_pyproject_for_uses_local_fenic_with_selected_extras(tmp_path):
+    package_size_matrix = _load_package_size_matrix()
+
+    pyproject = package_size_matrix.pyproject_for(
+        tmp_path,
+        ["pdf", "cluster"],
+        "3.11",
+    )
+
+    assert 'requires-python = ">=3.11"' in pyproject
+    assert f'"fenic[pdf,cluster] @ {tmp_path.as_uri()}"' in pyproject
+
+
+def test_write_json_and_csv_include_summary_fields(tmp_path):
+    package_size_matrix = _load_package_size_matrix()
+    result = package_size_matrix.SizeResult(
+        label="pdf",
+        extras=["pdf"],
+        package_count=2,
+        site_packages_bytes=1024,
+        venv_bytes=2048,
+        top_packages=[
+            package_size_matrix.PackageSize(
+                name="fenic",
+                version="1.2.3",
+                bytes=512,
+            )
+        ],
+    )
+
+    json_path = tmp_path / "sizes.json"
+    csv_path = tmp_path / "sizes.csv"
+    package_size_matrix.write_json(json_path, [result])
+    package_size_matrix.write_csv(csv_path, [result])
+
+    assert '"site_packages_bytes": 1024' in json_path.read_text()
+    assert "pdf,pdf,2,1024,2048" in csv_path.read_text()

--- a/tools/package_size_matrix.py
+++ b/tools/package_size_matrix.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Measure installed package footprint for fenic extra combinations.
+
+The harness creates temporary uv projects that depend on this checkout, syncs
+each project, and measures the installed site-packages footprint plus the
+largest installed distributions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - developer harness shells out to uv/du with argument lists.
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from importlib import metadata
+from pathlib import Path
+
+import tomllib
+
+DEFAULT_COMBOS = [
+    "core",
+    "pdf",
+    "cluster",
+    "sim-join",
+    "pdf,cluster,sim-join",
+]
+
+
+@dataclass(frozen=True)
+class PackageSize:
+    name: str
+    version: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class SizeResult:
+    label: str
+    extras: list[str]
+    package_count: int
+    site_packages_bytes: int
+    venv_bytes: int
+    top_packages: list[PackageSize]
+    project_dir: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create temporary uv projects for fenic extra combinations and "
+            "measure the resulting installed package footprint."
+        )
+    )
+    parser.add_argument(
+        "--fenic-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to the fenic checkout to install. Defaults to this repository.",
+    )
+    parser.add_argument(
+        "--combo",
+        action="append",
+        dest="combos",
+        help=(
+            "Extra combination to measure. Use 'core' for no extras, comma-separated "
+            "extras like 'pdf,cluster', or 'all' for every optional dependency."
+        ),
+    )
+    parser.add_argument(
+        "--python",
+        default=f"{sys.version_info.major}.{sys.version_info.minor}",
+        help="Python version passed to uv. Defaults to the interpreter running this tool.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=8,
+        help="Number of largest distributions to show for each combination.",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="Write machine-readable results to this path.",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        help="Write a CSV summary to this path.",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep temporary projects after measuring and include their paths in output.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the generated pyproject.toml for each combination without syncing.",
+    )
+    parser.add_argument(
+        "--uv",
+        default="uv",
+        help="uv executable to run.",
+    )
+    return parser.parse_args()
+
+
+def load_optional_extras(fenic_root: Path) -> list[str]:
+    with (fenic_root / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    return sorted(pyproject["project"].get("optional-dependencies", {}))
+
+
+def parse_combo(combo: str, all_extras: list[str]) -> tuple[str, list[str]]:
+    label = combo.strip()
+    if not label or label == "core":
+        return "core", []
+    if label == "all":
+        return "all", all_extras
+    extras = [extra.strip() for extra in label.split(",") if extra.strip()]
+    if not extras:
+        return "core", []
+    return ",".join(extras), extras
+
+
+def dependency_spec(fenic_root: Path, extras: list[str]) -> str:
+    root_uri = fenic_root.resolve().as_uri()
+    if extras:
+        return f"fenic[{','.join(extras)}] @ {root_uri}"
+    return f"fenic @ {root_uri}"
+
+
+def pyproject_for(fenic_root: Path, extras: list[str], python_version: str) -> str:
+    dependency = dependency_spec(fenic_root, extras)
+    return f"""[project]
+name = "fenic-size-probe"
+version = "0.0.0"
+requires-python = ">={python_version}"
+dependencies = [
+  "{dependency}",
+]
+"""
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(  # nosec B603 - command is passed as an argument list.
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = "\n".join(
+            [
+                f"command failed in {cwd}: {' '.join(command)}",
+                result.stdout.strip(),
+                result.stderr.strip(),
+            ]
+        ).strip()
+        raise RuntimeError(message)
+    return result
+
+
+def venv_python(project_dir: Path) -> Path:
+    if sys.platform == "win32":
+        return project_dir / ".venv" / "Scripts" / "python.exe"
+    return project_dir / ".venv" / "bin" / "python"
+
+
+def site_packages_path(project_dir: Path, env: dict[str, str]) -> Path:
+    code = (
+        "import json, site; "
+        "print(json.dumps([p for p in site.getsitepackages() if p.endswith('site-packages')][0]))"
+    )
+    result = run([str(venv_python(project_dir)), "-c", code], cwd=project_dir, env=env)
+    return Path(json.loads(result.stdout))
+
+
+def directory_size_bytes(path: Path) -> int:
+    du = shutil.which("du")
+    if du:
+        result = subprocess.run(  # nosec B603 - du path comes from shutil.which and args are fixed.
+            [du, "-sk", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.split()[0]) * 1024
+
+    total = 0
+    for child in path.rglob("*"):
+        if child.is_file():
+            total += child.stat().st_size
+    return total
+
+
+def distribution_size_bytes(dist: metadata.Distribution) -> int:
+    files = dist.files
+    if files is None:
+        return 0
+
+    total = 0
+    seen: set[Path] = set()
+    for package_path in files:
+        path = Path(dist.locate_file(package_path))
+        if path in seen or not path.exists() or not path.is_file():
+            continue
+        seen.add(path)
+        total += path.stat().st_size
+    return total
+
+
+def installed_packages(site_packages: Path) -> list[PackageSize]:
+    packages = []
+    for dist in metadata.distributions(path=[str(site_packages)]):
+        name = dist.metadata.get("Name") or "unknown"
+        version = dist.version or ""
+        packages.append(
+            PackageSize(
+                name=name,
+                version=version,
+                bytes=distribution_size_bytes(dist),
+            )
+        )
+    return sorted(packages, key=lambda package: package.bytes, reverse=True)
+
+
+def measure_combo(
+    *,
+    label: str,
+    extras: list[str],
+    fenic_root: Path,
+    python_version: str,
+    top: int,
+    uv: str,
+    keep: bool,
+    dry_run: bool,
+    env: dict[str, str],
+) -> SizeResult | None:
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"fenic-size-{label.replace(',', '-')}-"))
+    pyproject = pyproject_for(fenic_root, extras, python_version)
+    (temp_dir / "pyproject.toml").write_text(pyproject)
+
+    if dry_run:
+        print(f"# {label}: {temp_dir / 'pyproject.toml'}")
+        print(pyproject)
+        if not keep:
+            shutil.rmtree(temp_dir)
+        return None
+
+    run(
+        [
+            uv,
+            "sync",
+            "--no-dev",
+            "--no-install-project",
+            "--no-progress",
+            "--python",
+            python_version,
+        ],
+        cwd=temp_dir,
+        env=env,
+    )
+
+    site_packages = site_packages_path(temp_dir, env)
+    packages = installed_packages(site_packages)
+    result = SizeResult(
+        label=label,
+        extras=extras,
+        package_count=len(packages),
+        site_packages_bytes=directory_size_bytes(site_packages),
+        venv_bytes=directory_size_bytes(temp_dir / ".venv"),
+        top_packages=packages[:top],
+        project_dir=str(temp_dir) if keep else None,
+    )
+
+    if not keep:
+        shutil.rmtree(temp_dir)
+    return result
+
+
+def format_bytes(size: int) -> str:
+    value = float(size)
+    for unit in ["B", "KiB", "MiB", "GiB"]:
+        if value < 1024 or unit == "GiB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    raise AssertionError("unreachable")
+
+
+def print_table(results: list[SizeResult]) -> None:
+    if not results:
+        return
+
+    baseline = results[0].site_packages_bytes
+    rows = []
+    for result in results:
+        delta = result.site_packages_bytes - baseline
+        top = ", ".join(
+            f"{package.name} {format_bytes(package.bytes)}"
+            for package in result.top_packages
+        )
+        rows.append(
+            [
+                result.label,
+                str(result.package_count),
+                format_bytes(result.site_packages_bytes),
+                f"{delta / 1024 / 1024:+.1f} MiB",
+                format_bytes(result.venv_bytes),
+                top,
+            ]
+        )
+
+    headers = ["combo", "packages", "site-packages", "delta", ".venv", "top packages"]
+    widths = [
+        max(len(row[index]) for row in [headers, *rows])
+        for index in range(len(headers))
+    ]
+    print("  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)))
+    print("  ".join("-" * width for width in widths))
+    for row in rows:
+        print("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
+
+
+def write_json(path: Path, results: list[SizeResult]) -> None:
+    payload = [
+        {
+            **asdict(result),
+            "top_packages": [asdict(package) for package in result.top_packages],
+        }
+        for result in results
+    ]
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def write_csv(path: Path, results: list[SizeResult]) -> None:
+    with path.open("w", newline="") as csv_file:
+        writer = csv.DictWriter(
+            csv_file,
+            fieldnames=[
+                "combo",
+                "extras",
+                "package_count",
+                "site_packages_bytes",
+                "venv_bytes",
+                "top_packages",
+                "project_dir",
+            ],
+        )
+        writer.writeheader()
+        for result in results:
+            writer.writerow(
+                {
+                    "combo": result.label,
+                    "extras": ",".join(result.extras),
+                    "package_count": result.package_count,
+                    "site_packages_bytes": result.site_packages_bytes,
+                    "venv_bytes": result.venv_bytes,
+                    "top_packages": "; ".join(
+                        f"{package.name}:{package.bytes}"
+                        for package in result.top_packages
+                    ),
+                    "project_dir": result.project_dir or "",
+                }
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    fenic_root = args.fenic_root.resolve()
+    all_extras = load_optional_extras(fenic_root)
+    combos = args.combos or DEFAULT_COMBOS
+    env = os.environ.copy()
+    env["UV_PROJECT_ENVIRONMENT"] = ".venv"
+
+    results = []
+    for combo in combos:
+        label, extras = parse_combo(combo, all_extras)
+        print(f"measuring {label}...", file=sys.stderr)
+        result = measure_combo(
+            label=label,
+            extras=extras,
+            fenic_root=fenic_root,
+            python_version=args.python,
+            top=args.top,
+            uv=args.uv,
+            keep=args.keep,
+            dry_run=args.dry_run,
+            env=env,
+        )
+        if result is not None:
+            results.append(result)
+
+    print_table(results)
+    if args.json:
+        write_json(args.json, results)
+    if args.csv:
+        write_csv(args.csv, results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -763,7 +763,6 @@ dependencies = [
     { name = "duckdb" },
     { name = "jinja2" },
     { name = "json-schema-to-pydantic" },
-    { name = "lancedb" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -772,9 +771,7 @@ dependencies = [
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "polars" },
     { name = "protobuf" },
-    { name = "pymupdf" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
     { name = "sqlglot" },
     { name = "tiktoken" },
     { name = "types-protobuf" },
@@ -791,6 +788,10 @@ cloud = [
     { name = "pyarrow" },
     { name = "pydantic-settings" },
 ]
+cluster = [
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 cohere = [
     { name = "cohere" },
 ]
@@ -803,13 +804,23 @@ google = [
 mcp = [
     { name = "fastmcp" },
 ]
+pdf = [
+    { name = "pymupdf" },
+]
+sim-join = [
+    { name = "lancedb" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "lancedb" },
     { name = "maturin" },
+    { name = "pymupdf" },
     { name = "pytest" },
     { name = "requests" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 docs = [
     { name = "mike" },
@@ -834,30 +845,34 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'cloud'", specifier = ">=1.60.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.1" },
-    { name = "lancedb", specifier = ">=0.22.0,<0.25.0" },
+    { name = "lancedb", marker = "extra == 'sim-join'", specifier = ">=0.22.0,<0.25.0" },
     { name = "markdown-it-py", marker = "extra == 'eval'", specifier = ">=4.0.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "openai", specifier = ">=1.101.0" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "polars", specifier = ">=1.34.0,<1.36.0" },
     { name = "protobuf", specifier = ">=5.29.5" },
+    { name = "pyarrow", specifier = ">=23.0.1,<23.0.2" },
     { name = "pyarrow", marker = "extra == 'cloud'", specifier = ">=23.0.1,<23.0.2" },
     { name = "pydantic-settings", marker = "extra == 'cloud'" },
-    { name = "pymupdf", specifier = ">=1.26.4" },
-    { name = "scikit-learn", specifier = ">=1.7.1" },
+    { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.26.4" },
+    { name = "scikit-learn", marker = "extra == 'cluster'", specifier = ">=1.7.1" },
     { name = "sqlglot", specifier = ">=29.0.1,<31.0.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "types-protobuf", specifier = ">=5.29.1.20250403" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]
-provides-extras = ["anthropic", "google", "cohere", "cloud", "mcp", "eval"]
+provides-extras = ["anthropic", "google", "cohere", "cluster", "pdf", "sim-join", "cloud", "mcp", "eval"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.0" },
+    { name = "lancedb", specifier = ">=0.22.0,<0.25.0" },
     { name = "maturin", specifier = ">=1.8.6" },
+    { name = "pymupdf", specifier = ">=1.26.4" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "requests", specifier = ">=2.32.0" },
+    { name = "scikit-learn", specifier = ">=1.7.1" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -147,15 +147,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -827,7 +818,6 @@ dev = [
     { name = "maturin" },
     { name = "pymupdf" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "requests" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -881,7 +871,6 @@ dev = [
     { name = "maturin", specifier = ">=1.8.6" },
     { name = "pymupdf", specifier = ">=1.26.4" },
     { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
 ]
@@ -2798,20 +2787,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -818,6 +827,7 @@ dev = [
     { name = "maturin" },
     { name = "pymupdf" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "requests" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -871,6 +881,7 @@ dev = [
     { name = "maturin", specifier = ">=1.8.6" },
     { name = "pymupdf", specifier = ">=1.26.4" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
 ]
@@ -2787,6 +2798,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move PDF parsing, semantic clustering, and semantic similarity joins behind optional extras: `pdf`, `cluster`, and `sim-join`
- Lazy-load `pymupdf`, `scikit-learn`, and `lancedb` at the feature boundary with actionable install hints
- Update README, PyPI/docs, and affected examples/notebooks with the new extra install commands
- Add a `tools/package_size_matrix.py` harness for measuring installed footprint across extras combinations

## Size Matrix
Measured with `uv run --env-file .env python tools/package_size_matrix.py` on this branch:

```text
core                  404.8 MiB
pdf                   456.1 MiB  +51.4 MiB
cluster               509.5 MiB  +104.8 MiB
sim-join              480.2 MiB  +75.4 MiB
pdf,cluster,sim-join  636.4 MiB  +231.6 MiB
```

## Validation
- `uv run --env-file .env pytest tests/test_optional_extras.py tests/_backends/local/semantic_operators/test_parse_pdf.py -q`
- `uv run --env-file .env pytest tests/_backends/local/dataframe/test_semantic_sim_join.py tests/_backends/local/dataframe/test_semantic_cluster.py -q`
- `uv run --env-file .env pytest tests/test_package_size_matrix.py -q`
- `trunk check --fix`