### PR TITLE
perf: skip derived sim join vector columns

### DIFF
--- a/src/fenic/_backends/local/physical_plan/join.py
+++ b/src/fenic/_backends/local/physical_plan/join.py
@@ -259,20 +259,30 @@ class SemanticSimilarityJoinExec(PhysicalPlan):
         )
 
         # TODO(rohitrastogi): Avoid regenerating embeddings if semantic index already exists
-        result = SemanticSimJoin(left_df, right_df, self.k, self.similarity_metric).execute()
+        result = SemanticSimJoin(
+            left_df,
+            right_df,
+            self.k,
+            self.similarity_metric,
+            include_left_on=maybe_left_name is not None,
+            include_right_on=maybe_right_name is not None,
+        ).execute()
 
         if self.similarity_score_column:
             result = result.rename({DISTANCE_COL_NAME: self.similarity_score_column})
         else:
             result = result.drop(DISTANCE_COL_NAME)
 
-        # Restore original column names or drop temporary columns
-        result = restore_column_after_join(
-            result, maybe_left_name, LEFT_ON_COL_NAME
-        )
-        result = restore_column_after_join(
-            result, maybe_right_name, RIGHT_ON_COL_NAME
-        )
+        # Restore original column names. Derived temporary join columns are not
+        # materialized by SemanticSimJoin, so there is nothing to drop for them.
+        if maybe_left_name is not None:
+            result = restore_column_after_join(
+                result, maybe_left_name, LEFT_ON_COL_NAME
+            )
+        if maybe_right_name is not None:
+            result = restore_column_after_join(
+                result, maybe_right_name, RIGHT_ON_COL_NAME
+            )
 
         return result
 

--- a/src/fenic/_backends/local/semantic_operators/sim_join.py
+++ b/src/fenic/_backends/local/semantic_operators/sim_join.py
@@ -31,11 +31,15 @@ class SimJoin:
         right: pl.DataFrame,
         k: int,
         similarity_metric: SemanticSimilarityMetric,
+        include_left_on: bool = True,
+        include_right_on: bool = True,
     ):
         self.left = left.with_row_index(LEFT_ID_COL_NAME)
         self.right = right.with_row_index(RIGHT_ID_COL_NAME)
         self.k = k
         self.similarity_metric = similarity_metric
