### PR TITLE
test: add semantic operator execution guardrails

### DIFF
--- a/src/fenic/_backends/local/semantic_operators/reduce.py
+++ b/src/fenic/_backends/local/semantic_operators/reduce.py
@@ -155,7 +155,10 @@ class Reduce:
 
     def _preprocess_group(self, group: pl.Series) -> Tuple[str, pl.Series]:
         """Preprocess group by adding context and ordering the data column."""
-        group_df = pl.DataFrame(group.to_list())
+        if not self.group_context_names and not self.descending:
+            return self.user_instruction, group.struct.field(DATA_COLUMN_NAME)
+
+        group_df = group.struct.unnest()
 
         # Step 0: Build user instruction from group context if present
         if self.group_context_names:

--- a/src/fenic/_backends/local/semantic_operators/reduce.py
+++ b/src/fenic/_backends/local/semantic_operators/reduce.py
@@ -1,6 +1,5 @@
 import logging
 import math
-from concurrent.futures import ThreadPoolExecutor
 from textwrap import dedent
 from typing import List, Optional, Tuple
 
@@ -82,12 +81,25 @@ class Reduce:
             self._user_instruction_template = jinja2.Template(self.user_instruction)
 
     def execute(self) -> pl.Series:
-        """Execute parallel reduction across all groups."""
-        with ThreadPoolExecutor(max_workers=min(10, len(self.input))) as executor:
-            results = list(
-                executor.map(lambda x: self._reduce_group(*x), enumerate(self.input))
-            )
-        return pl.Series(results)
+        """Execute reduction over Polars group batches.
+
+        ``expr_converter`` calls this from ``map_batches`` after ``implode``. With
+        current Polars, the callback receives one Series of struct rows for the
+        current group, and ``returns_scalar=True`` expects one output value for
+        that group. Unit tests and direct callers may still pass a Series whose
+        items are grouped Series values; preserve that shape as multiple groups.
+        """
+        if len(self.input) == 0:
+            return pl.Series([None])
+
+        first_group = self.input[0]
+        if isinstance(first_group, pl.Series):
+            return pl.Series([
+                self._reduce_group(group_index, group)
+                for group_index, group in enumerate(self.input)
+            ])
+
+        return pl.Series([self._reduce_group(0, self.input)])
 
     def _reduce_group(self, group_index: int, group: pl.Series) -> str | None:
         """Reduces a single group of documents hierarchically until a single output is obtained.
@@ -143,9 +155,11 @@ class Reduce:
 
     def _preprocess_group(self, group: pl.Series) -> Tuple[str, pl.Series]:
         """Preprocess group by adding context and ordering the data column."""
+        group_df = pl.DataFrame(group.to_list())
+
         # Step 0: Build user instruction from group context if present
         if self.group_context_names:
-            first_row_data = group.first()
+            first_row_data = group_df.row(0, named=True)
             group_context = {name: first_row_data[name] for name in self.group_context_names}
             user_instruction = self._user_instruction_template.render(**group_context)
         else:
@@ -155,14 +169,7 @@ class Reduce:
         if self.descending:
             sort_column_names = [f"{SORT_KEY_COLUMN_NAME}_{i}" for i in range(len(self.descending))]
 
-            # Build a dict of sort key name -> Series extracted from struct field
-            sort_key_columns = {
-                name: group.struct.field(name)
-                for name in sort_column_names
-            }
-
-            # Create a DataFrame from those sort keys (no copy)
-            sort_keys_df = pl.DataFrame(sort_key_columns)
+            sort_keys_df = group_df.select(sort_column_names)
 
             # Compute sorted indices with arg_sort_by
             sorted_idx = sort_keys_df.select(
@@ -174,9 +181,9 @@ class Reduce:
             ).to_series()
 
             # Gather the data column in sorted order
-            sorted_data = group.struct.field(DATA_COLUMN_NAME).gather(sorted_idx)
+            sorted_data = group_df[DATA_COLUMN_NAME].gather(sorted_idx)
         else:
-            sorted_data = group.struct.field(DATA_COLUMN_NAME)
+            sorted_data = group_df[DATA_COLUMN_NAME]
 
         return user_instruction, sorted_data
 

--- a/tests/_backends/local/dataframe/test_semantic_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_join.py
@@ -259,6 +259,119 @@ def test_semantic_join_empty_result(local_session: Session):
         "other_col_right": pl.String,
     }
 
+
+def test_semantic_join_golden_output_with_nulls_and_explicit_sort(local_session: Session, monkeypatch):
+    from fenic._backends.local.semantic_operators.predicate import Predicate
+
+    left = local_session.create_dataframe(
+        {
+            "course_id": [3, 1, 2, 4],
+            "course_name": ["Intro to Computer Networks", "Riemann Geometry", "Operating Systems", None],
+            "left_payload": ["networks", "math", "systems", "missing"],
+        }
+    )
+    right = local_session.create_dataframe(
+        {
+            "skill_id": [20, 10, 30],
+            "skill": ["Computer Science", "Math", None],
+            "right_payload": ["cs", "math", "missing"],
+        }
+    )
+
+    def fake_execute(self):
+        return pl.Series(
+            [
+                ("Riemann Geometry" in rendered and "Math" in rendered)
+                or ("Operating Systems" in rendered and "Computer Science" in rendered)
+                or ("Intro to Computer Networks" in rendered and "Computer Science" in rendered)
+                for rendered in self.input.to_list()
+            ]
+        )
+
+    monkeypatch.setattr(Predicate, "execute", fake_execute)
+
+    result_df = left.semantic.join(
+        right,
+        "Does {{left_on}} belong to {{right_on}}?",
+        left_on=col("course_name"),
+        right_on=col("skill"),
+    )
+    assert result_df.schema.column_fields == [
+        ColumnField(name="course_id", data_type=IntegerType),
+        ColumnField(name="course_name", data_type=StringType),
+        ColumnField(name="left_payload", data_type=StringType),
+        ColumnField(name="skill_id", data_type=IntegerType),
+        ColumnField(name="skill", data_type=StringType),
+        ColumnField(name="right_payload", data_type=StringType),
+    ]
+
+    # semantic.join survivor order is tied to block iteration; sort explicitly so
+    # this golden-output test pins correspondence, not incidental execution order.
+    result = result_df.to_polars().sort(["course_id", "skill_id"])
+    assert result.schema == {
+        "course_id": pl.Int64,
+        "course_name": pl.String,
+        "left_payload": pl.String,
+        "skill_id": pl.Int64,
+        "skill": pl.String,
+        "right_payload": pl.String,
+    }
+    assert len(result) == 3
+    assert result.to_dicts() == [
+        {
+            "course_id": 1,
+            "course_name": "Riemann Geometry",
+            "left_payload": "math",
+            "skill_id": 10,
+            "skill": "Math",
+            "right_payload": "math",
+        },
+        {
+            "course_id": 2,
+            "course_name": "Operating Systems",
+            "left_payload": "systems",
+            "skill_id": 20,
+            "skill": "Computer Science",
+            "right_payload": "cs",
+        },
+        {
+            "course_id": 3,
+            "course_name": "Intro to Computer Networks",
+            "left_payload": "networks",
+            "skill_id": 20,
+            "skill": "Computer Science",
+            "right_payload": "cs",
+        },
+    ]
+
+
+def test_semantic_join_all_false_golden_empty_result(local_session: Session, monkeypatch):
+    from fenic._backends.local.semantic_operators.predicate import Predicate
+
+    monkeypatch.setattr(
+        Predicate,
+        "execute",
+        lambda self: pl.Series([False for _ in self.input.to_list()]),
+    )
+
+    left, right = _create_semantic_join_dataframe(local_session)
+    result = left.semantic.join(
+        right,
+        "Taking {{left_on}} will help me learn {{right_on}}",
+        left_on=col("course_name"),
+        right_on=col("skill"),
+    ).to_polars()
+    assert result.is_empty()
+    assert result.schema == {
+        "course_id": pl.Int64,
+        "course_name": pl.String,
+        "other_col_left": pl.String,
+        "skill_id": pl.Int64,
+        "skill": pl.String,
+        "other_col_right": pl.String,
+    }
+
+
 def test_semantic_join_with_derived_columns(local_session: Session):
     left, right = _create_semantic_join_dataframe(local_session)
     join_instruction = "Taking {{left_on}} will help me learn {{right_on}}"

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -3,6 +3,7 @@ import pytest
 
 from fenic import (
     ColumnField,
+    DoubleType,
     EmbeddingType,
     IntegerType,
     StringType,
@@ -443,6 +444,79 @@ def test_semantic_sim_join_with_invalid_custom_embeddings(local_session):
     # there should be no match with a None value on the right side.
     assert len(result) == 3
     assert None not in result["skill"].to_list()
+
+
+def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
+    left = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "left_id": [1, 2, 3, 4],
+                "left_label": ["x", "y", "null-vector", "nan-vector"],
+                "left_vec": [
+                    [0.0, 0.0],
+                    [10.0, 0.0],
+                    None,
+                    [float("nan"), 0.0],
+                ],
+            },
+            schema={
+                "left_id": pl.Int64,
+                "left_label": pl.String,
+                "left_vec": pl.List(pl.Float32),
+            },
+        )
+    ).with_column("left_vec", col("left_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")))
+    right = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "right_id": [10, 20, 30],
+                "right_label": ["near-x", "near-y", "null-vector"],
+                "right_vec": [[1.0, 0.0], [9.0, 0.0], None],
+            },
+            schema={
+                "right_id": pl.Int64,
+                "right_label": pl.String,
+                "right_vec": pl.List(pl.Float32),
+            },
+        )
+    ).with_column("right_vec", col("right_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")))
+
+    df = left.semantic.sim_join(
+        right,
+        left_on="left_vec",
+        right_on="right_vec",
+        k=2,
+        similarity_metric="l2",
+        similarity_score_column="distance",
+    )
+    assert df.schema.column_fields == [
+        ColumnField("left_id", IntegerType),
+        ColumnField("left_label", StringType),
+        ColumnField("left_vec", EmbeddingType(dimensions=2, embedding_model="test")),
+        ColumnField("right_id", IntegerType),
+        ColumnField("right_label", StringType),
+        ColumnField("right_vec", EmbeddingType(dimensions=2, embedding_model="test")),
+        ColumnField("distance", DoubleType),
+    ]
+
+    result = df.drop("left_vec", "right_vec").to_polars()
+    assert result.schema == pl.Schema(
+        {
+            "left_id": pl.Int64,
+            "left_label": pl.String,
+            "right_id": pl.Int64,
+            "right_label": pl.String,
+            "distance": pl.Float64,
+        }
+    )
+    assert len(result) == 4
+    assert result.to_dicts() == [
+        {"left_id": 1, "left_label": "x", "right_id": 10, "right_label": "near-x", "distance": 1.0},
+        {"left_id": 1, "left_label": "x", "right_id": 20, "right_label": "near-y", "distance": 81.0},
+        {"left_id": 2, "left_label": "y", "right_id": 20, "right_label": "near-y", "distance": 1.0},
+        {"left_id": 2, "left_label": "y", "right_id": 10, "right_label": "near-x", "distance": 81.0},
+    ]
+
 
 def test_semantic_sim_join_with_incompatible_embeddings(local_session):
     df = local_session.create_dataframe(

--- a/tests/_backends/local/functions/test_semantic_reduce.py
+++ b/tests/_backends/local/functions/test_semantic_reduce.py
@@ -18,7 +18,7 @@ from fenic.api.session import (
     Session,
     SessionConfig,
 )
-from fenic.core.error import ExecutionError, PlanError, ValidationError
+from fenic.core.error import PlanError, ValidationError
 
 
 def _install_deterministic_reduce_model(local_session, monkeypatch):
@@ -175,10 +175,6 @@ def test_semantic_reduce_golden_output_ordering_and_nulls(local_session, monkeyp
     ]
 
 
-@pytest.mark.xfail(
-    raises=ExecutionError,
-    reason="semantic.reduce currently creates a ThreadPoolExecutor with max_workers=0 for empty grouped inputs.",
-)
 def test_semantic_reduce_golden_empty_result(local_session, monkeypatch):
     _install_deterministic_reduce_model(local_session, monkeypatch)
 

--- a/tests/_backends/local/functions/test_semantic_reduce.py
+++ b/tests/_backends/local/functions/test_semantic_reduce.py
@@ -12,7 +12,7 @@ from fenic import (
     semantic,
     sum,
 )
-from fenic._inference.types import FenicCompletionsResponse
+from fenic._inference.types import FenicCompletionsRequest, FenicCompletionsResponse
 from fenic.api.session import (
     SemanticConfig,
     Session,
@@ -39,6 +39,57 @@ def _install_deterministic_reduce_model(local_session, monkeypatch):
         return responses
 
     monkeypatch.setattr(model, "get_completions", fake_get_completions)
+
+
+def test_semantic_reduce_calls_model_client_completion_api(local_session, monkeypatch):
+    """Tripwire semantic.reduce's call into LanguageModel/ModelClient completions."""
+    model = local_session._session_state.get_language_model()
+    monkeypatch.setattr(model, "count_tokens", lambda _: 1)
+
+    captured_batches = []
+
+    def fake_make_batch_requests(requests, operation_name, request_timeout=None):
+        captured_batches.append(
+            {
+                "requests": requests,
+                "operation_name": operation_name,
+                "request_timeout": request_timeout,
+            }
+        )
+        return [FenicCompletionsResponse(completion="tripwire summary", logprobs=None)]
+
+    monkeypatch.setattr(model.client, "make_batch_requests", fake_make_batch_requests)
+
+    result = local_session.create_dataframe({"notes": ["alpha", "beta"]}).agg(
+        semantic.reduce(
+            "Summarize the tripwire notes.",
+            col("notes"),
+            max_output_tokens=37,
+            temperature=0.25,
+        ).alias("summary")
+    ).to_polars()
+
+    assert result.to_dicts() == [{"summary": "tripwire summary"}]
+    assert len(captured_batches) == 1
+
+    batch = captured_batches[0]
+    assert batch["operation_name"] == "semantic.reduce(group=0)"
+    assert batch["request_timeout"] is None
+
+    requests = batch["requests"]
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, FenicCompletionsRequest)
+    assert request.max_completion_tokens == 37
+    assert request.top_logprobs is None
+    assert request.structured_output is None
+    assert request.model_profile is None
+    assert request.temperature in (0.25, None)
+    user_message = request.messages.user
+    assert user_message is not None
+    assert "Summarize the tripwire notes." in user_message
+    assert "<document1>\nalpha\n</document1>" in user_message
+    assert "<document2>\nbeta\n</document2>" in user_message
 
 
 def test_semantic_reduce(local_session):

