### PR TITLE
fix: clean up sim join vector indexes

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,7 +13,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.21.0
+    - go@1.25.11
     - node@22.16.0
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)

--- a/src/fenic/_backends/local/semantic_operators/sim_join.py
+++ b/src/fenic/_backends/local/semantic_operators/sim_join.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import uuid
 
 import lancedb
@@ -65,59 +67,62 @@ class SimJoin:
     def _batch_similarity_search(
         self, left: pl.DataFrame, right: pl.DataFrame
     ) -> pl.DataFrame:
-        guid = uuid.uuid4().hex
-        lance_table_dir = f"{VECTOR_INDEX_DIR}/{guid}"
-        db: DBConnection = lancedb.connect(lance_table_dir)
-        tbl: Table = db.create_table(
-            guid,
-            right.select(RIGHT_ON_COL_NAME, RIGHT_ID_COL_NAME).rename(
-                {RIGHT_ON_COL_NAME: VECTOR_COL_NAME}
-            ),
-        )
-        if len(right) > 5000:
-            tbl.create_index(metric=self.similarity_metric)
-
-        # Define UDF to perform search for each row
-        def search_vectors(left_embedding, left_id):
-            results = tbl.search(left_embedding).distance_type(self.similarity_metric).limit(self.k).to_list()
-
-            # Create list of structs with search results
-            matches = []
-            for result in results:
-                matches.append(
-                    {
-                        LEFT_ID_COL_NAME: left_id,
-                        RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
-                        DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
-                    }
-                )
-            return matches
-
-        # TODO(rohitrastogi): Do some experiments to see if sending concurrent requests to LanceDB
-        # using a thread pool is faster than sending requests sequentially. Vector search is CPU bound and LanceDB
-        # releases the GIL, so I'm not sure there will be any performance gains.
-        # FYI, LanceDB doesn't support batch vector search. If you pass a batch of vectors, it doesn't
-        # actually search in parallel.
-        return (
-            left.select(
-                pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
-                .map_elements(
-                    lambda x: search_vectors(x[LEFT_ON_COL_NAME], x[LEFT_ID_COL_NAME]),
-                    return_dtype=pl.List(
-                        pl.Struct(
-                            {
-                                LEFT_ID_COL_NAME: pl.Int32,
-                                RIGHT_ID_COL_NAME: pl.Int32,
-                                DISTANCE_COL_NAME: pl.Float64,
-                            }
-                        )
-                    ),
-                )
-                .alias(MATCH_RESULT_COL_NAME)
+        os.makedirs(VECTOR_INDEX_DIR, exist_ok=True)
+        table_name = uuid.uuid4().hex
+        with tempfile.TemporaryDirectory(
+            prefix="sim_join_", dir=VECTOR_INDEX_DIR
+        ) as lance_table_dir:
+            db: DBConnection = lancedb.connect(lance_table_dir)
+            tbl: Table = db.create_table(
+                table_name,
+                right.select(RIGHT_ON_COL_NAME, RIGHT_ID_COL_NAME).rename(
+                    {RIGHT_ON_COL_NAME: VECTOR_COL_NAME}
+                ),
             )
-            .explode(MATCH_RESULT_COL_NAME)
-            .unnest(MATCH_RESULT_COL_NAME)
-        )
+            if len(right) > 5000:
+                tbl.create_index(metric=self.similarity_metric)
+
+            # Define UDF to perform search for each row
+            def search_vectors(left_embedding, left_id):
+                results = tbl.search(left_embedding).distance_type(self.similarity_metric).limit(self.k).to_list()
+
+                # Create list of structs with search results
+                matches = []
+                for result in results:
+                    matches.append(
+                        {
+                            LEFT_ID_COL_NAME: left_id,
+                            RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
+                            DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
+                        }
+                    )
+                return matches
+
+            # TODO(rohitrastogi): Do some experiments to see if sending concurrent requests to LanceDB
+            # using a thread pool is faster than sending requests sequentially. Vector search is CPU bound and LanceDB
+            # releases the GIL, so I'm not sure there will be any performance gains.
+            # FYI, LanceDB doesn't support batch vector search. If you pass a batch of vectors, it doesn't
+            # actually search in parallel.
+            return (
+                left.select(
+                    pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
+                    .map_elements(
+                        lambda x: search_vectors(x[LEFT_ON_COL_NAME], x[LEFT_ID_COL_NAME]),
+                        return_dtype=pl.List(
+                            pl.Struct(
+                                {
+                                    LEFT_ID_COL_NAME: pl.Int32,
+                                    RIGHT_ID_COL_NAME: pl.Int32,
+                                    DISTANCE_COL_NAME: pl.Float64,
+                                }
+                            )
+                        ),
+                    )
+                    .alias(MATCH_RESULT_COL_NAME)
+                )
+                .explode(MATCH_RESULT_COL_NAME)
+                .unnest(MATCH_RESULT_COL_NAME)
+            )
 
     def _empty_result_with_schema(
         self, left: pl.DataFrame, right: pl.DataFrame

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -1,3 +1,6 @@
+import shutil
+from pathlib import Path
+
 import polars as pl
 import pytest
 
@@ -12,6 +15,7 @@ from fenic import (
     semantic,
     text,
 )
+from fenic._constants import VECTOR_INDEX_DIR
 from fenic.core.error import TypeMismatchError
 
 
@@ -444,6 +448,53 @@ def test_semantic_sim_join_with_invalid_custom_embeddings(local_session):
     # there should be no match with a None value on the right side.
     assert len(result) == 3
     assert None not in result["skill"].to_list()
+
+
+def test_semantic_sim_join_cleans_up_vector_index_dir(local_session):
+    shutil.rmtree(VECTOR_INDEX_DIR, ignore_errors=True)
+    vector_index_dir = Path(VECTOR_INDEX_DIR)
+
+    left = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "left_id": [1, 2],
+                "left_vec": [[0.0, 0.0], [10.0, 0.0]],
+            },
+            schema={
+                "left_id": pl.Int64,
+                "left_vec": pl.List(pl.Float32),
+            },
+        )
+    ).with_column(
+        "left_vec",
+        col("left_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")),
+    )
+    right = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "right_id": [10, 20],
+                "right_vec": [[1.0, 0.0], [9.0, 0.0]],
+            },
+            schema={
+                "right_id": pl.Int64,
+                "right_vec": pl.List(pl.Float32),
+            },
+        )
+    ).with_column(
+        "right_vec",
+        col("right_vec").cast(EmbeddingType(dimensions=2, embedding_model="test")),
+    )
+
+    result = left.semantic.sim_join(
+        right,
+        left_on="left_vec",
+        right_on="right_vec",
+        k=1,
+        similarity_metric="l2",
+    ).to_polars()
+
+    assert len(result) == 2
+    assert not list(vector_index_dir.iterdir())
 
 
 def test_semantic_sim_join_custom_embeddings_golden_output(local_session):