+        self.include_left_on = include_left_on
+        self.include_right_on = include_right_on
 
     def execute(self) -> pl.DataFrame:
         """Perform semantic similarity join on the DataFrame using vector embeddings.
@@ -52,10 +56,12 @@ class SimJoin:
             return self._empty_result_with_schema(left, right)
 
         matches_df = self._batch_similarity_search(left, right)
+        left_result = left if self.include_left_on else left.drop(LEFT_ON_COL_NAME)
+        right_result = right if self.include_right_on else right.drop(RIGHT_ON_COL_NAME)
 
         result = (
-            matches_df.join(left, on=LEFT_ID_COL_NAME, how="inner")
-            .join(right, on=RIGHT_ID_COL_NAME, how="inner")
+            matches_df.join(left_result, on=LEFT_ID_COL_NAME, how="inner")
+            .join(right_result, on=RIGHT_ID_COL_NAME, how="inner")
             .drop([LEFT_ID_COL_NAME, RIGHT_ID_COL_NAME])
         )
         # Reorder columns to have similarity score last
@@ -138,6 +144,16 @@ class SimJoin:
         right_schema = [
             (name, dtype) for name, dtype in right.schema.items() if name != RIGHT_ID_COL_NAME
         ]
+        if not self.include_left_on:
+            left_schema = [
+                (name, dtype) for name, dtype in left_schema if name != LEFT_ON_COL_NAME
+            ]
+        if not self.include_right_on:
+            right_schema = [
+                (name, dtype)
+                for name, dtype in right_schema
+                if name != RIGHT_ON_COL_NAME
+            ]
 
         schema = left_schema + right_schema + extra_cols
 

--- a/src/fenic/api/dataframe/semantic_extensions.py
+++ b/src/fenic/api/dataframe/semantic_extensions.py
@@ -281,7 +281,12 @@ class SemanticExtensions:
         Args:
             other: The right-hand DataFrame to join with.
             left_on: Expression or column representing embeddings in the left DataFrame.
+                If this is a named column, that column is treated as a user column and is
+                included in the output. If this is an expression, it is treated as a
+                temporary join key and is not included as an output column.
             right_on: Expression or column representing embeddings in the right DataFrame.
+                Named columns are included in the output; expression-derived join keys
+                are temporary and are not included in the output.
             k: Number of most similar matches to return per row.
             similarity_metric: Similarity metric to use: "l2", "cosine", or "dot".
             similarity_score_column: If set, adds a column with this name containing similarity scores.
@@ -290,8 +295,10 @@ class SemanticExtensions:
 
         Returns:
             A DataFrame containing one row for each of the top-k matches per row in the left DataFrame.
-            The result includes all columns from both DataFrames, optionally augmented with a similarity score column
-            if `similarity_score_column` is provided.
+            The result includes all columns from both input DataFrames and, when `similarity_score_column`
+            is provided, a similarity score column. Join key columns that already exist in the input
+            DataFrames are preserved as normal user columns. Join keys derived from expressions are
+            temporary execution columns and are not included in the result schema.
 
         Raises:
             ValidationError: If `k` is not positive or if the columns are invalid.

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -5,9 +5,11 @@ import polars as pl
 import pytest
 
 from fenic import (
+    ArrayType,
     ColumnField,
     DoubleType,
     EmbeddingType,
+    FloatType,
     IntegerType,
     StringType,
     col,
@@ -199,44 +201,206 @@ def test_semantic_sim_join(local_session, metric, embedding_model_name_and_dimen
     )
 
 
-def test_semantic_sim_join_empty_result(local_session):
-    left, right = _create_semantic_join_dataframe(local_session)
-    empty_left = left.filter(col("course_name").is_null())
-    df = empty_left.semantic.sim_join(
-        right,
-        left_on=semantic.embed(col("course_name")),
-        right_on=semantic.embed(col("skill")),
+def _create_public_sim_join_key_policy_dataframes(local_session):
+    left = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "left_id": [1, 2],
+                "left_vec": [[0.0, 0.0], [10.0, 0.0]],
+                "left_payload": ["x", "y"],
+            },
+            schema={
+                "left_id": pl.Int64,
+                "left_vec": pl.List(pl.Float32),
+                "left_payload": pl.String,
+            },
+        )
     )
-    result = df.to_polars()
-    assert result.is_empty()
-    assert result.schema == pl.Schema(
+    right = local_session.create_dataframe(
+        pl.DataFrame(
+            {
+                "right_id": [10, 20],
+                "right_vec": [[1.0, 0.0], [9.0, 0.0]],
+                "right_payload": ["near-x", "near-y"],
+            },
+            schema={
+                "right_id": pl.Int64,
+                "right_vec": pl.List(pl.Float32),
+                "right_payload": pl.String,
+            },
+        )
+    )
+    return left, right
+
+
+def _expected_public_sim_join_schema(
+    *,
+    include_left_embedding: bool,
+    include_right_embedding: bool,
+):
+    fields = [
+        ColumnField("left_id", IntegerType),
+        ColumnField("left_vec", ArrayType(FloatType)),
+        ColumnField("left_payload", StringType),
+    ]
+    if include_left_embedding:
+        fields.append(
+            ColumnField(
+                "left_embedding", EmbeddingType(dimensions=2, embedding_model="test")
+            )
+        )
+    fields.extend(
+        [
+            ColumnField("right_id", IntegerType),
+            ColumnField("right_vec", ArrayType(FloatType)),
+            ColumnField("right_payload", StringType),
+        ]
+    )
+    if include_right_embedding:
+        fields.append(
+            ColumnField(
+                "right_embedding", EmbeddingType(dimensions=2, embedding_model="test")
+            )
+        )
+    return fields
+
+
+def _expected_public_sim_join_polars_schema(
+    *,
+    include_left_embedding: bool,
+    include_right_embedding: bool,
+):
+    schema = {
+        "left_id": pl.Int64,
+        "left_vec": pl.List(pl.Float32),
+        "left_payload": pl.String,
+    }
+    if include_left_embedding:
+        schema["left_embedding"] = pl.Array(pl.Float32, 2)
+    schema.update(
         {
-            "course_id": pl.Int64,
-            "course_name": pl.String,
-            "other_col_left": pl.String,
-            "skill_id": pl.Int64,
-            "skill": pl.String,
-            "other_col_right": pl.String,
+            "right_id": pl.Int64,
+            "right_vec": pl.List(pl.Float32),
+            "right_payload": pl.String,
         }
     )
+    if include_right_embedding:
+        schema["right_embedding"] = pl.Array(pl.Float32, 2)
+    return pl.Schema(schema)
 
-    empty_right = right.filter(col("skill").is_null())
+
+@pytest.mark.parametrize(
+    (
+        "left_key_kind",
+        "right_key_kind",
+        "include_left_embedding",
+        "include_right_embedding",
+    ),
+    [
+        ("named", "named", True, True),
+        ("expression", "expression", False, False),
+        ("named", "expression", True, False),
+        ("expression", "named", False, True),
+    ],
+)
+def test_semantic_sim_join_public_api_join_key_column_policy(
+    local_session,
+    left_key_kind,
+    right_key_kind,
+    include_left_embedding,
+    include_right_embedding,
+):
+    """Named join columns are output columns; expression-derived join keys are not."""
+    left, right = _create_public_sim_join_key_policy_dataframes(local_session)
+
+    left_embedding = col("left_vec").cast(
+        EmbeddingType(dimensions=2, embedding_model="test")
+    )
+    right_embedding = col("right_vec").cast(
+        EmbeddingType(dimensions=2, embedding_model="test")
+    )
+
+    if left_key_kind == "named":
+        left = left.with_column("left_embedding", left_embedding)
+        left_on = "left_embedding"
+    else:
+        left_on = left_embedding
+
+    if right_key_kind == "named":
+        right = right.with_column("right_embedding", right_embedding)
+        right_on = "right_embedding"
+    else:
+        right_on = right_embedding
+
+    df = left.semantic.sim_join(
+        right, left_on=left_on, right_on=right_on, k=1, similarity_metric="l2"
+    )
+
+    assert df.schema.column_fields == _expected_public_sim_join_schema(
+        include_left_embedding=include_left_embedding,
+        include_right_embedding=include_right_embedding,
+    )
+
+    result = df.to_polars()
+    assert result.schema == _expected_public_sim_join_polars_schema(
+        include_left_embedding=include_left_embedding,
+        include_right_embedding=include_right_embedding,
+    )
+    assert len(result) == 2
+
+
+def test_semantic_sim_join_empty_result(local_session):
+    left, right = _create_public_sim_join_key_policy_dataframes(local_session)
+    left_embedding = col("left_vec").cast(
+        EmbeddingType(dimensions=2, embedding_model="test")
+    )
+    right_embedding = col("right_vec").cast(
+        EmbeddingType(dimensions=2, embedding_model="test")
+    )
+
+    empty_left = left.filter(col("left_id") < 0)
+    df = empty_left.semantic.sim_join(
+        right,
+        left_on=left_embedding,
+        right_on=right_embedding,
+        similarity_metric="l2",
+    )
+    assert df.schema.column_fields == _expected_public_sim_join_schema(
+        include_left_embedding=False,
+        include_right_embedding=False,
+    )
+    result = df.to_polars()
+    assert result.is_empty()
+    assert result.schema == _expected_public_sim_join_polars_schema(
+        include_left_embedding=False,
+        include_right_embedding=False,
+    )
+
+    empty_right = right.filter(col("right_id") < 0)
     df = left.semantic.sim_join(
         empty_right,
-        left_on=semantic.embed(col("course_name")),
-        right_on=semantic.embed(col("skill")),
+        left_on=left_embedding,
+        right_on=right_embedding,
+        similarity_metric="l2",
         similarity_score_column="similarity_score",
     )
+    assert df.schema.column_fields == [
+        *_expected_public_sim_join_schema(
+            include_left_embedding=False,
+            include_right_embedding=False,
+        ),
+        ColumnField("similarity_score", DoubleType),
+    ]
     result = df.to_polars()
     assert result.is_empty()
     assert result.schema == pl.Schema(
         {
-            "course_id": pl.Int64,
-            "course_name": pl.String,
-            "other_col_left": pl.String,
-            "skill_id": pl.Int64,
-            "skill": pl.String,
-            "other_col_right": pl.String,
+            **dict(
+                _expected_public_sim_join_polars_schema(
+                    include_left_embedding=False,
+                    include_right_embedding=False,
+                )
+            ),
             "similarity_score": pl.Float64,
         }
     )

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -15,6 +15,7 @@ from fenic import (
     semantic,
     text,
 )
+from fenic._backends.local.semantic_operators import sim_join as sim_join_module
 from fenic._constants import VECTOR_INDEX_DIR
 from fenic.core.error import TypeMismatchError
 
@@ -567,6 +568,74 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
         {"left_id": 2, "left_label": "y", "right_id": 20, "right_label": "near-y", "distance": 1.0},
         {"left_id": 2, "left_label": "y", "right_id": 10, "right_label": "near-x", "distance": 81.0},
     ]
+
+
+def _create_direct_sim_join_inputs():
+    left = pl.DataFrame(
+        {
+            sim_join_module.LEFT_ON_COL_NAME: [[0.0, 0.0], [10.0, 0.0]],
+            "left_payload": ["x", "y"],
+        },
+        schema={
+            sim_join_module.LEFT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "left_payload": pl.String,
+        },
+    )
+    right = pl.DataFrame(
+        {
+            sim_join_module.RIGHT_ON_COL_NAME: [[1.0, 0.0], [9.0, 0.0]],
+            "right_payload": ["near-x", "near-y"],
+        },
+        schema={
+            sim_join_module.RIGHT_ON_COL_NAME: pl.Array(pl.Float32, 2),
+            "right_payload": pl.String,
+        },
+    )
+    return left, right
+
+
+def test_semantic_sim_join_can_skip_normalized_vector_columns():
+    left, right = _create_direct_sim_join_inputs()
+
+    result = sim_join_module.SimJoin(
+        left,
+        right,
+        k=1,
+        similarity_metric="l2",
+        include_left_on=False,
+        include_right_on=False,
+    ).execute()
+
+    assert sim_join_module.LEFT_ON_COL_NAME not in result.columns
+    assert sim_join_module.RIGHT_ON_COL_NAME not in result.columns
+    assert result.columns == [
+        "left_payload",
+        "right_payload",
+        sim_join_module.DISTANCE_COL_NAME,
+    ]
+
+
+def test_semantic_sim_join_empty_result_can_skip_normalized_vector_columns():
+    left, right = _create_direct_sim_join_inputs()
+    empty_left = left.filter(pl.lit(False))
+
+    result = sim_join_module.SimJoin(
+        empty_left,
+        right,
+        k=1,
+        similarity_metric="l2",
+        include_left_on=False,
+        include_right_on=False,
+    ).execute()
+
+    assert result.is_empty()
+    assert result.schema == pl.Schema(
+        {
+            "left_payload": pl.String,
+            "right_payload": pl.String,
+            sim_join_module.DISTANCE_COL_NAME: pl.Float64,
+        }
+    )
 
 
 def test_semantic_sim_join_with_incompatible_embeddings(local_session):


### PR DESCRIPTION
## Summary
- Adds `SimJoin` output-projection flags for normalized left/right vector columns.
- Uses those flags from `SemanticSimilarityJoinExec` so derived-expression join vectors are not materialized in the final result.
- Documents and tests the existing public output-column policy: named join embedding columns remain user-facing output columns, while expression-derived join keys are temporary and omitted.

## Linear issues
- TD-3320

## Public API contract
Affected API:
- `DataFrame.semantic.sim_join`

Output-column policy:
- Named `left_on` / `right_on` embedding columns are existing user columns and remain in the result.
- Expression-derived `left_on` / `right_on` join keys are temporary execution columns and are not included in the result schema.
- `similarity_score_column` remains opt-in; when provided, it is appended as the score column.

This PR preserves existing behavior while making the implicit policy explicit in the docstring and public API tests. A future API-design pass can decide whether this deserves a named output-column policy parameter.

## What changed
- `SimJoin(..., include_left_on=True, include_right_on=True)` defaults preserve current direct-operator behavior.
- Physical-plan execution passes `False` for derived expression join sides, because those temporary normalized columns are implementation detail only.
- Empty-result schema construction follows the same projection rules.
- `semantic.sim_join` docstring now states named-vs-expression join-key output behavior.
- Public API tests now cover named/named, expression/expression, named/expression, and expression/named join-key forms, asserting both Fenic logical schema and materialized Polars schema.

## Evidence / validation
- RED: new direct `SimJoin` projection tests failed on `origin/main` with `TypeError: SimJoin.__init__() got an unexpected keyword argument 'include_left_on'`.
- Public API DoD tests: `uv run pytest tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_public_api_join_key_column_policy tests/_backends/local/dataframe/test_semantic_sim_join.py::test_semantic_sim_join_empty_result -q` → 5 passed.
- Full focused file: `uv run pytest tests/_backends/local/dataframe/test_semantic_sim_join.py -q` → 19 passed.
- Lint/security: `XDG_CACHE_HOME=/tmp/hermes-trunk-xdg-cache-drop-sim-join-dod trunk check --no-progress src/fenic/api/dataframe/semantic_extensions.py tests/_backends/local/dataframe/test_semantic_sim_join.py` → No issues.
- Independent Fenic API DoD review: passed; no required fixes.
- Commit signature: verified SSH signature for `brandon@typedef.ai`.

## Reviewer notes
This is intentionally split out from the larger #318 memory/batching branch. It only lands the output-projection plumbing that the d1536 benchmark spike identified as the actual memory lever. It does not include search batching, LanceDB tempdir cleanup, or the OpenAI client pin.

Benchmark context from the spike: excluding the normalized vector columns collapsed final-join RSS deltas from multi-GiB to single-digit MiB in d1536 cases, while preserving public output semantics for named columns.

## Release / risk
Low behavioral risk: named embedding columns keep the existing default behavior, and derived-expression temp columns were already not part of the public result schema. Main risk is internal direct `SimJoin` callers depending on the old constructor shape; defaults are backward-compatible.