--- a/tests/_backends/local/functions/test_semantic_reduce.py
+++ b/tests/_backends/local/functions/test_semantic_reduce.py
@@ -1,19 +1,44 @@
+import re
 
 import polars as pl
 import pytest
 
 from fenic import (
+    ColumnField,
+    IntegerType,
     OpenAIEmbeddingModel,
+    StringType,
     col,
     semantic,
     sum,
 )
+from fenic._inference.types import FenicCompletionsResponse
 from fenic.api.session import (
     SemanticConfig,
     Session,
     SessionConfig,
 )
-from fenic.core.error import PlanError, ValidationError
+from fenic.core.error import ExecutionError, PlanError, ValidationError
+
+
+def _install_deterministic_reduce_model(local_session, monkeypatch):
+    model = local_session._session_state.get_language_model()
+
+    monkeypatch.setattr(model, "count_tokens", lambda _: 1)
+
+    def fake_get_completions(messages, **kwargs):
+        responses = []
+        for message in messages:
+            docs = re.findall(r"<document\d+>\s*(.*?)\s*</document\d+>", message.user, re.DOTALL)
+            responses.append(
+                FenicCompletionsResponse(
+                    completion=" | ".join(docs),
+                    logprobs=None,
+                )
+            )
+        return responses
+
+    monkeypatch.setattr(model, "get_completions", fake_get_completions)
 
 
 def test_semantic_reduce(local_session):