### PR DESCRIPTION
## Summary

- Cleans up temporary LanceDB vector index directories after each `semantic.sim_join` execution.
- Splits the low-risk temp-dir hygiene fix out from the broader TD-3320 / PR #318 memory-bounding experiment.
- Updates Trunk's hermetic Go runtime from 1.21.0 to 1.25.11 so `gitleaks@8.28.0` installs without Go auto-toolchain fallback.

## Linear issues

- TD-3320: Bound semantic sim join memory usage — cleanup split only; this PR does not claim to solve the memory-bound strategy.

## What changed

- Wraps the per-call LanceDB table directory in `tempfile.TemporaryDirectory` under `indexes/vector`.
- Keeps the existing sim join search behavior intact; no batching or output-shape changes from PR #318 are included.
- Adds a focused regression test proving `semantic.sim_join` leaves no per-call vector index subdirectories after execution.
- Bumps `.trunk/trunk.yaml` Go runtime to match current Go-tool linters; `gitleaks@8.28.0` requires Go >= 1.23.8.

## Evidence / validation

- [x] RED: `OPENAI_API_KEY=*** uv run pytest tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_cleans_up_vector_index_dir -q` failed on `origin/main` with leftover `indexes/vector/<uuid>`.
- [x] GREEN: `OPENAI_API_KEY=*** uv run pytest tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_cleans_up_vector_index_dir -q` passed after the change.
- [x] Focused regression set: `OPENAI_API_KEY=*** uv run pytest tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_cleans_up_vector_index_dir tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_custom_embeddings_golden_output tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_with_invalid_custom_embeddings -q` → 3 passed.
- [x] `uvx ruff check --select I --fix tests/_backends/local/dataframe/test_semantic_sim_join.py`
- [x] `uv run python -m compileall -q src/fenic/_backends/local/semantic_operators/sim_join.py tests/_backends/local/dataframe/test_semantic_sim_join.py`
- [x] `git diff --check` and `git diff --cached --check`
- [x] Actual pre-commit hook rerun without `--no-verify` on commit `4603af4`: `gitleaks` reported no leaks and Trunk format checks reported no issues.
- [x] `trunk check --filter=gitleaks --all` → checked 570 files, no issues.
- [x] `trunk check --filter=shfmt --all` → checked 1 file, no issues.

## Reviewer notes

- The earlier `--no-verify` workaround was caused by a stale Trunk Go runtime: repo config pinned `go@1.21.0`, while `gitleaks@8.28.0` requires Go >= 1.23.8. Trunk attempted a Go auto-toolchain download into its hermetic cache and hit cache permission errors. This PR now bumps the hermetic Go runtime to `go@1.25.11` and the follow-up commit was created through the normal pre-commit hook path.
- This intentionally excludes the PR #318 left-side batching implementation because the performance recheck showed poor runtime/memory tradeoff.

## Release / risk

- Risk: Low — localizes cleanup of per-call LanceDB scratch data without changing join semantics; the Trunk runtime bump affects local/CI installation of Go-based linters only.
- Rollback: Revert this PR; prior session-level cleanup still attempts to remove `indexes/vector` on session shutdown.