### PR TITLE
ci: increase allcheckspassed retries

### DIFF
--- a/.github/workflows/pr_allcheckspassed.yaml
+++ b/.github/workflows/pr_allcheckspassed.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: wechuli/allcheckspassed@204ff63e89eabdc8086f0c50b91f675bcf37c8f6 # v2.4.0
         with:
           delay: "3" # default: 1
-          retries: "15" # default: 10
+          retries: "20" # default: 10
           polling_interval: "1" # default
           checks_exclude: Graphite / mergeability_check
           ignore_superseded_runs: "true"


### PR DESCRIPTION
allcheckspassed now keeps polling long enough for recent CI runs that exceed 15 minutes, reducing false failures while tests are still running. The retry budget increases from 15 to 20 without changing the checks being monitored.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