@@ -57,6 +82,73 @@ def test_semantic_reduce(local_session):
         "summary": pl.Utf8,
         "num_attendees": pl.Int64,
     }
+
+
+def test_semantic_reduce_golden_output_ordering_and_nulls(local_session, monkeypatch):
+    _install_deterministic_reduce_model(local_session, monkeypatch)
+
+    df = local_session.create_dataframe(
+        {
+            "bucket": ["alpha", "alpha", "alpha", "empty-docs", "null-docs"],
+            "sort_key": [2, 1, None, 1, 1],
+            "notes": ["second", "first", None, "", None],
+            "row_value": [10, 20, 30, 40, 50],
+        }
+    )
+
+    result_df = df.group_by("bucket").agg(
+        semantic.reduce(
+            "Summarize notes in order.",
+            col("notes"),
+            order_by=[col("sort_key").asc_nulls_last()],
+        ).alias("summary"),
+        sum("row_value").alias("row_value_sum"),
+    )
+    assert result_df.schema.column_fields == [
+        ColumnField(name="bucket", data_type=StringType),
+        ColumnField(name="summary", data_type=StringType),
+        ColumnField(name="row_value_sum", data_type=IntegerType),
+    ]
+
+    result = result_df.to_polars().sort("bucket")
+    assert result.schema == {
+        "bucket": pl.Utf8,
+        "summary": pl.Utf8,
+        "row_value_sum": pl.Int64,
+    }
+    assert len(result) == 3
+    assert result.to_dicts() == [
+        {"bucket": "alpha", "summary": "first | second", "row_value_sum": 60},
+        {"bucket": "empty-docs", "summary": None, "row_value_sum": 40},
+        {"bucket": "null-docs", "summary": None, "row_value_sum": 50},
+    ]
+
+
+@pytest.mark.xfail(
+    raises=ExecutionError,
+    reason="semantic.reduce currently creates a ThreadPoolExecutor with max_workers=0 for empty grouped inputs.",
+)
+def test_semantic_reduce_golden_empty_result(local_session, monkeypatch):
+    _install_deterministic_reduce_model(local_session, monkeypatch)
+
+    df = local_session.create_dataframe(
+        {
+            "bucket": ["alpha"],
+            "notes": ["first"],
+            "row_value": [1],
+        }
+    )
+    empty_result = df.filter(col("bucket") == "missing").group_by("bucket").agg(
+        semantic.reduce("Summarize notes in order.", col("notes")).alias("summary"),
+        sum("row_value").alias("row_value_sum"),
+    ).to_polars()
+    assert empty_result.is_empty()
+    assert empty_result.schema == {
+        "bucket": pl.Utf8,
+        "summary": pl.Utf8,
+        "row_value_sum": pl.Int64,
+    }
+
 
 def test_semantic_reduce_with_order_by(local_session):
     """Test semantic.reduce() method."""

