### PR TITLE
perf: bound semantic similarity join memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "polars>=1.34.0,<1.36.0",
   "tiktoken>=0.11.0",
   "lancedb>=0.22.0,<0.25.0",
-  "openai>=1.101.0",
+  "openai==2.40.0",
   "sqlglot>=29.0.1,<31.0.0",
   "pandas>=2.2.2",
   "cloudpickle>=3.1.1",

--- a/src/fenic/_backends/local/physical_plan/join.py
+++ b/src/fenic/_backends/local/physical_plan/join.py
@@ -259,20 +259,30 @@ class SemanticSimilarityJoinExec(PhysicalPlan):
         )
 
         # TODO(rohitrastogi): Avoid regenerating embeddings if semantic index already exists
-        result = SemanticSimJoin(left_df, right_df, self.k, self.similarity_metric).execute()
+        result = SemanticSimJoin(
+            left_df,
+            right_df,
+            self.k,
+            self.similarity_metric,
+            include_left_on=maybe_left_name is not None,
+            include_right_on=maybe_right_name is not None,
+        ).execute()
 
         if self.similarity_score_column:
             result = result.rename({DISTANCE_COL_NAME: self.similarity_score_column})
         else:
             result = result.drop(DISTANCE_COL_NAME)
 
-        # Restore original column names or drop temporary columns
-        result = restore_column_after_join(
-            result, maybe_left_name, LEFT_ON_COL_NAME
-        )
-        result = restore_column_after_join(
-            result, maybe_right_name, RIGHT_ON_COL_NAME
-        )
+        # Restore original column names. Derived temporary join columns are not
+        # materialized by SemanticSimJoin, so there is nothing to drop for them.
+        if maybe_left_name is not None:
+            result = restore_column_after_join(
+                result, maybe_left_name, LEFT_ON_COL_NAME
+            )
+        if maybe_right_name is not None:
+            result = restore_column_after_join(
+                result, maybe_right_name, RIGHT_ON_COL_NAME
+            )
 
         return result
 

--- a/src/fenic/_backends/local/semantic_operators/sim_join.py
+++ b/src/fenic/_backends/local/semantic_operators/sim_join.py
@@ -1,4 +1,5 @@
-import uuid
+import os
+import tempfile
 
 import lancedb
 import polars as pl
@@ -21,6 +22,8 @@ RIGHT_ON_COL_NAME = "__right_on__"
 LEFT_ID_COL_NAME = "__left_id__"
 RIGHT_ID_COL_NAME = "__right_id__"
 MATCH_RESULT_COL_NAME = "__match_result__"
+DEFAULT_LEFT_BATCH_SIZE = 1024
+
 
 class SimJoin:
     def __init__(
@@ -29,11 +32,19 @@ class SimJoin:
         right: pl.DataFrame,
         k: int,
         similarity_metric: SemanticSimilarityMetric,
+        left_batch_size: int = DEFAULT_LEFT_BATCH_SIZE,
+        include_left_on: bool = True,
+        include_right_on: bool = True,
     ):
         self.left = left.with_row_index(LEFT_ID_COL_NAME)
         self.right = right.with_row_index(RIGHT_ID_COL_NAME)
         self.k = k
         self.similarity_metric = similarity_metric
