### PR TITLE
chore(renovate): group polars rust crates into one lockstep PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,17 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>typedef-ai/renovate:default.json5'],
+  packageRules: [
+    {
+      // The polars Rust crate family must be upgraded in lockstep: pyo3-polars
+      // pins specific polars/polars-arrow versions, so bumping any one of them
+      // alone puts two incompatible copies of the polars crates in the dep
+      // graph (see PR #251). pyo3 is included because pyo3-polars also pins a
+      // specific pyo3 minor version.
+      description: 'Group polars Rust crates (and pyo3) into a single lockstep PR',
+      matchManagers: ['cargo'],
+      matchPackageNames: ['polars', 'polars-arrow', 'pyo3-polars', 'pyo3'],
+      groupName: 'polars rust crates',
+    },
+  ],
 }


### PR DESCRIPTION
## Why

Renovate PR #251 bumped `polars` to 0.54 alone, leaving `polars-arrow` (0.48.1) and `pyo3-polars` (0.21.0) behind. Those crates pin each other's versions, so a solo bump puts two incompatible copies of the polars crate family in the dependency graph and the build fails with type mismatches in every `#[polars_expr]` plugin function.

## What

Adds a repo-local `packageRules` entry grouping `polars`, `polars-arrow`, `pyo3-polars`, and `pyo3` cargo updates into a single Renovate PR (`pyo3` is included because `pyo3-polars` also pins a specific pyo3 minor).

Note: grouping makes future bumps coherent but doesn't guarantee they compile — pyo3-polars releases lag polars releases (no published pyo3-polars supports polars 0.54 yet). The actual upgrade to the 0.53 stack will follow in a separate PR stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)