--- a/tests/test_benchmark_semantic_operator_memory.py
+++ b/tests/test_benchmark_semantic_operator_memory.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+
+SCRIPT = "tools/benchmark_semantic_operator_memory.py"
+
+
+def test_semantic_operator_memory_harness_emits_machine_readable_case_result():
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--cases",
+            "semantic_join",
+            "--rows",
+            "2",
+            "--label",
+            "pytest",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+
+    assert payload["label"] == "pytest"
+    assert payload["measurement"]["rss_source"] == "resource.getrusage(RUSAGE_SELF).ru_maxrss"
+    assert payload["measurement"]["polars_allocation_bytes"] is None
+    assert "does not expose a process peak allocator counter" in payload["measurement"]["polars_allocation_note"]
+    assert [case["case"] for case in payload["cases"]] == ["semantic_join"]
+
+    case = payload["cases"][0]
+    assert case["peak_rss_bytes"] > 0
+    assert case["elapsed_ms"] >= 0
+    assert case["result_rows"] >= 0
+    assert case["parameters"]["rows"] == 2
+    assert case["parameters"]["network_calls"] == "disabled"
+
+
+def test_semantic_operator_memory_harness_markdown_keeps_copyable_json_block():
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--cases",
+            "sim_join",
+            "--rows",
+            "2",
+            "--label",
+            "markdown-test",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "# Semantic operator memory benchmark" in result.stdout
+    assert "```json" in result.stdout
+    json_block = result.stdout.split("```json", 1)[1].split("```", 1)[0].strip()
+    payload = json.loads(json_block)
+    assert payload["cases"][0]["case"] == "sim_join"
+    assert payload["cases"][0]["peak_rss_bytes"] > 0