+        if left_batch_size <= 0:
+            raise ValueError("left_batch_size must be positive")
+        self.left_batch_size = left_batch_size
+        self.include_left_on = include_left_on
+        self.include_right_on = include_right_on
 
     def execute(self) -> pl.DataFrame:
         """Perform semantic similarity join on the DataFrame using vector embeddings.
@@ -50,10 +61,12 @@ class SimJoin:
             return self._empty_result_with_schema(left, right)
 
         matches_df = self._batch_similarity_search(left, right)
+        left_result = left if self.include_left_on else left.drop(LEFT_ON_COL_NAME)
+        right_result = right if self.include_right_on else right.drop(RIGHT_ON_COL_NAME)
 
         result = (
-            matches_df.join(left, on=LEFT_ID_COL_NAME, how="inner")
-            .join(right, on=RIGHT_ID_COL_NAME, how="inner")
+            matches_df.join(left_result, on=LEFT_ID_COL_NAME, how="inner")
+            .join(right_result, on=RIGHT_ID_COL_NAME, how="inner")
             .drop([LEFT_ID_COL_NAME, RIGHT_ID_COL_NAME])
         )
         # Reorder columns to have similarity score last
@@ -65,59 +78,74 @@ class SimJoin:
     def _batch_similarity_search(
         self, left: pl.DataFrame, right: pl.DataFrame
     ) -> pl.DataFrame:
-        guid = uuid.uuid4().hex
-        lance_table_dir = f"{VECTOR_INDEX_DIR}/{guid}"
-        db: DBConnection = lancedb.connect(lance_table_dir)
-        tbl: Table = db.create_table(
-            guid,
-            right.select(RIGHT_ON_COL_NAME, RIGHT_ID_COL_NAME).rename(
-                {RIGHT_ON_COL_NAME: VECTOR_COL_NAME}
-            ),
-        )
-        if len(right) > 5000:
-            tbl.create_index(metric=self.similarity_metric)
-
-        # Define UDF to perform search for each row
-        def search_vectors(left_embedding, left_id):
-            results = tbl.search(left_embedding).distance_type(self.similarity_metric).limit(self.k).to_list()
-
-            # Create list of structs with search results
-            matches = []
-            for result in results:
-                matches.append(
-                    {
-                        LEFT_ID_COL_NAME: left_id,
-                        RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
-                        DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
-                    }
-                )
-            return matches
-
-        # TODO(rohitrastogi): Do some experiments to see if sending concurrent requests to LanceDB
-        # using a thread pool is faster than sending requests sequentially. Vector search is CPU bound and LanceDB
-        # releases the GIL, so I'm not sure there will be any performance gains.
-        # FYI, LanceDB doesn't support batch vector search. If you pass a batch of vectors, it doesn't
-        # actually search in parallel.
-        return (
-            left.select(
-                pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
-                .map_elements(
-                    lambda x: search_vectors(x[LEFT_ON_COL_NAME], x[LEFT_ID_COL_NAME]),
-                    return_dtype=pl.List(
-                        pl.Struct(
-                            {
-                                LEFT_ID_COL_NAME: pl.Int32,
-                                RIGHT_ID_COL_NAME: pl.Int32,
-                                DISTANCE_COL_NAME: pl.Float64,
-                            }
-                        )
-                    ),
-                )
-                .alias(MATCH_RESULT_COL_NAME)
+        os.makedirs(VECTOR_INDEX_DIR, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="sim_join_", dir=VECTOR_INDEX_DIR
+        ) as lance_table_dir:
+            db: DBConnection = lancedb.connect(lance_table_dir)
+            tbl: Table = db.create_table(
+                "right_vectors",
+                right.select(RIGHT_ON_COL_NAME, RIGHT_ID_COL_NAME).rename(
+                    {RIGHT_ON_COL_NAME: VECTOR_COL_NAME}
+                ),
             )
-            .explode(MATCH_RESULT_COL_NAME)
-            .unnest(MATCH_RESULT_COL_NAME)
-        )
+            if len(right) > 5000:
+                tbl.create_index(metric=self.similarity_metric)
+
+            # Define UDF to perform search for each row
+            def search_vectors(left_embedding, left_id):
+                results = (
+                    tbl.search(left_embedding)
+                    .distance_type(self.similarity_metric)
+                    .limit(self.k)
+                    .to_list()
+                )
+
+                # Create list of structs with search results
+                matches = []
+                for result in results:
+                    matches.append(
+                        {
+                            LEFT_ID_COL_NAME: left_id,
+                            RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
+                            DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
+                        }
+                    )
+                return matches
+
+            # TODO(rohitrastogi): Do some experiments to see if sending concurrent requests to LanceDB
+            # using a thread pool is faster than sending requests sequentially. Vector search is CPU bound and LanceDB
+            # releases the GIL, so I'm not sure there will be any performance gains.
+            # FYI, LanceDB doesn't support batch vector search. If you pass a batch
+            # of vectors, it doesn't actually search in parallel.
+            def search_left_batch(left_batch: pl.DataFrame) -> pl.DataFrame:
+                return (
+                    left_batch.select(
+                        pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
+                        .map_elements(
+                            lambda x: search_vectors(
+                                x[LEFT_ON_COL_NAME], x[LEFT_ID_COL_NAME]
+                            ),
+                            return_dtype=pl.List(
+                                pl.Struct(
+                                    {
+                                        LEFT_ID_COL_NAME: pl.Int32,
+                                        RIGHT_ID_COL_NAME: pl.Int32,
+                                        DISTANCE_COL_NAME: pl.Float64,
+                                    }
+                                )
+                            ),
+                        )
+                        .alias(MATCH_RESULT_COL_NAME)
+                    )
+                    .explode(MATCH_RESULT_COL_NAME)
+                    .unnest(MATCH_RESULT_COL_NAME)
+                )
+
+            return pl.concat(
+                search_left_batch(left.slice(offset, self.left_batch_size))
+                for offset in range(0, len(left), self.left_batch_size)
+            )
 
     def _empty_result_with_schema(
         self, left: pl.DataFrame, right: pl.DataFrame
@@ -128,11 +156,25 @@ class SimJoin:
 
         # Drop the ID columns after join
         left_schema = [
-            (name, dtype) for name, dtype in left.schema.items() if name != LEFT_ID_COL_NAME
+            (name, dtype)
+            for name, dtype in left.schema.items()
+            if name != LEFT_ID_COL_NAME
         ]
         right_schema = [
-            (name, dtype) for name, dtype in right.schema.items() if name != RIGHT_ID_COL_NAME
+            (name, dtype)
+            for name, dtype in right.schema.items()
+            if name != RIGHT_ID_COL_NAME
         ]
+        if not self.include_left_on:
+            left_schema = [
+                (name, dtype) for name, dtype in left_schema if name != LEFT_ON_COL_NAME
+            ]
+        if not self.include_right_on:
+            right_schema = [
+                (name, dtype)
+                for name, dtype in right_schema
+                if name != RIGHT_ON_COL_NAME
+            ]
 
         schema = left_schema + right_schema + extra_cols
 

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -12,6 +12,7 @@ from fenic import (
     semantic,
     text,
 )
+from fenic._backends.local.semantic_operators import sim_join as sim_join_module
 from fenic.core.error import TypeMismatchError
 
 
@@ -108,7 +109,7 @@ def _create_semantic_join_dataframe_invalid_custom_embeddings(local_session):
                 "course_embeddings": [
                     [float(1.0)],
                     [None],
-                    [float('nan')],
+                    [float("nan")],
                     [float(3.0)],
                     [float(6.0)],
                     None,
@@ -121,7 +122,12 @@ def _create_semantic_join_dataframe_invalid_custom_embeddings(local_session):
                 "course_embeddings": pl.List(pl.Float32),
             },
         )
-    ).with_column("course_embeddings", col("course_embeddings").cast(EmbeddingType(dimensions=1, embedding_model="test")))
+    ).with_column(
+        "course_embeddings",
+        col("course_embeddings").cast(
+            EmbeddingType(dimensions=1, embedding_model="test")
+        ),
+    )
     right = local_session.create_dataframe(
         pl.DataFrame(
             {
@@ -131,7 +137,7 @@ def _create_semantic_join_dataframe_invalid_custom_embeddings(local_session):
                 "skill_embeddings": [
                     [float(1.0)],
                     [None],
-                    [float('nan')],
+                    [float("nan")],
                     None,
                 ],
             },
@@ -142,7 +148,12 @@ def _create_semantic_join_dataframe_invalid_custom_embeddings(local_session):
                 "skill_embeddings": pl.List(pl.Float32),
             },
         )
-    ).with_column("skill_embeddings", col("skill_embeddings").cast(EmbeddingType(dimensions=1, embedding_model="test")))
+    ).with_column(
+        "skill_embeddings",
+        col("skill_embeddings").cast(
+            EmbeddingType(dimensions=1, embedding_model="test")
+        ),
+    )
     return left, right
 
 
@@ -155,29 +166,39 @@ def _create_semantic_sim_join_supplement(local_session):
     )
     return df_supplement
 
+
 @pytest.mark.parametrize("metric", ["dot", "cosine", "l2"])
 def test_semantic_sim_join(local_session, metric, embedding_model_name_and_dimensions):
     embedding_model_name, embedding_dimensions = embedding_model_name_and_dimensions
     left, right = _create_semantic_join_dataframe(local_session)
-    df = (
-        left.with_column("course_embeddings", semantic.embed(col("course_name")))
-        .semantic.sim_join(
-            right.with_column("skill_embeddings", semantic.embed(col("skill"))),
-            left_on="course_embeddings",
-            right_on="skill_embeddings",
-            k=1,
-            similarity_metric=metric,
-        )
+    df = left.with_column(
+        "course_embeddings", semantic.embed(col("course_name"))
+    ).semantic.sim_join(
+        right.with_column("skill_embeddings", semantic.embed(col("skill"))),
+        left_on="course_embeddings",
+        right_on="skill_embeddings",
+        k=1,
+        similarity_metric=metric,
     )
     assert df.schema.column_fields == [
         ColumnField("course_id", IntegerType),
         ColumnField("course_name", StringType),
         ColumnField("other_col_left", StringType),
-        ColumnField("course_embeddings", EmbeddingType(dimensions=embedding_dimensions, embedding_model=embedding_model_name)),
+        ColumnField(
+            "course_embeddings",
+            EmbeddingType(
+                dimensions=embedding_dimensions, embedding_model=embedding_model_name
+            ),
+        ),
         ColumnField("skill_id", IntegerType),
         ColumnField("skill", StringType),
         ColumnField("other_col_right", StringType),
-        ColumnField("skill_embeddings", EmbeddingType(dimensions=embedding_dimensions, embedding_model=embedding_model_name)),
+        ColumnField(
+            "skill_embeddings",
+            EmbeddingType(
+                dimensions=embedding_dimensions, embedding_model=embedding_model_name
+            ),
+        ),
     ]
     result = df.to_polars()
     assert result.schema == pl.Schema(
@@ -422,7 +443,9 @@ def test_semantic_sim_join_with_right_none(local_session):
 
 def test_semantic_sim_join_with_invalid_custom_embeddings(local_session):
     """Test that we can perform a sim join where a user brings their own embeddings."""
-    left, right = _create_semantic_join_dataframe_invalid_custom_embeddings(local_session)
+    left, right = _create_semantic_join_dataframe_invalid_custom_embeddings(
+        local_session
+    )
     df = left.semantic.sim_join(
         right,
         left_on="course_embeddings",
@@ -465,7 +488,10 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
                 "left_vec": pl.List(pl.Float32),
             },
         )
-    ).with_column("left_vec", col("left_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")))
+    ).with_column(
+        "left_vec",
+        col("left_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")),
+    )
     right = local_session.create_dataframe(
         pl.DataFrame(
             {
@@ -479,7 +505,10 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
                 "right_vec": pl.List(pl.Float32),
             },
         )
-    ).with_column("right_vec", col("right_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")))
+    ).with_column(
+        "right_vec",
+        col("right_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")),
+    )
 
     df = left.semantic.sim_join(
         right,
@@ -511,10 +540,151 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
     )
     assert len(result) == 4
     assert result.to_dicts() == [
-        {"left_id": 1, "left_label": "x", "right_id": 10, "right_label": "near-x", "distance": 1.0},
-        {"left_id": 1, "left_label": "x", "right_id": 20, "right_label": "near-y", "distance": 81.0},
-        {"left_id": 2, "left_label": "y", "right_id": 20, "right_label": "near-y", "distance": 1.0},
-        {"left_id": 2, "left_label": "y", "right_id": 10, "right_label": "near-x", "distance": 81.0},
+        {
+            "left_id": 1,
+            "left_label": "x",
+            "right_id": 10,
+            "right_label": "near-x",
+            "distance": 1.0,
+        },
+        {
+            "left_id": 1,
+            "left_label": "x",
+            "right_id": 20,
+            "right_label": "near-y",
+            "distance": 81.0,
+        },
+        {
+            "left_id": 2,
+            "left_label": "y",
+            "right_id": 20,
+            "right_label": "near-y",
+            "distance": 1.0,
+        },
+        {
+            "left_id": 2,
+            "left_label": "y",
+            "right_id": 10,
+            "right_label": "near-x",
+            "distance": 81.0,
+        },
+    ]
+
+
+def test_semantic_sim_join_removes_lancedb_temp_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(sim_join_module, "VECTOR_INDEX_DIR", str(tmp_path))
+    left = pl.DataFrame(
+        {
+            sim_join_module.LEFT_ON_COL_NAME: [[0.0, 0.0], [10.0, 0.0]],
+            "left_payload": ["x", "y"],
+        },
+        schema={
+            sim_join_module.LEFT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "left_payload": pl.String,
+        },
+    )
+    right = pl.DataFrame(
+        {
+            sim_join_module.RIGHT_ON_COL_NAME: [[1.0, 0.0], [9.0, 0.0]],
+            "right_payload": ["near-x", "near-y"],
+        },
+        schema={
+            sim_join_module.RIGHT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "right_payload": pl.String,
+        },
+    )
+
+    result = sim_join_module.SimJoin(left, right, k=1, similarity_metric="l2").execute()
+
+    assert result.height == 2
+    assert list(tmp_path.iterdir()) == []
+
+
+def _create_direct_sim_join_inputs():
+    left = pl.DataFrame(
+        {
+            sim_join_module.LEFT_ON_COL_NAME: [[0.0, 0.0], [10.0, 0.0], [20.0, 0.0]],
+            "left_payload": ["x", "y", "z"],
+        },
+        schema={
+            sim_join_module.LEFT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "left_payload": pl.String,
+        },
+    )
+    right = pl.DataFrame(
+        {
+            sim_join_module.RIGHT_ON_COL_NAME: [[1.0, 0.0], [9.0, 0.0]],
+            "right_payload": ["near-x", "near-y"],
+        },
+        schema={
+            sim_join_module.RIGHT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "right_payload": pl.String,
+        },
+    )
+    return left, right
+
+
+def test_semantic_sim_join_left_batching_preserves_output():
+    left, right = _create_direct_sim_join_inputs()
+
+    result = sim_join_module.SimJoin(
+        left, right, k=2, similarity_metric="l2", left_batch_size=1
+    ).execute()
+
+    assert result.select(
+        "left_payload", "right_payload", sim_join_module.DISTANCE_COL_NAME
+    ).to_dicts() == [
+        {
+            "left_payload": "x",
+            "right_payload": "near-x",
+            sim_join_module.DISTANCE_COL_NAME: 1.0,
+        },
+        {
+            "left_payload": "x",
+            "right_payload": "near-y",
+            sim_join_module.DISTANCE_COL_NAME: 81.0,
+        },
+        {
+            "left_payload": "y",
+            "right_payload": "near-y",
+            sim_join_module.DISTANCE_COL_NAME: 1.0,
+        },
+        {
+            "left_payload": "y",
+            "right_payload": "near-x",
+            sim_join_module.DISTANCE_COL_NAME: 81.0,
+        },
+        {
+            "left_payload": "z",
+            "right_payload": "near-y",
+            sim_join_module.DISTANCE_COL_NAME: 121.0,
+        },
+        {
+            "left_payload": "z",
+            "right_payload": "near-x",
+            sim_join_module.DISTANCE_COL_NAME: 361.0,
+        },
+    ]
+
+
+def test_semantic_sim_join_can_skip_normalized_vector_columns():
+    left, right = _create_direct_sim_join_inputs()
+
+    result = sim_join_module.SimJoin(
+        left,
+        right,
+        k=1,
+        similarity_metric="l2",
+        include_left_on=False,
+        include_right_on=False,
+    ).execute()
+
+    assert sim_join_module.LEFT_ON_COL_NAME not in result.columns
+    assert sim_join_module.RIGHT_ON_COL_NAME not in result.columns
+    assert result.columns == [
+        "left_payload",
+        "right_payload",
+        sim_join_module.DISTANCE_COL_NAME,
     ]
 
 
@@ -535,13 +705,23 @@ def test_semantic_sim_join_with_incompatible_embeddings(local_session):
                 [7.0, 8.0, 9.0],
                 [10.0, 11.0, 12.0],
                 [13.0, 14.0, 15.0],
-            ]
+            ],
         }
     )
-    left = df.select(col("course_embeddings").cast(EmbeddingType(dimensions=3, embedding_model="oai-small")).alias("left_embeddings"))
-    right = df.select(col("course_embeddings").cast(EmbeddingType(dimensions=3, embedding_model="oai-large")).alias("right_embeddings"))
+    left = df.select(
+        col("course_embeddings")
+        .cast(EmbeddingType(dimensions=3, embedding_model="oai-small"))
+        .alias("left_embeddings")
+    )
+    right = df.select(
+        col("course_embeddings")
+        .cast(EmbeddingType(dimensions=3, embedding_model="oai-large"))
+        .alias("right_embeddings")
+    )
     with pytest.raises(
         TypeMismatchError,
         match="Cannot apply semantic.sim_join with mismatched types",
     ):
-        left.semantic.sim_join(right, left_on="left_embeddings", right_on="right_embeddings", k=1)
+        left.semantic.sim_join(
+            right, left_on="left_embeddings", right_on="right_embeddings", k=1
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ requires-dist = [
     { name = "lancedb", specifier = ">=0.22.0,<0.25.0" },
     { name = "markdown-it-py", marker = "extra == 'eval'", specifier = ">=4.0.0" },
     { name = "numpy", specifier = ">=2.0.0" },
-    { name = "openai", specifier = ">=1.101.0" },
+    { name = "openai", specifier = "==2.40.0" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "polars", specifier = ">=1.34.0,<1.36.0" },
     { name = "protobuf", specifier = ">=5.29.5" },
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.101.0"
+version = "2.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1769,9 +1769,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/7c/eaf06b62281f5ca4f774c4cff066e6ddfd6a027e0ac791be16acec3a95e3/openai-1.101.0.tar.gz", hash = "sha256:29f56df2236069686e64aca0e13c24a4ec310545afb25ef7da2ab1a18523f22d", size = 518415, upload-time = "2025-08-21T21:11:01.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177, upload-time = "2026-06-01T21:48:23.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/a6/0e39baa335bbd1c66c7e0a41dbbec10c5a15ab95c1344e7f7beb28eee65a/openai-1.101.0-py3-none-any.whl", hash = "sha256:6539a446cce154f8d9fb42757acdfd3ed9357ab0d34fcac11096c461da87133b", size = 810772, upload-time = "2025-08-21T21:10:59.215Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935, upload-time = "2026-06-01T21:48:21.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bounds semantic similarity join vector-search memory by processing left-side embeddings in batches instead of one eager Polars map over the full left side.
- Uses a managed temporary LanceDB directory so sim_join vector-index artifacts are cleaned after execution.
- Avoids materializing synthetic normalized vector columns for derived `semantic.sim_join` expressions in the final result.
- Pins `openai==2.40.0` to avoid the `openai>=2.41.0` request-header regression that surfaced in CI while this PR was being validated.

## Linear issues
- TD-3320

## What changed
- Added `left_batch_size` to the local semantic sim join executor and slices left embeddings through LanceDB search in bounded chunks.
- Replaced persistent UUID-named LanceDB temp dirs with `TemporaryDirectory` under the existing vector-index root.
- Added explicit include/drop controls for normalized join-vector columns so derived expressions do not widen the result.
- Added direct no-network regression coverage for batching, temp-dir cleanup, synthetic vector-column dropping, and existing custom embedding golden output.
- Temporarily pinned OpenAI client below 2.41.0 so unrelated header inflation does not mask the sim_join regression/validation signal.

## Evidence / validation
- `uvx ruff check src/fenic/_backends/local/semantic_operators/sim_join.py src/fenic/_backends/local/physical_plan/join.py tests/_backends/local/dataframe/test_semantic_sim_join.py` → pass
- `OPENAI_API_KEY=*** .venv/bin/python -m pytest -q tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_custom_embeddings_golden_output tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_can_skip_normalized_vector_columns tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_left_batching_preserves_output tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_removes_lancedb_temp_dir tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_with_incompatible_embeddings` → `5 passed, 5 warnings`
- OpenAI pin validation:
  - `uv run pytest tests/examples/test_examples.py -q` → `11 passed`
  - focused semantic cluster / sim_join CI repro tests with `openai==2.40.0` → `3 passed`
  - GitHub CI for head `bcba005a40a0` is green, including `test 3.11, local, true`, `trunk check`, `Trunk Check`, and `allcheckspassed`.
- Memory smoke harness, same parameters (`sim_join`, rows=64, right_rows=32, dimensions=8, k=2):
  - before: `ok=True`, `result_rows=128`, `peak_rss_bytes=441061376`, `elapsed_ms=13883.341`
  - after: `ok=True`, `result_rows=128`, `peak_rss_bytes=410025984`, `elapsed_ms=4042.508`
- Larger-scale memory harness runs, comparing `origin/main` / `4168f5c` against PR head `bcba005a40a0`:

| matrix | before peak RSS | after peak RSS | delta | result rows | elapsed before → after |
|---|---:|---:|---:|---:|---:|
| `rows=2048, right_rows=1024, embedding_dimensions=64, k=10` | 462,057,472 | 407,810,048 | -54,247,424 (-11.7%) | 20,480 | 8.6s → 18.4s |
| `rows=4096, right_rows=2048, embedding_dimensions=64, k=10` | 489,304,064 | 470,720,512 | -18,583,552 (-3.8%) | 40,960 | 8.2s → 44.1s |
| `rows=8192, right_rows=4096, embedding_dimensions=64, k=10` | 573,063,168 | 529,420,288 | -43,642,880 (-7.6%) | 81,920 | 12.2s → 45.1s |

Command shape used for each before/after pair:

```bash
uv run python tools/benchmark_semantic_operator_memory.py \
  --cases sim_join \
  --rows <rows> \
  --right-rows <right_rows> \
  --embedding-dimensions 64 \
  --k 10 \
  --label TD-3320-<before|after>-sim-join-<size> \
  --json
```


### 2026-06-12 performance recheck / hold recommendation

A clean recheck after moving the PR worktree to the canonical Fenic worktree location did **not** reproduce the original 44–45s after-run outliers, but it also does **not** support landing this PR as-is for memory savings. The current implementation still materializes the complete match set and final eager output; only the left-side LanceDB search loop is chunked. Profiling shows the changed path spends its time in repeated Polars `map_elements` / collect passes over left batches, so batching adds execution overhead without meaningfully bounding end-to-end peak RSS.

Recheck evidence is stored locally under `.hermes/evidence/perf-recheck-2026-06-12/`.

| matrix | before elapsed | after elapsed | runtime ratio | before RSS | after RSS | RSS delta |
|---|---:|---:|---:|---:|---:|---:|
| `2048x1024` | 7.14s | 4.77s | 0.67× | 441.8 MiB | 463.5 MiB | +21.7 MiB (+4.9%) |
| `4096x2048` | 5.41s | 9.12s | 1.69× | 466.1 MiB | 491.0 MiB | +24.9 MiB (+5.3%) |
| `8192x4096` | 9.90s | 17.81s | 1.80× | 547.5 MiB | 537.9 MiB | -9.6 MiB (-1.8%) |

Recommendation: hold/redesign the memory-bound sim_join approach unless we can demonstrate a workload that currently OOMs and is made safe by this bounded path. The temp-dir cleanup and OpenAI pin may still be worth salvaging separately.

## Reviewer notes
- This does not change user-facing nearest-neighbor semantics; batching is only on the left-side search loop.
- Scope boundary from adversarial review: this PR does not make sim_join fully streaming end-to-end. Normalized input columns, the complete `matches_df`, and the final eager output are still materialized; the bounded part is the left-side LanceDB search loop.
- The larger-scale harness shows lower peak RSS on the tested matrices, but also shows the current sequential batching path is slower at larger row counts. Treat this PR as a memory-bound/safety improvement, not a throughput improvement; batch-size/concurrency tuning should be follow-up work if needed.
- The `len(right) > 5000` LanceDB-index path was not separately covered by the new temp-dir cleanup test; the cleanup mechanism uses the same `TemporaryDirectory` lifecycle, but this is a reasonable follow-up if reviewers want indexed-path coverage.
- Full `test_semantic_sim_join.py` still requires real model credentials for network-backed embedding tests, so focused validation used the no-network/direct custom-embedding tests plus the existing memory benchmark harness.
- Local pre-commit was blocked by Trunk failing to install `gitleaks` because its cached Go toolchain directory hit a chmod permission error; the touched files are Python-only, and the explicit validation above was run after the commit contents were staged.

## Release / risk
- Risk is localized to local semantic similarity join execution plus the temporary OpenAI dependency pin.
- Primary regression risks are result ordering/schema changes and derived-expression column restoration; both are covered by focused tests in this PR.
- The OpenAI pin should be revisited once the upstream/client header regression is understood or fixed.
