### PR TITLE
docs: rewrite README around semantic DataFrames framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 It's a DataFrame query engine for semantic data processing, with AI operators — `extract`, `classify`, `summarize`, `embed`, semantic `join`, and more — built into the query model. Use it to turn documents, transcripts, logs, eval traces, tickets, tables, and APIs into typed rows and repeatable workflows.
 
-The point is a shift in what your data work _produces_. Humans author, inspect, and validate fenic pipelines. Agents discover, compose, and reuse them. The result isn't a one-off prompt or a brittle regex script that has to be reverse-engineered later — it's a durable artifact: typed, inspectable, rerunnable, and callable.
+The point is a shift in what your data work _produces_. Humans and agents work on the same pipelines — both can author, inspect, and reuse them. The result isn't a one-off prompt or a brittle regex script that has to be reverse-engineered later — it's a durable artifact: typed, inspectable, rerunnable, and callable.
 
 > **From exploration to artifact.**
 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,20 @@
     </picture>
 </div>
 
-# fenic: Declarative context engineering for agents (works with any agent framework)
+# fenic: semantic DataFrames for humans and agents
 
 [![PyPI version](https://img.shields.io/pypi/v/fenic.svg)](https://pypi.org/project/fenic/)
 [![Python versions](https://img.shields.io/pypi/pyversions/fenic.svg)](https://pypi.org/project/fenic/)
 [![License](https://img.shields.io/github/license/typedef-ai/fenic.svg)](https://github.com/typedef-ai/fenic/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1381706122322513952?label=Discord&logo=discord)](https://discord.gg/GdqF3J7huR)
 
-**Apply context ops in Python and SQL (extract, chunk, retrieve, store, compact, summarize) to produce typed, tool-bounded outputs your agents can use.**
+**fenic turns AI-assisted exploration of structured and unstructured data into reusable, inspectable DataFrame pipelines.**
 
-Keep your runtime. Add fenic. Get sophisticated context construction with inference offloading with no framework lock-in and no rewrites.
+It's a DataFrame query engine for semantic data processing, with AI operators — `extract`, `classify`, `summarize`, `embed`, semantic `join`, and more — built into the query model. Use it to turn documents, transcripts, logs, eval traces, tickets, tables, and APIs into typed rows and repeatable workflows.
 
-fenic is a **context construction layer** that works with any agent framework. You declare what your agent should see, build it with deterministic + semantic transforms, and expose it as **typed**, **bounded tools**, while **offloading inference** so context work happens outside your agent's prompt/context window. This reduces context bloat so agents stay focused on reasoning.
+The point is a shift in what your data work *produces*. Humans author, inspect, and validate fenic pipelines. Agents discover, compose, and reuse them. The result isn't a one-off prompt or a brittle regex script that has to be reverse-engineered later — it's a durable artifact: typed, inspectable, rerunnable, and callable.
 
-<p align="center">
-  <b>Quick links:</b>
-  <a href="#what-you-can-build">Use Cases</a> •
-  <a href="#quick-introduction">Intro</a> •
-  <a href="#quickstart-pick-your-path">Quickstart</a> •
-  <a href="#core-concepts">Concepts</a> •
-  <a href="#key-capabilities">Capabilities</a>
-</p>
-
-## Quick Install
+> **From exploration to artifact.**
 
 ```bash
 pip install fenic
@@ -36,857 +27,330 @@ pip install fenic
 
 ---
 
-## What You Can Build
+## What is fenic?
 
-### Memory & Personalization
+fenic is a **semantic DataFrame engine**. You write the PySpark/SQL-style operations you already know — `select`, `filter`, `join`, `group_by`, `agg` — alongside *semantic operators* that call language models as a first-class part of the query. You configure models once on a `Session`, build a pipeline lazily, and fenic compiles and runs it on a query engine built for inference: automatic batching, rate limiting, retries, token/cost accounting, and response caching.
 
-- **Curated memory packs** — extract/dedupe/redact facts; serve read-only for recall
-- **Blocks & episodes** — persistent profile + recent event timeline; scoped snapshots
-- **Decaying resolution memory** — window functions for temporal compression (daily → weekly → monthly)
-- **Cross-agent shared memory** — typed tables accessible by multiple agents in your framework
+Two ideas make it different from gluing an LLM onto pandas:
 
-### Retrieval & Knowledge
-
-- **Policy / KB Q&A** — parse PDFs → `extract(Schema)` → `embed` → neighbors with citations
-- **Chunked retrieval** — chunk/overlap you control, hybrid filter, optional re-rank
-
-### Context Operations (Inference Offloaded)
-
-- **Summarization** — deterministic or LLM-powered, reducing context bloat so agents stay focused on reasoning
-- **Invariant management** — store facts that should persist; re-inject at decision points
-- **Token-budget-aware truncation** — shape tool responses to fit budgets
-- ...and more - fenic's API allows you to define any context operation you might need
-
-### Structured Context from Data
-
-- **Entity matching** — resolve duplicates / link records
-- **Theme extraction** — cluster + label patterns
-- **Semantic linking** — connect records across systems by meaning
-- …and more — fenic's declarative API supports any data transformation your agents need
+- **Inference lives inside the query model.** Extraction, classification, summarization, and embeddings are operators with schemas and types — not side calls you orchestrate by hand.
+- **The pipeline is the artifact.** Because the work is expressed as typed operators, it's already inspectable (row-level lineage, `explain`, per-query metrics), rerunnable (lazy plans + caching), and promotable into a named table, view, or **MCP tool** an agent can call.
 
 ---
 
-## Quick Introduction
+## 60 seconds: messy text → typed rows
 
-Context engineering is the practice of managing everything that goes into an LLM's context window, retrieval, memory, conversation history, tool responses, prompts. It's all tokens in, tokens out. And it's both an **information problem** (what information, in what structure) and an **optimization problem** (how much, when to compress, what to forget).
-
-fenic's declarative approach fits naturally here. Instead of writing imperative code for each context operation, you describe _what_ your context should look like—and iterate quickly as you learn what works. Combine deterministic transforms (filters, aggregations, windows) with semantic ones (extract, embed, summarize) in a single composable flow.
-
-Critically, fenic **offloads inference**: summarization, extraction, and embedding happen outside your agent's context window. Your runtime gets the results with less context bloat, so agents stay focused on reasoning.
-
-> **Note:** LLM calls still cost tokens/$, but fenic keeps that work out of your agent's prompt/context window.
-
-### The fenic Approach
-
-| Without fenic                                             | With fenic                                               |
-| --------------------------------------------------------- | -------------------------------------------------------- |
-| Agent summarizes conversation → tokens consumed           | fenic summarizes → agent gets result; less context bloat |
-| Agent extracts facts → tokens consumed                    | fenic extracts → agent gets structured data              |
-| Agent searches, filters, aggregates → multiple tool calls | fenic pre-computes → agent gets precise rows             |
-| Context ops compete with reasoning                        | Less context bloat → agents stay focused on reasoning    |
-
-### Example: PDF → Typed Q&A → Bounded Tools
-
-Build the exact context your agent is allowed to use with typed Q/A facts distilled from policy PDFs, then expose it as a narrow tool surface.
+Replace brittle parsing and one-off prompts with a typed, schema-bound operator. Define the shape you want as a Pydantic model; fenic returns structured columns you can query.
 
 ```python
 import fenic as fc
-from fenic import SemanticConfig, OpenAILanguageModel, OpenAIEmbeddingModel
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
 from pydantic import BaseModel, Field
 
-# 1) Typed schema for extraction
-class FAQSchema(BaseModel):
-    question: str = Field(description="A question extracted from the document")
-    answer: str = Field(description="The answer to the question")
+class Ticket(BaseModel):
+    product: str = Field(description="The product the user is asking about")
+    sentiment: str = Field(description="positive, neutral, or negative")
+    issue: str = Field(description="One-line summary of the user's problem")
 
-session = fc.Session.get_or_create(fc.SessionConfig(
-    app_name="faq_app",
-    semantic=SemanticConfig(
-        language_models={
-            "gpt": OpenAILanguageModel(model_name="gpt-5-nano", rpm=100, tpm=100_000)
-        },
-        embedding_models={
-            "embed": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=100, tpm=100_000)
-        },
-        default_embedding_model="embed"
-    )
-))
-
-# 2) Hydrate → shape with deterministic + semantic transforms
-rows = [
-    {"id": 1, "pdf_path": "data/policies/eu_refund_policy.pdf"},
-    {"id": 2, "pdf_path": "data/policies/password_reset_guide.pdf"},
-]
-df = session.create_dataframe(rows)
-
-ctx = (
-    df.select(
-        fc.col("id"),
-        fc.col("pdf_path"),
-        fc.semantic.parse_pdf(fc.col("pdf_path")).alias("text")  # parse to markdown
-    )
-    .filter(fc.col("text").cast(fc.StringType).contains("policy"))  # deterministic filter
-    .select(
-        fc.col("id"),
-        fc.semantic.extract(fc.col("text").cast(fc.StringType), FAQSchema).alias("facts"),  # typed extraction
-        fc.semantic.embed(fc.col("text").cast(fc.StringType)).alias("vec")                  # embedding
-    )
-    .unnest("facts")  # -> id, question, answer, vec
-)
-
-# 3) Serve as bounded tools (MCP or direct functions)
-ctx.write.save_as_table("faq_context", mode="overwrite")
-
-generated_tools = auto_generate_system_tools_from_tables(
-    ["faq_context"], session, tool_namespace="faq", max_result_limit=100
-)
-
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=generated_tools,
-    server_name="FAQ Server",
-)
-```
-
-**The result:** Agents fetch small, precise rows—not entire PDFs. Runs are faster, cheaper, reproducible, and more accurate.
-
-**What happened here:**
-
-- PDF parsing, extraction, embedding → **inference offloaded to fenic**
-- Agent context → **only receives small, shaped results**
-- Context construction → **less context bloat** (agents stay focused on reasoning)
-- Framework dependency → **none—works with any runtime**
-
-**Works with any agentic framework** (LangGraph, PydanticAI, CrewAI, ...) — fenic exposes MCP tools or Python functions.
-
----
-
-## Quickstart (Pick Your Path)
-
-Four core context construction patterns, each works with any agent framework:
-
-| Pattern                           | What It Shows                        |
-| --------------------------------- | ------------------------------------ |
-| **Memory — facts**                | Extract → embed → semantic recall    |
-| **Memory — blocks & episodes**    | Persistent profile + recent timeline |
-| **Retrieval — schema-first rows** | Typed extraction with citations      |
-| **Retrieval — semantic spans**    | Chunked docs with neighbors          |
-
-Each builds a typed table and exposes tools via MCP or direct Python functions.
-
----
-
-### 1) Memory — Facts _(extract → embed → recall)_
-
-Add structure to free-form chats by extracting them into typed facts and recall them semantically so agents don't carry giant histories.
-
-**Tools exposed:** `mem_recall` (semantic query), plus system tools over `preferences`
-
-<details>
-<summary><b>Show code</b></summary>
-
-```python
-import fenic as fc
-from fenic import SemanticConfig, OpenAILanguageModel, OpenAIEmbeddingModel
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
-from fenic.core.mcp.types import SystemTool
-from pydantic import BaseModel, Field
-
-class Preference(BaseModel):
-    category: str = Field(description="The category of the preference")
-    value: str = Field(description="The value of the preference")
-
-session = fc.Session.get_or_create(fc.SessionConfig(
-    app_name="mem_facts",
-    semantic=SemanticConfig(
-        language_models={"gpt": OpenAILanguageModel(model_name="gpt-4.1-nano", rpm=100, tpm=100_000)},
-        embedding_models={"embed": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=100, tpm=100_000)},
-        default_embedding_model="embed"
-    )
-))
-
-msgs = session.create_dataframe([
-    {"user_id": "user123", "message": "I'm vegetarian and allergic to nuts."},
-    {"user_id": "user123", "message": "I prefer morning meetings."},
-])
-
-prefs = (
-    msgs.select(
-        fc.col("user_id"),
-        fc.semantic.extract(fc.col("message"), Preference).alias("pref"),
-        fc.semantic.embed(fc.col("message")).alias("vec"),
-    )
-    .unnest("pref")
-)
-prefs.write.save_as_table("preferences", mode="overwrite")
-
-async def mem_recall(user_id: str, query: str, k: int = 3):
-    user_prefs = session.table("preferences").filter(fc.col("user_id") == fc.lit(user_id))
-    q = session.create_dataframe([{"q": query}])
-    res = q.semantic.sim_join(
-        user_prefs,
-        left_on=fc.semantic.embed(fc.col("q")),
-        right_on=fc.col("vec"),
-        k=k,
-        similarity_score_column="relevance",
-    ).select("category", "value", "relevance")
-    return res._plan
-
-generated_system_tools = auto_generate_system_tools_from_tables(
-    ["preferences"], session, tool_namespace="mem", max_result_limit=100
-)
-
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=[
-        SystemTool(
-            name="mem_recall",
-            description="Semantic memory recall",
-            max_result_limit=100,
-            func=mem_recall,
+session = fc.Session.get_or_create(
+    fc.SessionConfig(
+        app_name="quickstart",
+        semantic=fc.SemanticConfig(
+            language_models={
+                "mini": fc.OpenAILanguageModel(model_name="gpt-4o-mini", rpm=500, tpm=200_000)
+            },
         ),
-        *generated_system_tools,
-    ],
-    server_name="Memory (Facts)",
+    )
 )
+
+df = session.create_dataframe([
+    {"id": 1, "text": "The CSV export in Reports keeps timing out since the last update."},
+    {"id": 2, "text": "Love the new dashboard, but SSO login is broken on mobile."},
+])
+
+# Free text -> typed, queryable rows
+tickets = (
+    df.select("id", fc.semantic.extract("text", Ticket).alias("t"))
+      .unnest("t")
+)
+tickets.show()
+# id | product | sentiment | issue
+# 1  | Reports | negative  | CSV export times out
+# 2  | Auth    | negative  | SSO login broken on mobile
 ```
 
-</details>
+Set the API key for whichever provider you use:
+
+```bash
+export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY / GOOGLE_API_KEY / COHERE_API_KEY / OPENROUTER_API_KEY
+```
 
 ---
 
-### 2) Memory — Blocks & Episodes _(profile + timeline)_
+## Why fenic?
 
-Maintain a profile block alongside a recent event timeline; return scoped snapshots.
+**Unstructured data is everywhere, and working with it is brittle.** Teams reach for regex, one-off scripts, notebooks, and prompt chains to pull meaning out of documents, logs, tickets, transcripts, and traces. The results are hard to reproduce and hard to inspect.
 
-**Tools exposed:** `get_user_context` (profile + last N events), plus system tools
+**Agents made exploration easy and introduced a new problem.** An agent can dig through messy data and find something useful — but unless that discovery becomes code, data, or a pipeline, it dies as a chat transcript. The next person has to reverse-engineer what happened.
 
-<details>
-<summary><b>Show code</b></summary>
+**fenic gives semantic data work a DataFrame abstraction.** Express the exploration as fenic operators and it's *already* the artifact:
+
+| | Without fenic | With fenic |
+| --- | --- | --- |
+| **Extraction** | regex + one-off prompts, re-derived each time | `extract(Schema)` → typed columns, validated at plan time |
+| **Reproducibility** | "what did the agent do?" | a lazy plan you can `explain()` and rerun |
+| **Inspection** | scroll the transcript | row-level `lineage()`, typed rows, per-query cost/tokens |
+| **Reuse** | copy/paste the script | promote to a table, view, or MCP tool |
+| **Humans vs. agents** | separate, incompatible workflows | one shared pipeline both can read and run |
+
+The model is still probabilistic — but the *pipeline* around it is typed, bounded, cached, replayable, and inspectable.
+
+---
+
+## Featured workflow: from eval exploration to durable eval intelligence
+
+Eval analysis is the perfect case: the data is messy and semi-structured (traces, tool calls, outputs, judge notes), and the useful patterns usually get discovered once and lost. With fenic, an agent (or you) explores the traces, and the useful operations become a pipeline that reruns on every new batch.
 
 ```python
-from datetime import datetime
-from typing import Optional
-
 import fenic as fc
-from fenic import SemanticConfig, OpenAILanguageModel
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
-from fenic.core.mcp.types import SystemTool
+from typing import Literal
 from pydantic import BaseModel, Field
 
-class MemoryBlock(BaseModel):
-    block_name: str = Field(description="Name of the memory block")
-    content: str = Field(description="Content stored in the memory block")
-    last_updated: str = Field(description="Timestamp of last update")
-
-class AccountEvent(BaseModel):
-    event_type: str = Field(description="Type of account event")
-    amount: Optional[float] = Field(default=None, description="Amount involved in the event")
-    status: Optional[str] = Field(default=None, description="Status of the event")
-    description: Optional[str] = Field(default=None, description="Description of the event")
-
-session = fc.Session.get_or_create(fc.SessionConfig(
-    app_name="mem_blocks",
-    semantic=SemanticConfig(
-        language_models={"gpt": OpenAILanguageModel(model_name="gpt-4.1-nano", rpm=100, tpm=100_000)}
+class FailureMode(BaseModel):
+    failed: bool = Field(description="Whether the agent failed the task")
+    category: Literal["tool_error", "instruction_following", "retrieval", "reasoning", "none"] = Field(
+        description="Primary failure category, or 'none' if the run succeeded"
     )
-))
+    evidence: str = Field(description="Short quote or summary justifying the classification")
 
-blocks = session.create_dataframe([
-    {"user_id": "user123", "block_name": "profile", "content": "Name: Taylor; Dept: Finance",
-     "last_updated": datetime.now().isoformat()}
-])
-blocks.write.save_as_table("memory_blocks", mode="overwrite")
-
-ev = session.create_dataframe([
-    {"user_id": "user123", "event": "Failed transaction of $99.99", "timestamp": "2025-01-01"},
-    {"user_id": "user123", "event": "Card expired",                   "timestamp": "2025-01-05"},
-    {"user_id": "user123", "event": "Account suspended",              "timestamp": "2025-01-06"},
-])
-timeline = (
-    ev.select(
-        fc.col("user_id"),
-        fc.col("timestamp"),
-        fc.semantic.extract(fc.col("event"), AccountEvent).alias("data"),
+session = fc.Session.get_or_create(
+    fc.SessionConfig(
+        app_name="eval_triage",
+        semantic=fc.SemanticConfig(
+            language_models={
+                "mini": fc.OpenAILanguageModel(model_name="gpt-4o-mini", rpm=500, tpm=200_000)
+            },
+        ),
     )
-    .unnest("data")
 )
-timeline.write.save_as_table("account_timeline", mode="overwrite")
 
-async def get_user_context(user_id: str, last_n: int = 3):
-    profile = (
-        session.table("memory_blocks")
-        .filter((fc.col("user_id") == fc.lit(user_id)) & (fc.col("block_name") == fc.lit("profile")))
-        .select("block_name", "content", "last_updated")
-    )
-    recent = (
-        session.table("account_timeline")
-        .filter(fc.col("user_id") == fc.lit(user_id))
-        .sort(fc.col("timestamp").desc())
-        .limit(last_n)
-        .select("timestamp", "event_type", "status", "amount", "description")
-    )
-    return {"profile": profile._plan, "recent_events": recent._plan}
+# Eval traces are almost always JSON — one file per run here (a JSONL file or a
+# warehouse table work too). `content` is loaded as JSON.
+traces = session.read.docs("eval_runs/**/*.json", content_type="json", recursive=True)
 
-generated_system_tools = auto_generate_system_tools_from_tables(
-    ["memory_blocks", "account_timeline"],
+# Optional: project just the fields the model should see to control token cost, e.g.
+#   traces = traces.with_column("convo", fc.json.jq(fc.col("content"), ".messages"))
+
+failures = (
+    traces
+    .with_column("analysis", fc.semantic.extract(fc.col("content").cast(fc.StringType), FailureMode))
+    .unnest("analysis")
+    .filter(fc.col("failed"))
+)
+
+# One inspectable, root-caused summary per failure category
+failure_modes = failures.group_by("category").agg(
+    fc.count("*").alias("n"),
+    fc.semantic.reduce(
+        "Summarize the common root cause across these failures",
+        column=fc.col("evidence"),
+    ).alias("pattern"),
+)
+
+failure_modes.write.save_as_table("failure_modes", mode="overwrite")
+```
+
+The exploration is now **cumulative**: rerun it on the next model version to detect regressions, inspect any row back to its source trace with `failures.lineage()`, and — see below — hand the result to the agent as a tool. Each new analysis becomes another reusable transform in a growing library for understanding model behavior.
+
+---
+
+## Query meaning and metadata together
+
+The interesting questions usually need both structured and unstructured data — customer metadata *and* support tickets, eval scores *and* trajectories, CRM fields *and* call transcripts. fenic does relational and semantic work in the same pipeline, including joins on *meaning* rather than exact keys.
+
+```python
+# Match on meaning, not exact values
+matches = candidates.semantic.join(
+    roles,
+    predicate=(
+        "Candidate background: {{ left_on }}\n"
+        "Role requirements: {{ right_on }}\n"
+        "The candidate is a strong fit for the role."
+    ),
+    left_on=fc.col("resume"),
+    right_on=fc.col("job_description"),
+)
+
+# ...then group, aggregate, and rank with ordinary DataFrame ops
+ranked = (
+    matches.group_by("role_id")
+    .agg(fc.count("*").alias("n_candidates"))
+    .order_by(fc.desc("n_candidates"))
+)
+```
+
+---
+
+## Make it an artifact your agents reuse
+
+A fenic table or view becomes a governed tool surface over **MCP** (Model Context Protocol) — so the same pipeline a human inspects is what an agent calls, with typed parameters and bounded result sizes.
+
+Auto-generate a suite of system tools (schema, profile, read, search, analyze) over your tables:
+
+```python
+from fenic import SystemToolConfig
+
+session.catalog.set_table_description(
+    "failure_modes", "Recurring agent failure modes with counts and root-cause summaries"
+)
+
+server = fc.create_mcp_server(
     session,
-    tool_namespace="memctx",
-    max_result_limit=100,
+    "Eval Intelligence",
+    system_tools=SystemToolConfig(
+        table_names=["failure_modes"],
+        tool_namespace="evals",
+        max_result_rows=100,
+    ),
 )
 
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=[
-        SystemTool(
-            name="get_user_context",
-            description="Profile + recent events",
-            max_result_limit=100,
-            func=get_user_context,
-        ),
-        *generated_system_tools,
-    ],
-    server_name="Memory (Blocks & Episodes)",
-)
+fc.run_mcp_server_sync(server, transport="http", port=8000)
 ```
 
-</details>
-
----
-
-### 3) Retrieval — From unstructured to structured data
-
-Turn unstructured sources into typed rows (Q&A, policies, products), pre-embed, and retrieve with citations.
-
-**Tools exposed:** `qa_neighbors(query, k)` with citations, plus system tools
-
-<details>
-<summary><b>Show code</b></summary>
+Or define a precise, parameterized tool — like a typed SQL macro:
 
 ```python
-import fenic as fc
-from fenic import SemanticConfig, OpenAILanguageModel, OpenAIEmbeddingModel
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
-from fenic.core.mcp.types import SystemTool
-from pydantic import BaseModel, Field
-
-class QAPair(BaseModel):
-    question: str = Field(description="A question extracted from the document")
-    answer: str = Field(description="The answer to the question")
-
-session = fc.Session.get_or_create(fc.SessionConfig(
-    app_name="policy_qa",
-    semantic=SemanticConfig(
-        language_models={"gpt": OpenAILanguageModel(model_name="gpt-5-nano", rpm=100, tpm=100_000)},
-        embedding_models={"embed": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=100, tpm=100_000)},
-        default_embedding_model="embed"
-    )
-))
-
-qa_pairs = (
-    session.read.pdf_metadata("policies/*.pdf")
-    .select(fc.col("file_path").alias("source"),
-            fc.semantic.parse_pdf(fc.col("file_path")).alias("content"))
-    .select(fc.col("source"),
-            fc.semantic.extract(fc.col("content").cast(fc.StringType), QAPair).alias("qa"))
-    .unnest("qa")
-    .select("source",
-            "question",
-            "answer",
-            fc.semantic.embed(fc.col("question")).alias("embedding"))
-)
-qa_pairs.write.save_as_table("policy_qa", mode="overwrite")
-
-async def qa_neighbors(query: str, k: int = 3):
-    q = session.create_dataframe([{"q": query}])
-    res = q.semantic.sim_join(
-        session.table("policy_qa"),
-        left_on=fc.semantic.embed(fc.col("q")),
-        right_on=fc.col("embedding"),
-        k=k,
-        similarity_score_column="relevance",
-    ).select("question", "answer", "source", "relevance")
-    return res._plan
-
-generated_system_tools = auto_generate_system_tools_from_tables(
-    ["policy_qa"], session, tool_namespace="qa", max_result_limit=50
+recent = session.table("failure_modes").filter(
+    fc.col("category") == fc.tool_param("category", fc.StringType)
 )
 
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=[
-        SystemTool(
-            name="qa_neighbors",
-            description="Semantic Q/A retrieval",
-            max_result_limit=50,
-            func=qa_neighbors,
-        ),
-        *generated_system_tools,
-    ],
-    server_name="Policy QA",
+session.catalog.create_tool(
+    "failures_by_category",
+    "Look up recurring failures for a given category",
+    recent,
+    tool_params=[fc.ToolParam(name="category", description="Failure category to filter by")],
 )
 ```
 
-</details>
-
----
-
-### 4) Retrieval — Semantic Spans
-
-Break long documents into overlapping spans, embed once, serve semantic top-K.
-
-**Tools exposed:** `docs_neighbors(query, k)`, plus system tools
-
-<details>
-<summary><b>Show code</b></summary>
-
-```python
-import fenic as fc
-from fenic import SemanticConfig, OpenAILanguageModel, OpenAIEmbeddingModel
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
-from fenic.core.mcp.types import SystemTool
-
-session = fc.Session.get_or_create(fc.SessionConfig(
-    app_name="docs",
-    semantic=SemanticConfig(
-        language_models={"gpt": OpenAILanguageModel(model_name="gpt-5-nano", rpm=100, tpm=100_000)},
-        embedding_models={"embed": OpenAIEmbeddingModel(model_name="text-embedding-3-small", rpm=100, tpm=100_000)},
-        default_embedding_model="embed"
-    )
-))
-
-exploded = (
-    session.read.pdf_metadata("docs/**/*.pdf")
-    .select(fc.col("file_path").alias("source"),
-            fc.semantic.parse_pdf(fc.col("file_path")).alias("content"))
-    .select(fc.col("source"),
-            fc.text.recursive_word_chunk(
-                fc.col("content").cast(fc.StringType),
-                chunk_size=500,
-                chunk_overlap_percentage=10,
-            ).alias("chunks"))
-    .explode("chunks")
-)
-
-# Use SQL to generate unique chunk IDs with ROW_NUMBER()
-chunks = (
-    session.sql("SELECT ROW_NUMBER() OVER () as chunk_id, * FROM {df}", df=exploded)
-    .select("chunk_id",
-            "source",
-            fc.col("chunks").alias("text"),
-            fc.semantic.embed(fc.col("chunks")).alias("embedding"))
-)
-chunks.write.save_as_table("chunks", mode="overwrite")
-
-async def docs_neighbors(query: str, k: int = 3):
-    q = session.create_dataframe([{"q": query}])
-    res = q.semantic.sim_join(
-        session.table("chunks"),
-        left_on=fc.semantic.embed(fc.col("q")),
-        right_on=fc.col("embedding"),
-        k=k,
-        similarity_score_column="relevance",
-    ).select("chunk_id", "source", "text", "relevance")
-    return res._plan
-
-generated_system_tools = auto_generate_system_tools_from_tables(
-    ["chunks"], session, tool_namespace="docs", max_result_limit=100
-)
-
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=[
-        SystemTool(
-            name="docs_neighbors",
-            description="Semantic chunk retrieval",
-            max_result_limit=100,
-            func=docs_neighbors,
-        ),
-        *generated_system_tools,
-    ],
-    server_name="Docs",
-)
-```
-
-</details>
-
----
-
-## Core Concepts
-
-### Lifecycle: Hydrate → Shape → Serve → Operate
-
-1. **Hydrate** — Load sources (PDF/MD/CSV/DB)
-2. **Shape** — Transform with deterministic ops (select/filter/join/window) + semantic ops (extract/embed/summarize)
-3. **Serve** — Expose as bounded tools (MCP or Python functions) with result caps
-4. **Operate** — Version with snapshots/tags; rollback instantly
-
-### Design Principles
-
-| Principle                   | What It Means                                                                |
-| --------------------------- | ---------------------------------------------------------------------------- |
-| **Framework-agnostic**      | Works with any runtime that can call tools or functions                      |
-| **Inference offloading**    | Context operations happen in fenic, not your agent's context window          |
-| **Context as typed tables** | Model context relationally; query it precisely                               |
-| **Declarative transforms**  | Focus on _what_ context to build, not _how_—iterate fast on context strategy |
-| **Bounded tool surfaces**   | Minimal, auditable interfaces with result caps                               |
-| **Immutable snapshots**     | Version context                                                              |
-| **Runtime enablement**      | Provide primitives; let your framework orchestrate                           |
-
----
-
-## Key Capabilities
-
-<details>
-<summary><b>Inference Offloading</b> — LLM ops happen in fenic, not your agent's context</summary>
-
-```python
-# This summarization happens in fenic's inference—
-# your agent receives only the result, with less context bloat
-summary = (
-    session.table("conversations")
-    .select(
-        fc.col("user_id"),
-        fc.semantic.map(
-            "Summarize this conversation in 2 sentences: {{ messages }}",
-            messages=fc.col("messages")
-        ).alias("summary")
-    )
-)
-```
-
-**Traditional approach:** Agent performs the summarization or it delegates to a sub-agent → tokens consumed from agent budget or complexity is increased by having to manage the context of multiple agents
-**fenic approach:** fenic handles summarization → agent receives the result → less context bloat, so agents stay focused on reasoning
-
-</details>
-
-<details>
-<summary><b>Token Budget Awareness</b> — Track and manage token budgets</summary>
-
-Track and manage token budgets across your context operations:
-
-```python
-# Token statistics available throughout the pipeline
-metrics = df.write.save_as_table("context", mode="overwrite")
-
-print(f"Total cost: ${metrics.total_lm_metrics.cost:.4f}")
-print(f"Input tokens: {metrics.total_lm_metrics.num_uncached_input_tokens}")
-print(f"Output tokens: {metrics.total_lm_metrics.num_output_tokens}")
-
-# Tool responses shaped to fit budgets
-from fenic.api.mcp._tool_generation_utils import auto_generate_system_tools_from_tables
-from fenic.core.mcp._server import FenicMCPServer
-
-generated_tools = auto_generate_system_tools_from_tables(
-    ["context"], session, tool_namespace="ctx", max_result_limit=50  # Cap response size
-)
-
-server = FenicMCPServer(
-    session._session_state,
-    user_defined_tools=[],
-    system_tools=generated_tools,
-    server_name="Budget-Aware Tools",
-)
-```
-
-</details>
-
-<details>
-<summary><b>State Management & Rollback</b> — Relational model with versioned tables</summary>
-
-```python
-# Version your context with dated table names
-ctx.write.save_as_table("policy_qa_2025_11_06", mode="overwrite")
-ctx.write.save_as_table("policy_qa_2025_11_12", mode="overwrite")
-
-# Point prod to a version by copying
-ctx.write.save_as_table("policy_qa_prod", mode="overwrite")
-
-# Rollback instantly by repointing prod to an older version
-old_ctx = session.table("policy_qa_2025_11_06")
-old_ctx.write.save_as_table("policy_qa_prod", mode="overwrite")
-```
-
-</details>
-
-<details>
-<summary><b>Temporal Memory with Window Functions</b> — Decaying resolution patterns</summary>
-
-```python
-from datetime import date, timedelta
-
-# Define temporal boundaries
-today = date.today()
-week_start = today - timedelta(days=today.weekday())
-
-# Window functions for temporal processing
-daily_summary = (
-    session.table("events")
-    .filter(fc.col("timestamp") >= fc.lit(today))
-    .select(
-        fc.col("user_id"),
-        fc.semantic.reduce(
-            "Summarize today's events",
-            fc.col("event_text")
-        ).alias("daily_summary")
-    )
-)
-
-# Weekly rollup from daily summaries
-weekly_summary = (
-    session.table("daily_summaries")
-    .filter(fc.col("date") >= fc.lit(week_start))
-    .group_by("user_id")
-    .agg(
-        fc.semantic.reduce(
-            "Summarize this week's key events",
-            fc.col("daily_summary")
-        ).alias("weekly_summary")
-    )
-)
-```
-
-</details>
-
-<details>
-<summary><b>Tool Response Shaping</b> — Truncation strategies, less context bloat</summary>
-
-```python
-# Deterministic: pagination and filtering
-async def search_with_pagination(query: str, page: int = 0, page_size: int = 10):
-    filtered = (
-        session.table("documents")
-        .filter(fc.col("content").contains(query))
-    )
-    # Use SQL for OFFSET support
-    return session.sql(
-        f"SELECT * FROM {{df}} ORDER BY relevance DESC LIMIT {page_size} OFFSET {page * page_size}",
-        df=filtered
-    )._plan
-
-# Semantic: summarize large results (inference offloaded)
-async def search_with_summary(query: str, k: int = 20):
-    results = session.table("documents").limit(k)
-    return (
-        results.select(
-            fc.col("id"),
-            fc.semantic.map(
-                f"Extract the part most relevant to: {query}\n\nContent: {{{{ content }}}}",
-                content=fc.col("content")
-            ).alias("relevant_excerpt")
-        )
-    )._plan
-```
-
-</details>
-
-<details>
-<summary><b>Tool-Level Observability</b> — See inside tools, not just inputs/outputs</summary>
-
-```python
-# fenic tracks operations inside tools
-# Close the loop between runtime traces and tool internals
-
-metrics = df.write.save_as_table("context", mode="overwrite")
-
-# Aggregated LM metrics across all operators
-lm = metrics.total_lm_metrics
-print(f"Tokens: {lm.num_uncached_input_tokens + lm.num_output_tokens}, Cost: ${lm.cost:.4f}")
-
-# Detailed execution plan with per-operator metrics
-print(metrics.get_execution_plan_details())
-```
-
-</details>
-
----
-
-## Declarative Shaping
-
-### Deterministic Transforms
-
-`select`, `filter`, `sort`, `limit`, `join`, `group_by`, `agg`, `window`, `unnest`, `explode`
-
-### Semantic Transforms
-
-`semantic.extract` (to Pydantic), `semantic.embed`, `semantic.classify`, `semantic.map` (template-driven),
-`semantic.reduce` (multi-row), `semantic.predicate` (NL filters), `semantic.sim_join`, `semantic.parse_pdf`
-
-```python
-from pydantic import BaseModel
-
-class PolicyInfo(BaseModel):
-    category: str
-    date: str
-    summary: str
-
-# Combine both—works with any framework
-results = (
-    session.read.pdf_metadata("docs/*.pdf")
-    .select(
-        fc.semantic.parse_pdf(fc.col("file_path")).alias("content")  # semantic
-    )
-    .filter(fc.col("content").contains("policy"))                     # deterministic
-    .select(
-        fc.semantic.extract(fc.col("content"), PolicyInfo).alias("data"),  # semantic
-        fc.semantic.embed(fc.col("content")).alias("vec")                  # semantic
-    )
-    .filter(fc.col("data").category == fc.lit("refund"))              # deterministic
-    .sort(fc.col("data").date.desc())                                 # deterministic
-    .limit(10)                                                        # deterministic
-)
-```
-
----
-
-## Production Operations
-
-### Batching & Rate Limiting
-
-```python
-config = fc.SessionConfig(
-    semantic=fc.SemanticConfig(
-        language_models={
-            "gpt": fc.OpenAILanguageModel(
-                model_name="gpt-4o-mini",
-                rpm=1000,  # requests per minute
-                tpm=1_000_000  # tokens per minute
-            )
-        }
-    )
-)
-```
-
-<details>
-<summary><b>Show more production features</b> — async UDFs, error handling...</summary>
-
-### Async UDFs with Concurrency Control
-
-```python
-@fc.async_udf(
-    return_type=fc.StringType,
-    max_concurrency=50,
-    timeout_seconds=10,
-    num_retries=3
-)
-async def fetch_user_profile(user_id: str) -> str:
-    async with aiohttp.ClientSession() as s:
-        async with s.get(f"https://api.example.com/{user_id}") as resp:
-            return await resp.text()
-```
-
-### Error Handling
-
-- Automatic retries for transient failures
-- Graceful degradation: failed rows return `None`
-- Per-op timeouts
-- Schema validation before execution
-</details>
-
----
-
-## Integrations
-
-### AI Providers
-
-| Provider      | Type             | Models                                      |
-| ------------- | ---------------- | ------------------------------------------- |
-| OpenAI        | LLM + Embeddings | GPT-4, GPT-5, o-series, text-embedding-3-\* |
-| Anthropic     | LLM              | Claude (Haiku/Sonnet/Opus)                  |
-| Google Gemini | LLM + Embeddings | Gemini 2.0/2.5 Flash                        |
-| OpenRouter    | LLM (aggregator) | 200+ models                                 |
-| Cohere        | LLM + Embeddings | embed-v4.0                                  |
-
-### Agent Frameworks
-
-Any agentic framework (LangGraph, PydanticAI, CrewAI, ...)
-
-<details>
-<summary><b>Show more integrations</b> — AI providers, data sources, outputs, agent frameworks</summary>
-
-### Data Sources
-
-Local files, S3, Hugging Face Datasets, in-memory (Polars/Pandas/PyArrow)
-
-### Outputs
-
-CSV/Parquet, fenic native storage, DataFrame exports, MCP servers, Python functions
-
-</details>
-
----
-
-## Install
+Serve every registered tool straight from the catalog with the CLI:
 
 ```bash
-pip install fenic
-# or
-uv add fenic
-# Requires Python 3.10+
+fenic-serve --app-name eval_triage --port 8000
 ```
 
 ---
 
-## Configuration
+## Semantic operators
 
-```bash
-export OPENAI_API_KEY=...
-export ANTHROPIC_API_KEY=...
-export GOOGLE_API_KEY=...
+Column operators (via `fc.semantic.*`), used inside `select` / `with_column` / `filter` / `agg`:
+
+| Operator | What it does |
+| --- | --- |
+| `extract(col, Schema)` | Unstructured text → a typed struct from a Pydantic schema |
+| `classify(col, classes)` | Label text into predefined classes (optionally with descriptions + examples) |
+| `predicate(prompt, **cols)` | Natural-language boolean — use it to `filter` rows |
+| `map(prompt, **cols)` | Apply a templated generation prompt per row (optionally typed output) |
+| `reduce(prompt, column)` | Aggregate many rows in a group into one result (great after `group_by`) |
+| `analyze_sentiment(col)` | positive / negative / neutral |
+| `summarize(col)` | Paragraph or key-points summary |
+| `embed(col)` | Embeddings for similarity, clustering, and search |
+| `parse_pdf(col)` | PDF paths → Markdown |
+
+DataFrame operators (via `df.semantic.*`):
+
+| Operator | What it does |
+| --- | --- |
+| `join(other, predicate, left_on, right_on)` | Join two DataFrames on a natural-language predicate |
+| `sim_join(other, left_on, right_on, k)` | Top-k embedding-similarity join |
+| `with_cluster_labels(by, num_clusters)` | K-means clustering over an embedding column |
+
+All of it composes with ordinary DataFrame operations — `select`, `filter`, `with_columns`, `join`, `group_by`/`agg`, `order_by`, `limit`, `unnest`, `explode` — and full **SQL** via `session.sql("... {df} ...", df=df)`. Few-shot examples, per-model aliases/profiles, and structured output are built in.
+
+---
+
+## Native support for unstructured data
+
+First-class logical types mean text-heavy data is typed, not just strings:
+
+- **Markdown** — parse, generate a table of contents, extract header-based chunks, convert to JSON
+- **Transcript** — SRT / WebVTT / generic, with speaker and timestamp awareness
+- **JSON** — query and reshape nested data with `jq` expressions
+- **HTML**, **Document paths (PDF)**, and **Embeddings** (fixed-dimension vectors)
+- Rust-accelerated text processing: recursive chunking with overlap, regex, fuzzy matching
+
+Read from local files, **S3**, and **Hugging Face** datasets:
+
+```python
+session.read.csv("data/*.csv")
+session.read.parquet("s3://bucket/data/*.parquet")
+session.read.docs("docs/**/*.md", content_type="markdown", recursive=True)
+session.read.pdf_metadata("data/**/*.pdf", recursive=True)
 ```
+
+---
+
+## Inspect and operate
+
+Because everything is a typed plan, you can see exactly what happened:
+
+- `df.explain()` — the logical/physical plan for a pipeline
+- `df.lineage()` — trace specific rows **forwards and backwards** through every operation
+- Per-query metrics — tokens and cost for each run
+- Caching — an LLM response cache plus `.cache()` to materialize expensive intermediates
+
+```python
+result = df.lineage()
+result.backwards(["<row-id>"])   # which source rows produced this output?
+```
+
+---
+
+## Providers
+
+| Provider | Type | Notes |
+| --- | --- | --- |
+| OpenAI | LLM + embeddings | GPT, o-series, GPT-5 family; `text-embedding-3-*` |
+| Anthropic | LLM | Claude (Haiku / Sonnet / Opus), with thinking budgets |
+| Google | LLM + embeddings | Gemini (AI Studio *and* Vertex) |
+| Cohere | Embeddings | `embed-v4.0` |
+| OpenRouter | LLM (aggregator) | provider routing, fallbacks, price/throughput controls |
+
+Reasoning/thinking effort is configurable per model via profiles, and you can register multiple models and pick per operator with `model_alias`.
 
 ---
 
 ## Examples
 
-### Agent Projects ([fenic-examples](https://github.com/typedef-ai/fenic-examples))
+End-to-end agent projects live in [**fenic-examples**](https://github.com/typedef-ai/fenic-examples):
 
 - A deep research agent for Hacker News
-- A log triage with LangGraph
-- How to do AI Feature Engineering for RecSys
+- Log triage with LangGraph
+- AI feature engineering for recommender systems
 
 <details>
-<summary><b>Show more examples</b> — 11 notebooks with Colab links</summary>
+<summary><b>In-repo notebooks (with Colab links)</b></summary>
 
-| Example                                                                 | Description                                                                                                                         |                                                                                          Colab                                                                                          |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| [Hello World!](examples/hello_world)                                    | Introduction to semantic extraction and classification using fenic's core operators through error log analysis.                     |               [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/hello_world/hello_world.ipynb)               |
-| [Enrichment](examples/enrichment)                                       | Multi-stage DataFrames with template-based text extraction, joins, and LLM-powered transformations demonstrated via log enrichment. |                [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/enrichment/enrichment.ipynb)                |
-| [Meeting Transcript Processing](examples/meeting_transcript_processing) | Native transcript parsing, Pydantic schema integration, and complex aggregations shown through meeting analysis.                    | [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/meeting_transcript_processing/transcript_processing.ipynb) |
-| [News Analysis](examples/news_analysis)                                 | Analyze and extract insights from news articles using semantic operators and structured data processing.                            |             [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/news_analysis/news_analysis.ipynb)             |
-| [Podcast Summarization](examples/podcast_summarization)                 | Process and summarize podcast transcripts with speaker-aware analysis and key point extraction.                                     |     [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/podcast_summarization/podcast_summarization.ipynb)     |
-| [Semantic Join](examples/semantic_joins)                                | Instead of simple fuzzy matching, use fenic's powerful semantic join functionality to match data across tables.                     |            [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/semantic_joins/semantic_joins.ipynb)            |
-| [Named Entity Recognition](examples/named_entity_recognition)           | Extract and classify named entities from text using semantic extraction and classification.                                         |            [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/named_entity_recognition/ner.ipynb)             |
-| [Markdown Processing](examples/markdown_processing)                     | Process and transform markdown documents with structured data extraction and formatting.                                            |       [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/markdown_processing/markdown_processing.ipynb)       |
-| [JSON Processing](examples/json_processing)                             | Handle complex JSON data structures with semantic operations and schema validation.                                                 |           [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/json_processing/json_processing.ipynb)           |
-| [Feedback Clustering](examples/feedback_clustering)                     | Group and analyze feedback using semantic similarity and clustering operations.                                                     |       [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/feedback_clustering/feedback_clustering.ipynb)       |
-| [Document Extraction](examples/document_extraction)                     | Extract structured information from various document formats using semantic operators.                                              |       [![Open in Colab](docs/images/colab-badge.svg)](https://colab.research.google.com/github/typedef-ai/fenic/blob/main/examples/document_extraction/document_extraction.ipynb)       |
+| Example | Description |
+| --- | --- |
+| [Hello World!](examples/hello_world) | Semantic extraction and classification through error-log analysis |
+| [Enrichment](examples/enrichment) | Multi-stage pipelines: template extraction, joins, LLM transforms |
+| [Meeting Transcript Processing](examples/meeting_transcript_processing) | Native transcript parsing + Pydantic schemas + aggregations |
+| [News Analysis](examples/news_analysis) | Bias detection with classify/extract/reduce |
+| [Podcast Summarization](examples/podcast_summarization) | Speaker-aware, multi-level summarization |
+| [Semantic Join](examples/semantic_joins) | Match records across tables by meaning |
+| [Named Entity Recognition](examples/named_entity_recognition) | Multi-stage entity extraction + classification |
+| [Markdown Processing](examples/markdown_processing) | Structure extraction from Markdown |
+| [JSON Processing](examples/json_processing) | Nested JSON with `jq` |
+| [Feedback Clustering](examples/feedback_clustering) | Embeddings + clustering + summarization |
+| [Document Extraction](examples/document_extraction) | Structured metadata from diverse documents |
 
 </details>
 
 ---
 
-## Support
+## Community
 
-Join our community on [Discord](https://discord.gg/GdqF3J7huR) where you can connect with other users, ask questions, and get help with your fenic projects. Our community is always happy to welcome newcomers!
-
-If you find fenic useful, consider giving us a ⭐ at the top of this repository. Your support helps us grow and improve the framework for everyone!
+Join us on [Discord](https://discord.gg/GdqF3J7huR) to ask questions and share what you're building. If fenic is useful to you, a ⭐ on the repo helps others find it.
 
 ## Contributing
 
-We welcome contributions of all kinds! Whether you're interested in writing code, improving documentation, testing features, or proposing new ideas, your help is valuable to us.
-
-For developers planning to submit code changes, we encourage you to first open an issue to discuss your ideas before creating a Pull Request. This helps ensure alignment with the project's direction and prevents duplicate efforts.
-
-Please refer to our [contribution guidelines](CONTRIBUTING.md) for detailed information about the development process and project setup.
+Contributions of all kinds are welcome — code, docs, tests, and ideas. For code changes, please open an issue to discuss your approach before sending a PR. See our [contribution guidelines](CONTRIBUTING.md) for development setup and workflow.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 It's a DataFrame query engine for semantic data processing, with AI operators — `extract`, `classify`, `summarize`, `embed`, semantic `join`, and more — built into the query model. Use it to turn documents, transcripts, logs, eval traces, tickets, tables, and APIs into typed rows and repeatable workflows.
 
-The point is a shift in what your data work *produces*. Humans author, inspect, and validate fenic pipelines. Agents discover, compose, and reuse them. The result isn't a one-off prompt or a brittle regex script that has to be reverse-engineered later — it's a durable artifact: typed, inspectable, rerunnable, and callable.
+The point is a shift in what your data work _produces_. Humans author, inspect, and validate fenic pipelines. Agents discover, compose, and reuse them. The result isn't a one-off prompt or a brittle regex script that has to be reverse-engineered later — it's a durable artifact: typed, inspectable, rerunnable, and callable.
 
 > **From exploration to artifact.**
 
@@ -29,7 +29,7 @@ pip install fenic
 
 ## What is fenic?
 
-fenic is a **semantic DataFrame engine**. You write the PySpark/SQL-style operations you already know — `select`, `filter`, `join`, `group_by`, `agg` — alongside *semantic operators* that call language models as a first-class part of the query. You configure models once on a `Session`, build a pipeline lazily, and fenic compiles and runs it on a query engine built for inference: automatic batching, rate limiting, retries, token/cost accounting, and response caching.
+fenic is a **semantic DataFrame engine**. You write the PySpark/SQL-style operations you already know — `select`, `filter`, `join`, `group_by`, `agg` — alongside _semantic operators_ that call language models as a first-class part of the query. You configure models once on a `Session`, build a pipeline lazily, and fenic compiles and runs it on a query engine built for inference: automatic batching, rate limiting, retries, token/cost accounting, and response caching.
 
 Two ideas make it different from gluing an LLM onto pandas:
 
@@ -92,17 +92,17 @@ export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY / GOOGLE_API_KEY / COHER
 
 **Agents made exploration easy and introduced a new problem.** An agent can dig through messy data and find something useful — but unless that discovery becomes code, data, or a pipeline, it dies as a chat transcript. The next person has to reverse-engineer what happened.
 
-**fenic gives semantic data work a DataFrame abstraction.** Express the exploration as fenic operators and it's *already* the artifact:
+**fenic gives semantic data work a DataFrame abstraction.** Express the exploration as fenic operators and it's _already_ the artifact:
 
-| | Without fenic | With fenic |
-| --- | --- | --- |
-| **Extraction** | regex + one-off prompts, re-derived each time | `extract(Schema)` → typed columns, validated at plan time |
-| **Reproducibility** | "what did the agent do?" | a lazy plan you can `explain()` and rerun |
-| **Inspection** | scroll the transcript | row-level `lineage()`, typed rows, per-query cost/tokens |
-| **Reuse** | copy/paste the script | promote to a table, view, or MCP tool |
-| **Humans vs. agents** | separate, incompatible workflows | one shared pipeline both can read and run |
+|                       | Without fenic                                 | With fenic                                                |
+| --------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| **Extraction**        | regex + one-off prompts, re-derived each time | `extract(Schema)` → typed columns, validated at plan time |
+| **Reproducibility**   | "what did the agent do?"                      | a lazy plan you can `explain()` and rerun                 |
+| **Inspection**        | scroll the transcript                         | row-level `lineage()`, typed rows, per-query cost/tokens  |
+| **Reuse**             | copy/paste the script                         | promote to a table, view, or MCP tool                     |
+| **Humans vs. agents** | separate, incompatible workflows              | one shared pipeline both can read and run                 |
 
-The model is still probabilistic — but the *pipeline* around it is typed, bounded, cached, replayable, and inspectable.
+The model is still probabilistic — but the _pipeline_ around it is typed, bounded, cached, replayable, and inspectable.
 
 ---
 
@@ -165,7 +165,7 @@ The exploration is now **cumulative**: rerun it on the next model version to det
 
 ## Query meaning and metadata together
 
-The interesting questions usually need both structured and unstructured data — customer metadata *and* support tickets, eval scores *and* trajectories, CRM fields *and* call transcripts. fenic does relational and semantic work in the same pipeline, including joins on *meaning* rather than exact keys.
+The interesting questions usually need both structured and unstructured data — customer metadata _and_ support tickets, eval scores _and_ trajectories, CRM fields _and_ call transcripts. fenic does relational and semantic work in the same pipeline, including joins on _meaning_ rather than exact keys.
 
 ```python
 # Match on meaning, not exact values
@@ -243,25 +243,25 @@ fenic-serve --app-name eval_triage --port 8000
 
 Column operators (via `fc.semantic.*`), used inside `select` / `with_column` / `filter` / `agg`:
 
-| Operator | What it does |
-| --- | --- |
-| `extract(col, Schema)` | Unstructured text → a typed struct from a Pydantic schema |
-| `classify(col, classes)` | Label text into predefined classes (optionally with descriptions + examples) |
-| `predicate(prompt, **cols)` | Natural-language boolean — use it to `filter` rows |
-| `map(prompt, **cols)` | Apply a templated generation prompt per row (optionally typed output) |
-| `reduce(prompt, column)` | Aggregate many rows in a group into one result (great after `group_by`) |
-| `analyze_sentiment(col)` | positive / negative / neutral |
-| `summarize(col)` | Paragraph or key-points summary |
-| `embed(col)` | Embeddings for similarity, clustering, and search |
-| `parse_pdf(col)` | PDF paths → Markdown |
+| Operator                    | What it does                                                                 |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `extract(col, Schema)`      | Unstructured text → a typed struct from a Pydantic schema                    |
+| `classify(col, classes)`    | Label text into predefined classes (optionally with descriptions + examples) |
+| `predicate(prompt, **cols)` | Natural-language boolean — use it to `filter` rows                           |
+| `map(prompt, **cols)`       | Apply a templated generation prompt per row (optionally typed output)        |
+| `reduce(prompt, column)`    | Aggregate many rows in a group into one result (great after `group_by`)      |
+| `analyze_sentiment(col)`    | positive / negative / neutral                                                |
+| `summarize(col)`            | Paragraph or key-points summary                                              |
+| `embed(col)`                | Embeddings for similarity, clustering, and search                            |
+| `parse_pdf(col)`            | PDF paths → Markdown                                                         |
 
 DataFrame operators (via `df.semantic.*`):
 
-| Operator | What it does |
-| --- | --- |
+| Operator                                    | What it does                                        |
+| ------------------------------------------- | --------------------------------------------------- |
 | `join(other, predicate, left_on, right_on)` | Join two DataFrames on a natural-language predicate |
-| `sim_join(other, left_on, right_on, k)` | Top-k embedding-similarity join |
-| `with_cluster_labels(by, num_clusters)` | K-means clustering over an embedding column |
+| `sim_join(other, left_on, right_on, k)`     | Top-k embedding-similarity join                     |
+| `with_cluster_labels(by, num_clusters)`     | K-means clustering over an embedding column         |
 
 All of it composes with ordinary DataFrame operations — `select`, `filter`, `with_columns`, `join`, `group_by`/`agg`, `order_by`, `limit`, `unnest`, `explode` — and full **SQL** via `session.sql("... {df} ...", df=df)`. Few-shot examples, per-model aliases/profiles, and structured output are built in.
 
@@ -306,12 +306,12 @@ result.backwards(["<row-id>"])   # which source rows produced this output?
 
 ## Providers
 
-| Provider | Type | Notes |
-| --- | --- | --- |
-| OpenAI | LLM + embeddings | GPT, o-series, GPT-5 family; `text-embedding-3-*` |
-| Anthropic | LLM | Claude (Haiku / Sonnet / Opus), with thinking budgets |
-| Google | LLM + embeddings | Gemini (AI Studio *and* Vertex) |
-| Cohere | Embeddings | `embed-v4.0` |
+| Provider   | Type             | Notes                                                  |
+| ---------- | ---------------- | ------------------------------------------------------ |
+| OpenAI     | LLM + embeddings | GPT, o-series, GPT-5 family; `text-embedding-3-*`      |
+| Anthropic  | LLM              | Claude (Haiku / Sonnet / Opus), with thinking budgets  |
+| Google     | LLM + embeddings | Gemini (AI Studio _and_ Vertex)                        |
+| Cohere     | Embeddings       | `embed-v4.0`                                           |
 | OpenRouter | LLM (aggregator) | provider routing, fallbacks, price/throughput controls |
 
 Reasoning/thinking effort is configurable per model via profiles, and you can register multiple models and pick per operator with `model_alias`.
@@ -329,19 +329,19 @@ End-to-end agent projects live in [**fenic-examples**](https://github.com/typede
 <details>
 <summary><b>In-repo notebooks (with Colab links)</b></summary>
 
-| Example | Description |
-| --- | --- |
-| [Hello World!](examples/hello_world) | Semantic extraction and classification through error-log analysis |
-| [Enrichment](examples/enrichment) | Multi-stage pipelines: template extraction, joins, LLM transforms |
-| [Meeting Transcript Processing](examples/meeting_transcript_processing) | Native transcript parsing + Pydantic schemas + aggregations |
-| [News Analysis](examples/news_analysis) | Bias detection with classify/extract/reduce |
-| [Podcast Summarization](examples/podcast_summarization) | Speaker-aware, multi-level summarization |
-| [Semantic Join](examples/semantic_joins) | Match records across tables by meaning |
-| [Named Entity Recognition](examples/named_entity_recognition) | Multi-stage entity extraction + classification |
-| [Markdown Processing](examples/markdown_processing) | Structure extraction from Markdown |
-| [JSON Processing](examples/json_processing) | Nested JSON with `jq` |
-| [Feedback Clustering](examples/feedback_clustering) | Embeddings + clustering + summarization |
-| [Document Extraction](examples/document_extraction) | Structured metadata from diverse documents |
+| Example                                                                 | Description                                                       |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Hello World!](examples/hello_world)                                    | Semantic extraction and classification through error-log analysis |
+| [Enrichment](examples/enrichment)                                       | Multi-stage pipelines: template extraction, joins, LLM transforms |
+| [Meeting Transcript Processing](examples/meeting_transcript_processing) | Native transcript parsing + Pydantic schemas + aggregations       |
+| [News Analysis](examples/news_analysis)                                 | Bias detection with classify/extract/reduce                       |
+| [Podcast Summarization](examples/podcast_summarization)                 | Speaker-aware, multi-level summarization                          |
+| [Semantic Join](examples/semantic_joins)                                | Match records across tables by meaning                            |
+| [Named Entity Recognition](examples/named_entity_recognition)           | Multi-stage entity extraction + classification                    |
+| [Markdown Processing](examples/markdown_processing)                     | Structure extraction from Markdown                                |
+| [JSON Processing](examples/json_processing)                             | Nested JSON with `jq`                                             |
+| [Feedback Clustering](examples/feedback_clustering)                     | Embeddings + clustering + summarization                           |
+| [Document Extraction](examples/document_extraction)                     | Structured metadata from diverse documents                        |
 
 </details>
 


### PR DESCRIPTION
## Summary

Replaces the current "Declarative context engineering" README with a new **"semantic DataFrames for humans and agents"** narrative — repositioning fenic as a semantic DataFrame query engine where LLM operators (`extract`, `classify`, `summarize`, `embed`, semantic `join`, …) are first-class parts of the query model, and the pipeline itself is the durable, inspectable, rerunnable artifact.

Net: **+203 / −739** lines (tighter, single narrative).

## Accuracy verification

Every code example, API signature, argument name, namespace, jinja template convention, and provider claim in the new copy was verified against the current source in `src/fenic` (source reading + live `inspect.signature` introspection). All checks passed:

- **`fc.semantic.*` column ops** — `extract`, `classify`, `predicate`, `map`, `reduce(column=…)`, `analyze_sentiment`, `summarize`, `embed`, `parse_pdf`
- **`df.semantic.*` ops** — `join` (incl. the `{{ left_on }}` / `{{ right_on }}` template convention), `sim_join`, `with_cluster_labels`
- **MCP / catalog** — `create_mcp_server`, `SystemToolConfig(table_names, tool_namespace, max_result_rows)`, `run_mcp_server_sync`, `set_table_description`, `create_tool`, `ToolParam`, `tool_param`
- **IO / json / sql / inspection** — `read.docs(content_type="json")`, `read.csv/parquet(s3://)/pdf_metadata`, `json.jq`, `session.sql("…{df}…")`, `explain()`, `lineage().backwards([…])`, metrics, `.cache()`, S3 + Hugging Face
- **Session/config + providers table** — OpenAI, Anthropic, Google (AI Studio + Vertex), Cohere, OpenRouter, `model_alias`, thinking/reasoning profiles
- **`fenic-serve` CLI** — confirmed `fenic-serve --app-name … --port …` serves all registered catalog tools (catalog persists to `./<app_name>.duckdb` by default)

## Notes

- The logo assets and badges are unchanged and still resolve.
- Only `README.md` is touched.