--- a/tools/benchmark_semantic_operator_memory.py
+++ b/tools/benchmark_semantic_operator_memory.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Peak-memory benchmark harness for representative semantic operators.
+
+This harness is intentionally opt-in and local-only. It runs each requested case
+in an isolated child process, records the child process peak RSS via
+``resource.getrusage(RUSAGE_SELF).ru_maxrss``, and emits copyable JSON evidence
+that can be compared before/after a change.
+
+Polars allocation note:
+    Polars does not currently expose a stable process peak allocator counter
+    through the existing fenic test/benchmark tooling. This harness therefore
+    treats peak RSS as the authoritative memory signal and reports Polars
+    allocation as unavailable instead of inventing allocator precision.
+
+Examples:
+    uv run python tools/benchmark_semantic_operator_memory.py --rows 64
+    uv run python tools/benchmark_semantic_operator_memory.py --json --label before
+    uv run python tools/benchmark_semantic_operator_memory.py --cases sim_join,semantic_reduce
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import multiprocessing as mp
+import os
+import platform
+import resource
+import subprocess  # nosec B404 - used only to invoke the local git executable for metadata.
+import sys
+import tempfile
+import time
+import traceback
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+CaseName = Literal["sim_join", "semantic_reduce", "semantic_join", "map_extract_chain"]
+ALL_CASES: tuple[CaseName, ...] = (
+    "sim_join",
+    "semantic_reduce",
+    "semantic_join",
+    "map_extract_chain",
+)
+RSS_SOURCE = "resource.getrusage(RUSAGE_SELF).ru_maxrss"
+POLARS_ALLOCATION_NOTE = (
+    "Polars does not expose a process peak allocator counter through the existing "
+    "fenic benchmark/test tooling; peak RSS is reported as the stable comparable "
+    "memory signal."
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class BenchmarkConfig:
+    rows: int
+    right_rows: int
+    groups: int
+    embedding_dimensions: int
+    k: int
+    label: str
+
+
+def _ru_maxrss_to_bytes(ru_maxrss: int) -> int:
+    # Linux reports KiB; macOS reports bytes. The worker host for this task is Linux.
+    return ru_maxrss if sys.platform == "darwin" else ru_maxrss * 1024
+
+
+def _peak_rss_bytes() -> int:
+    return _ru_maxrss_to_bytes(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+
+
+def _git_value(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(  # nosec
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return None
+
+
+def _patch_provider_validation() -> None:
+    import fenic._backends.local.model_registry as model_registry
+
+    async def _no_validate_provider_api_keys(providers: set[object]) -> None:
+        return None
+
+    model_registry._validate_provider_api_keys = _no_validate_provider_api_keys
+
+
+def _configure_local_language_model(session: Any) -> None:
+    from fenic._inference.types import FenicCompletionsResponse
+
+    model = session._session_state.get_language_model()
+
+    def count_tokens(value: object) -> int:
+        if value is None:
+            return 1
+        if isinstance(value, str):
+            return max(1, len(value.split()))
+        return max(1, len(str(value).split()))
+
+    def fake_get_completions(
+        messages: list[object | None],
+        max_tokens: int | None = None,
+        temperature: float = 0,
+        response_format: object | None = None,
+        top_logprobs: int | None = None,
+        model_profile: str | None = None,
+        operation_name: str | None = None,
+        request_timeout: float | None = None,
+    ) -> list[FenicCompletionsResponse | None]:
+        responses: list[FenicCompletionsResponse | None] = []
+        for idx, message in enumerate(messages):
+            if message is None:
+                responses.append(None)
+                continue
+            user = getattr(message, "user", "") or ""
+            if operation_name == "semantic.predicate":
+                completion = json.dumps({"output": _deterministic_predicate(user)})
+            elif operation_name and operation_name.startswith("semantic.reduce"):
+                completion = f"summary-{idx}-{_stable_bucket(user)}"
+            elif operation_name == "semantic.extract":
+                completion = json.dumps(
+                    {
+                        "category": _stable_bucket(user),
+                        "priority": (idx % 5) + 1,
+                    }
+                )
+            else:
+                completion = f"mapped {_stable_bucket(user)} :: {user[:80]}"
+            responses.append(FenicCompletionsResponse(completion=completion, logprobs=None))
+        return responses
+
+    model.count_tokens = count_tokens
+    model.get_completions = fake_get_completions
+
+
+def _deterministic_predicate(rendered_prompt: str) -> bool:
+    # Keep the semantic.join result bounded but non-empty without relying on a provider.
+    return _stable_bucket(rendered_prompt) in {"alpha", "gamma"}
+
+
+def _stable_bucket(value: str) -> str:
+    buckets = ("alpha", "beta", "gamma", "delta")
+    return buckets[sum(value.encode("utf-8")) % len(buckets)]
+
+
+def _new_session(tmpdir: str, *, with_language_model: bool) -> Any:
+    from fenic import OpenAILanguageModel, SemanticConfig, Session, SessionConfig
+
+    _patch_provider_validation()
+    # The configured client is patched before any semantic operation executes; this
+    # dummy value only lets provider client construction run without external I/O.
+    os.environ.setdefault("OPENAI_API_KEY", "local-semantic-memory-harness-no-network")
+
+    semantic_config = None
+    if with_language_model:
+        semantic_config = SemanticConfig(
+            language_models={
+                "local": OpenAILanguageModel(
+                    model_name="gpt-4.1-nano",
+                    rpm=1_000_000,
+                    tpm=1_000_000,
+                )
+            },
+            default_language_model="local",
+        )
+
+    return Session.get_or_create(
+        SessionConfig(
+            app_name=f"semantic-memory-{os.getpid()}-{time.time_ns()}",
+            db_path=Path(tmpdir),
+            semantic=semantic_config,
+        )
+    )
+
+
+def _embedding_vector(seed: int, dimensions: int) -> list[float]:
+    return [float(((seed + 1) * (idx + 3)) % 17) / 17.0 for idx in range(dimensions)]
+
+
+def _run_sim_join(config: BenchmarkConfig) -> dict[str, Any]:
+    import polars as pl
+
+    from fenic import EmbeddingType, col
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        session = _new_session(tmpdir, with_language_model=False)
+        try:
+            left = session.create_dataframe(
+                pl.DataFrame(
+                    {
+                        "left_id": list(range(config.rows)),
+                        "left_label": [f"left-{idx % 8}" for idx in range(config.rows)],
+                        "left_vec": [
+                            _embedding_vector(idx, config.embedding_dimensions)
+                            for idx in range(config.rows)
+                        ],
+                    },
+                    schema={
+                        "left_id": pl.Int64,
+                        "left_label": pl.String,
+                        "left_vec": pl.List(pl.Float32),
+                    },
+                )
+            ).with_column(
+                "left_vec",
+                col("left_vec").cast(
+                    EmbeddingType(
+                        dimensions=config.embedding_dimensions,
+                        embedding_model="local-memory-harness",
+                    )
+                ),
+            )
+            right = session.create_dataframe(
+                pl.DataFrame(
+                    {
+                        "right_id": list(range(config.right_rows)),
+                        "right_label": [f"right-{idx % 8}" for idx in range(config.right_rows)],
+                        "right_vec": [
+                            _embedding_vector(idx, config.embedding_dimensions)
+                            for idx in range(config.right_rows)
+                        ],
+                    },
+                    schema={
+                        "right_id": pl.Int64,
+                        "right_label": pl.String,
+                        "right_vec": pl.List(pl.Float32),
+                    },
+                )
+            ).with_column(
+                "right_vec",
+                col("right_vec").cast(
+                    EmbeddingType(
+                        dimensions=config.embedding_dimensions,
+                        embedding_model="local-memory-harness",
+                    )
+                ),
+            )
+            result = left.semantic.sim_join(
+                right,
+                left_on="left_vec",
+                right_on="right_vec",
+                k=config.k,
+                similarity_metric="l2",
+                similarity_score_column="distance",
+            ).to_polars()
+            return {
+                "result_rows": len(result),
+                "result_columns": result.columns,
+            }
+        finally:
+            session.stop(skip_usage_summary=True)
+
+
+def _run_semantic_reduce(config: BenchmarkConfig) -> dict[str, Any]:
+    from fenic import col, semantic
+    from fenic import sum as fenic_sum
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        session = _new_session(tmpdir, with_language_model=True)
+        try:
+            _configure_local_language_model(session)
+            rows = max(config.rows, config.groups)
+            source = session.create_dataframe(
+                {
+                    "bucket": [f"bucket-{idx % config.groups}" for idx in range(rows)],
+                    "sort_key": list(range(rows)),
+                    "notes": [
+                        f"doc-{idx}: customer {idx % 5} reported memory signal {idx % 7}."
+                        for idx in range(rows)
+                    ],
+                    "weight": [1 for _ in range(rows)],
+                }
+            )
+            result = (
+                source.group_by("bucket")
+                .agg(
+                    semantic.reduce(
+                        "Summarize memory signals in order.",
+                        col("notes"),
+                        order_by=[col("sort_key")],
+                    ).alias("summary"),
+                    fenic_sum("weight").alias("weight_sum"),
+                )
+                .to_polars()
+            )
+            return {
+                "result_rows": len(result),
+                "result_columns": result.columns,
+            }
+        finally:
+            session.stop(skip_usage_summary=True)
+
+
+def _run_semantic_join(config: BenchmarkConfig) -> dict[str, Any]:
+    from fenic import col
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        session = _new_session(tmpdir, with_language_model=True)
+        try:
+            _configure_local_language_model(session)
+            left = session.create_dataframe(
+                {
+                    "left_id": list(range(config.rows)),
+                    "course_name": [f"course-{idx % 6}" for idx in range(config.rows)],
+                    "left_payload": [f"payload-left-{idx}" for idx in range(config.rows)],
+                }
+            )
+            right = session.create_dataframe(
+                {
+                    "right_id": list(range(config.right_rows)),
+                    "skill": [f"skill-{idx % 6}" for idx in range(config.right_rows)],
+                    "right_payload": [f"payload-right-{idx}" for idx in range(config.right_rows)],
+                }
+            )
+            result = left.semantic.join(
+                right,
+                "Does {{left_on}} correspond to {{right_on}}?",
+                left_on=col("course_name"),
+                right_on=col("skill"),
+            ).to_polars()
+            return {
+                "result_rows": len(result),
+                "result_columns": result.columns,
+            }
+        finally:
+            session.stop(skip_usage_summary=True)
+
+
+def _run_map_extract_chain(config: BenchmarkConfig) -> dict[str, Any]:
+    from pydantic import BaseModel, Field
+
+    from fenic import col, semantic
+
+    class ExtractedSignal(BaseModel):
+        category: str = Field(description="Stable synthetic category")
+        priority: int = Field(description="Stable synthetic priority")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        session = _new_session(tmpdir, with_language_model=True)
+        try:
+            _configure_local_language_model(session)
+            source = session.create_dataframe(
+                {
+                    "record_id": list(range(config.rows)),
+                    "description": [
+                        f"record-{idx}: operator memory behavior for category {idx % 4}"
+                        for idx in range(config.rows)
+                    ],
+                }
+            )
+            mapped = source.select(
+                col("record_id"),
+                semantic.map(
+                    "Normalize this benchmark record: {{description}}",
+                    description=col("description"),
+                ).alias("normalized"),
+            )
+            result = mapped.select(
+                col("record_id"),
+                semantic.extract(col("normalized"), ExtractedSignal).alias("signal"),
+            ).to_polars()
+            return {
+                "result_rows": len(result),
+                "result_columns": result.columns,
+            }
+        finally:
+            session.stop(skip_usage_summary=True)
+
+
+CASE_RUNNERS: dict[CaseName, Callable[[BenchmarkConfig], dict[str, Any]]] = {
+    "sim_join": _run_sim_join,
+    "semantic_reduce": _run_semantic_reduce,
+    "semantic_join": _run_semantic_join,
+    "map_extract_chain": _run_map_extract_chain,
+}
+
+
+def _run_case_child(case: CaseName, config: BenchmarkConfig, queue: mp.Queue) -> None:
+    started = time.perf_counter()
+    try:
+        details = CASE_RUNNERS[case](config)
+        elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+        queue.put(
+            {
+                "ok": True,
+                "case": case,
+                "elapsed_ms": elapsed_ms,
+                "peak_rss_bytes": _peak_rss_bytes(),
+                "result_rows": details["result_rows"],
+                "result_columns": details["result_columns"],
+                "parameters": {
+                    "rows": config.rows,
+                    "right_rows": config.right_rows,
+                    "groups": config.groups,
+                    "embedding_dimensions": config.embedding_dimensions,
+                    "k": config.k,
+                    "network_calls": "disabled",
+                },
+            }
+        )
+    except Exception as exc:
+        queue.put(
+            {
+                "ok": False,
+                "case": case,
+                "error": repr(exc),
+                "traceback": traceback.format_exc(),
+                "peak_rss_bytes": _peak_rss_bytes(),
+            }
+        )
+
+
+def _run_case(case: CaseName, config: BenchmarkConfig) -> dict[str, Any]:
+    ctx = mp.get_context("spawn")
+    queue: mp.Queue = ctx.Queue()
+    process = ctx.Process(target=_run_case_child, args=(case, config, queue))
+    process.start()
+    process.join()
+    if queue.empty():
+        return {
+            "ok": False,
+            "case": case,
+            "error": f"child exited with code {process.exitcode} before reporting",
+            "peak_rss_bytes": 0,
+        }
+    result = queue.get()
+    result["exit_code"] = process.exitcode
+    return result
+
+
+def _parse_cases(value: str) -> list[CaseName]:
+    if value == "all":
+        return list(ALL_CASES)
+    selected: list[CaseName] = []
+    for raw_case in value.split(","):
+        case = raw_case.strip()
+        if case not in ALL_CASES:
+            raise argparse.ArgumentTypeError(
+                f"unknown case {case!r}; choose from {', '.join(ALL_CASES)} or all"
+            )
+        selected.append(case)  # type: ignore[arg-type]
+    if not selected:
+        raise argparse.ArgumentTypeError("at least one case is required")
+    return selected
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    config = BenchmarkConfig(
+        rows=args.rows,
+        right_rows=args.right_rows,
+        groups=args.groups,
+        embedding_dimensions=args.embedding_dimensions,
+        k=args.k,
+        label=args.label,
+    )
+    case_results = [_run_case(case, config) for case in args.cases]
+    failures = [case for case in case_results if not case.get("ok")]
+    payload = {
+        "schema_version": 1,
+        "label": args.label,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "git": {
+            "branch": _git_value(["rev-parse", "--abbrev-ref", "HEAD"]),
+            "commit": _git_value(["rev-parse", "HEAD"]),
+            "merge_base_origin_main": _git_value(["merge-base", "HEAD", "origin/main"]),
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "measurement": {
+            "rss_source": RSS_SOURCE,
+            "peak_rss_unit": "bytes",
+            "polars_allocation_bytes": None,
+            "polars_allocation_note": POLARS_ALLOCATION_NOTE,
+            "process_isolation": "one spawned child process per case",
+        },
+        "cases": case_results,
+    }
+    if failures:
+        payload["failures"] = failures
+    return payload
+
+
+def _format_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Semantic operator memory benchmark",
+        "",
+        f"Label: `{payload['label']}`",
+        f"Generated: `{payload['generated_at']}`",
+        f"Git commit: `{payload['git']['commit']}`",
+        "",
+        "Peak memory is reported as child-process peak RSS in bytes. Polars "
+        "allocator peak bytes are unavailable in this harness and intentionally "
+        "reported as null.",
+        "",
+        "| case | peak_rss_bytes | elapsed_ms | result_rows |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for case in payload["cases"]:
+        lines.append(
+            f"| {case['case']} | {case.get('peak_rss_bytes', 0)} | "
+            f"{case.get('elapsed_ms', 'n/a')} | {case.get('result_rows', 'n/a')} |"
+        )
+    lines.extend(
+        [
+            "",
+            "```json",
+            json.dumps(payload, indent=2, sort_keys=True),
+            "```",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", type=_parse_cases, default=list(ALL_CASES))
+    parser.add_argument("--rows", type=int, default=64)
+    parser.add_argument("--right-rows", type=int, default=32)
+    parser.add_argument("--groups", type=int, default=8)
+    parser.add_argument("--embedding-dimensions", type=int, default=8)
+    parser.add_argument("--k", type=int, default=2)
+    parser.add_argument("--label", default="local")
+    parser.add_argument("--json", action="store_true", help="Emit raw JSON only.")
+    args = parser.parse_args()
+
+    if args.rows <= 0 or args.right_rows <= 0 or args.groups <= 0:
+        raise SystemExit("--rows, --right-rows, and --groups must be positive")
+    if args.embedding_dimensions <= 0 or args.k <= 0:
+        raise SystemExit("--embedding-dimensions and --k must be positive")
+
+    payload = run_benchmark(args)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_markdown(payload))
+    if payload.get("failures"):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_semantic_operator_memory.py
+++ b/tools/benchmark_semantic_operator_memory.py
@@ -4,7 +4,21 @@
 This harness is intentionally opt-in and local-only. It runs each requested case
 in an isolated child process, records the child process peak RSS via
 ``resource.getrusage(RUSAGE_SELF).ru_maxrss``, and emits copyable JSON evidence
-that can be compared before/after a change.
+that can be compared before/after a change. See
+``tools/benchmark_semantic_operator_memory_protocol.md`` for the full benchmark
+matrix, PR evidence protocol, and reviewer checklist.
+
+Default benchmark matrix:
+    ``--cases all`` runs ``sim_join``, ``semantic_reduce``, ``semantic_join``, and
+    ``map_extract_chain`` using ``--rows 64 --right-rows 32 --groups 8
+    --embedding-dimensions 8 --k 2``. These defaults are the starting point for
+    evidence-grade local before/after runs.
+
+Smoke-test boundary:
+    Pytest-sized cases such as ``--rows 2`` prove that the harness works and does
+    not call external providers. They are smoke tests only, not evidence for
+    memory-improvement claims. Increase sizes when process/session startup RSS
+    dominates the operator signal.
 
 Polars allocation note:
     Polars does not currently expose a stable process peak allocator counter
@@ -12,10 +26,19 @@ Polars allocation note:
     treats peak RSS as the authoritative memory signal and reports Polars
     allocation as unavailable instead of inventing allocator precision.
 
-Examples:
-    uv run python tools/benchmark_semantic_operator_memory.py --rows 64
-    uv run python tools/benchmark_semantic_operator_memory.py --json --label before
-    uv run python tools/benchmark_semantic_operator_memory.py --cases sim_join,semantic_reduce
+Evidence examples (wrap as needed):
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --json --label TD-XXXX-before-default
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --json --label TD-XXXX-after-default
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --cases sim_join --json --label TD-XXXX-before-sim-join
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --cases semantic_reduce --json --label TD-XXXX-before-semantic-reduce
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --cases semantic_join --json --label TD-XXXX-before-semantic-join
+    uv run python tools/benchmark_semantic_operator_memory.py
+        --cases map_extract_chain --json --label TD-XXXX-before-map-extract-chain
 """
 
 from __future__ import annotations
@@ -522,7 +545,10 @@ def _format_markdown(payload: dict[str, Any]) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--cases", type=_parse_cases, default=list(ALL_CASES))
     parser.add_argument("--rows", type=int, default=64)
     parser.add_argument("--right-rows", type=int, default=32)

--- a/tools/benchmark_semantic_operator_memory.py
+++ b/tools/benchmark_semantic_operator_memory.py
@@ -58,6 +58,7 @@ import time
 import traceback
 from collections.abc import Callable
 from pathlib import Path
+from queue import Empty
 from typing import Any, Literal
 
 CaseName = Literal["sim_join", "semantic_reduce", "semantic_join", "map_extract_chain"]
@@ -447,14 +448,22 @@ def _run_case(case: CaseName, config: BenchmarkConfig) -> dict[str, Any]:
     process = ctx.Process(target=_run_case_child, args=(case, config, queue))
     process.start()
     process.join()
-    if queue.empty():
+    try:
+        result = queue.get_nowait()
+    except Empty:
         return {
             "ok": False,
             "case": case,
             "error": f"child exited with code {process.exitcode} before reporting",
             "peak_rss_bytes": 0,
         }
-    result = queue.get()
+    except Exception as exc:
+        return {
+            "ok": False,
+            "case": case,
+            "error": f"failed to read child result after exit code {process.exitcode}: {exc!r}",
+            "peak_rss_bytes": 0,
+        }
     result["exit_code"] = process.exitcode
     return result
 
@@ -489,7 +498,7 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
     payload = {
         "schema_version": 1,
         "label": args.label,
-        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "git": {
             "branch": _git_value(["rev-parse", "--abbrev-ref", "HEAD"]),
             "commit": _git_value(["rev-parse", "HEAD"]),

--- a/tools/benchmark_semantic_operator_memory_protocol.md
+++ b/tools/benchmark_semantic_operator_memory_protocol.md
@@ -1,0 +1,137 @@
+# Semantic operator memory benchmark protocol
+
+`tools/benchmark_semantic_operator_memory.py` is the opt-in, local-only peak RSS
+harness for representative semantic operators. Use this protocol when a PR claims
+that semantic operator memory usage improved or regressed.
+
+The harness reports child-process peak RSS in bytes from
+`resource.getrusage(RUSAGE_SELF).ru_maxrss`. Polars allocator peak bytes are not
+available through the existing fenic benchmark/test tooling, so PR evidence must
+compare peak RSS instead of inventing allocator precision.
+
+## Default benchmark matrix
+
+The default CLI matrix is intentionally small enough for local repeatability and
+large enough to exercise the full operator path for each case. These are the
+starting parameters used when no size flags are supplied:
+
+- Similarity join
+  - Selector: `--cases sim_join`
+  - Size: `--rows 64 --right-rows 32 --embedding-dimensions 8 --k 2`
+  - Exercises embedding column construction, vector casting, and top-k similarity
+    join materialization.
+- Semantic reduce
+  - Selector: `--cases semantic_reduce`
+  - Size: `--rows 64 --groups 8`
+  - Exercises grouped semantic reduce with deterministic local completions and
+    ordered aggregation.
+- Semantic join
+  - Selector: `--cases semantic_join`
+  - Size: `--rows 64 --right-rows 32`
+  - Exercises predicate-based semantic join using deterministic local completions.
+- Map/extract chain
+  - Selector: `--cases map_extract_chain`
+  - Size: `--rows 64`
+  - Exercises chained `semantic.map` -> `semantic.extract` materialization.
+
+`--cases all` runs the full matrix. Unless a PR has a narrower reason to target a
+single operator, before/after evidence should include the full matrix.
+
+## Smoke tests versus evidence-grade runs
+
+Pytest-sized cases such as `--rows 2` are smoke tests only. They prove that the
+harness executes, emits JSON/Markdown, and avoids external provider calls. They do
+not provide stable evidence for memory claims because fixed process/session
+startup overhead can dominate the operator work.
+
+For evidence-grade runs, start with the default matrix. Increase `--rows`,
+`--right-rows`, `--groups`, or `--embedding-dimensions` when before/after numbers
+are close enough that process startup noise could hide the operator signal. Larger
+sizes are especially useful when the reported delta is within a small multiple of
+the baseline idle/session RSS or when a change affects per-row, per-candidate, or
+per-group memory behavior.
+
+## Evidence-grade commands
+
+Run commands from the repo root. Prefer `--json` for artifacts checked by agents
+or CI-adjacent review tooling; omit `--json` when a reviewer wants copyable
+Markdown with the embedded JSON block.
+
+Full default matrix:
+
+```bash
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --json \
+  --label TD-XXXX-before-default
+
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --json \
+  --label TD-XXXX-after-default
+```
+
+Per-operator commands:
+
+```bash
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --cases sim_join \
+  --json \
+  --label TD-XXXX-before-sim-join
+
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --cases semantic_reduce \
+  --json \
+  --label TD-XXXX-before-semantic-reduce
+
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --cases semantic_join \
+  --json \
+  --label TD-XXXX-before-semantic-join
+
+uv run python tools/benchmark_semantic_operator_memory.py \
+  --cases map_extract_chain \
+  --json \
+  --label TD-XXXX-before-map-extract-chain
+```
+
+Repeat the same command set after the implementation change with `after` labels.
+Keep all non-code review artifacts under `.hermes/evidence/` or another ignored
+local path; do not commit raw benchmark outputs unless the PR explicitly needs a
+curated fixture.
+
+## Labeling convention
+
+Use labels in this shape:
+
+```text
+<TD issue>-<before|after>-<scope>[-<size>]
+```
+
+Examples:
+
+- `TD-3381-before-default`
+- `TD-3381-after-default`
+- `TD-3381-before-semantic-join-rows-512-right-256`
+- `TD-3381-after-semantic-join-rows-512-right-256`
+
+The before and after labels must differ only by the `before`/`after` segment when
+they are meant to compare the same matrix and size.
+
+## Reviewer checklist for memory-improvement PRs
+
+A PR that claims semantic operator peak-memory improvement should cite:
+
+1. Before and after benchmark JSON or Markdown output produced by this harness.
+2. The exact command line for each cited artifact, including case selectors and
+   size flags.
+3. The git commit and branch embedded in each benchmark payload.
+4. Confirmation that pytest-sized runs such as `--rows 2` were used only as smoke
+   checks, not as memory evidence.
+5. Rationale for any non-default size, including why a larger matrix was needed
+   to escape process/session startup noise.
+6. A short interpretation of the peak RSS delta by case, without introducing hard
+   pass/fail memory thresholds unless a separate benchmark policy explicitly adds
+   them.
+
+Do not add large benchmark runs to default CI as part of this protocol. Keep the
+harness opt-in until a separate CI policy defines runtime budget, hardware shape,
+and acceptable noise bounds.


### PR DESCRIPTION
## Summary

This PR adds local semantic-operator guardrails that make the execution path easier to verify before we tune runtime behavior. It locks in representative golden outputs, adds a deterministic semantic.reduce → model-client tripwire, and introduces a repeatable peak-RSS benchmark protocol so future memory-footprint improvements can cite comparable before/after evidence instead of relying on ad hoc observations.

The branch also includes the semantic.reduce compatibility fix needed after the Polars stack update changed the grouped `map_batches` callback shape. Follow-up review tightened that fix to avoid Python `to_list()`/DataFrame round-trips in the hot preprocessing path.

## Linear issues

- TD-3317: M0 golden-output correctness tests for semantic operators
- TD-3319: M0 reduce→model_client integration API tripwire
- TD-3316: M0 peak-memory regression harness for semantic operators
- TD-3381: M0 semantic memory benchmark matrix and PR evidence protocol

## What changed

- Added golden-output coverage for semantic.join, semantic.sim_join, and semantic.reduce local execution behavior.
- Added a deterministic semantic.reduce integration tripwire proving the operator reaches the LanguageModel / ModelClient completions API with the expected request shape.
- Fixed semantic.reduce for current Polars grouped `map_batches` callback behavior while preserving compatibility with direct Series-of-Series callers.
- Avoided unnecessary Python materialization in semantic.reduce preprocessing by using direct struct-field extraction for the no-context/no-sort path and `struct.unnest()` when a DataFrame is needed.
- Added a process-isolated semantic-operator memory harness plus focused tests.
- Documented the smoke-test versus evidence-grade benchmark matrix and PR evidence protocol for memory-improvement claims.

## Evidence / validation

- [x] `git diff --check`
- [x] `trunk check --fix --no-progress src/fenic/_backends/local/semantic_operators/reduce.py tests/_backends/local/functions/test_semantic_reduce.py` — checked 3 files, no issues.
- [x] `uv run pytest -q tests/_backends/local/semantic_operators/test_reduce.py tests/_backends/local/functions/test_semantic_reduce.py tests/test_benchmark_semantic_operator_memory.py` — 25 passed, 5 warnings.
- [x] Earlier PR package validation: `uv run --env-file /home/hermes/.hermes/.env pytest -q tests/_backends/local/dataframe/test_semantic_join.py tests/_backends/local/dataframe/test_semantic_sim_join.py tests/_backends/local/functions/test_semantic_reduce.py tests/test_benchmark_semantic_operator_memory.py` — 36 passed, 1 xfailed, 5 warnings before the later empty-input xfail cleanup.
- [x] `uv run python tools/benchmark_semantic_operator_memory.py --help` — help renders the benchmark protocol guidance.
- [x] `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u GEMINI_API_KEY uv run python tools/benchmark_semantic_operator_memory.py --cases semantic_reduce,map_extract_chain --rows 2 --right-rows 2 --groups 1 --label pr-package-offline-check --json` — both cases passed without provider credentials.

## Reviewer notes

- TD-3318/provider idle-gap instrumentation is intentionally excluded from this PR.
- The semantic.reduce empty-input golden-output case now passes and is no longer marked xfail.
- Cross-group semantic.reduce execution is now delegated to Polars grouped `map_batches` scheduling for the real execution path. Local fake-model review observed grouped callbacks still running concurrently; the explicit `Reduce.execute()` ThreadPoolExecutor is no longer the concurrency owner.
- `.hermes/` evidence and `.venv/` are preserved locally but ignored/untracked and not included in the PR.

## Release / risk

- Risk: Low/Medium — mostly test/tooling/protocol guardrails, plus a semantic.reduce runtime compatibility fix for current Polars grouped `map_batches` behavior. The compatibility path has focused semantic.reduce coverage and avoids the preprocessing overhead called out during review.
- Rollback: Revert this PR; no migration or production state change is required.