### PR TITLE
feat: add GPT-5.6 and Claude 5 models

### DIFF
--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -81,6 +81,16 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                 effort=profile.effort,
                 output_config={"effort": profile.effort} if profile.effort else None,
             )
+        elif self.model_parameters.requires_adaptive_thinking:
+            return AnthropicProfileConfiguration(
+                thinking_enabled=True,
+                uses_adaptive_thinking=True,
+                effort=profile.effort,
+                thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
+                    type="adaptive"
+                ),
+                output_config={"effort": profile.effort} if profile.effort else None,
+            )
         elif profile.effort and self.model_parameters.uses_adaptive_thinking:
             return AnthropicProfileConfiguration(
                 thinking_enabled=True,
@@ -107,6 +117,14 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
         """Get default Anthropic configuration.
 
         Returns:
-            Default configuration with thinking disabled
+            Default configuration for the model
         """
+        if self.model_parameters.requires_adaptive_thinking:
+            return AnthropicProfileConfiguration(
+                thinking_enabled=True,
+                uses_adaptive_thinking=True,
+                thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
+                    type="adaptive"
+                ),
+            )
         return AnthropicProfileConfiguration()

--- a/src/fenic/_inference/anthropic/anthropic_profile_manager.py
+++ b/src/fenic/_inference/anthropic/anthropic_profile_manager.py
@@ -81,16 +81,6 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                 effort=profile.effort,
                 output_config={"effort": profile.effort} if profile.effort else None,
             )
-        elif self.model_parameters.requires_adaptive_thinking:
-            return AnthropicProfileConfiguration(
-                thinking_enabled=True,
-                uses_adaptive_thinking=True,
-                effort=profile.effort,
-                thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
-                    type="adaptive"
-                ),
-                output_config={"effort": profile.effort} if profile.effort else None,
-            )
         elif profile.effort and self.model_parameters.uses_adaptive_thinking:
             return AnthropicProfileConfiguration(
                 thinking_enabled=True,
@@ -104,6 +94,14 @@ class AnthropicCompletionsProfileManager(ProfileManager[ResolvedAnthropicModelPr
                 uses_adaptive_thinking=True,
                 effort=profile.effort,
                 output_config={"effort": profile.effort},
+            )
+        elif self.model_parameters.requires_adaptive_thinking:
+            return AnthropicProfileConfiguration(
+                thinking_enabled=True,
+                uses_adaptive_thinking=True,
+                thinking_config=anthropic.types.ThinkingConfigAdaptiveParam(
+                    type="adaptive"
+                ),
             )
         elif profile.effort:
             return AnthropicProfileConfiguration(

--- a/src/fenic/api/session/config.py
+++ b/src/fenic/api/session/config.py
@@ -561,7 +561,8 @@ class OpenAILanguageModel(BaseModel):
 
         Attributes:
             reasoning_effort: Provide a reasoning effort. Only for gpt5 and o-series models.
-                Valid values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'.
+                Valid values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'.
+                - For gpt-5.6 models: supports 'xhigh' and 'max'
                 - For gpt-5.5 models: defaults to 'medium', supports 'xhigh'
                 - For gpt-5.4 models: defaults to 'none' (disabled reasoning), supports 'xhigh'
                 - For gpt-5.1 and gpt-5.2 models: defaults to 'none' (disabled reasoning), does NOT support 'minimal' or 'xhigh'
@@ -902,7 +903,7 @@ class OpenRouterLanguageModel(BaseModel):
                 ([OpenRouter Documentation](https://openrouter.ai/docs/features/model-routing#the-models-parameter)).
             provider: Provider routing preferences (include/exclude specific providers, set provider ranking method preference)
                 ([OpenRouter Documentation](https://openrouter.ai/docs/features/provider-routing)).
-            reasoning_effort: OpenRouter reasoning effort configuration (none, minimal, low, medium, high, xhigh).
+            reasoning_effort: OpenRouter reasoning effort configuration (none, minimal, low, medium, high, xhigh, max).
                 If the model does support reasoning, but not `reasoning_effort`, a `reasoning_max_tokens` will be calculated
                 that is roughly equivalent as a percentage of the model's maximum output size
                 ([OpenRouter Documentation](https://openrouter.ai/docs/use-cases/reasoning-tokens#reasoning-effort-level))
@@ -1817,6 +1818,17 @@ def _validate_language_profile(
             supported_efforts.extend(["'low'", "'medium'", "'high'"])
             supported_efforts_str = f"{', '.join(supported_efforts[:-1])}, or {supported_efforts[-1]}"
             raise ConfigurationError(f"Model '{model_alias}' does not support 'xhigh' reasoning. Please set reasoning_effort on '{profile_alias}' to {supported_efforts_str} instead.")
+        if not completion_model_params.supports_max_reasoning and profile.reasoning_effort == "max":
+            supported_efforts = []
+            if completion_model_params.supports_disabled_reasoning:
+                supported_efforts.append("'none'")
+            if completion_model_params.supports_minimal_reasoning:
+                supported_efforts.append("'minimal'")
+            supported_efforts.extend(["'low'", "'medium'", "'high'"])
+            if completion_model_params.supports_xhigh_reasoning:
+                supported_efforts.append("'xhigh'")
+            supported_efforts_str = f"{', '.join(supported_efforts[:-1])}, or {supported_efforts[-1]}"
+            raise ConfigurationError(f"Model '{model_alias}' does not support 'max' reasoning. Please set reasoning_effort on '{profile_alias}' to {supported_efforts_str} instead.")
         if not completion_model_params.supports_verbosity and profile.verbosity is not None:
             raise ConfigurationError(f"Model '{model_alias}' does not support verbosity. Please remove verbosity from '{profile_alias}'.")
     elif isinstance(language_model, AnthropicLanguageModel):

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -191,7 +191,6 @@ class EmbeddingModelParameters:
 CompletionModelCollection: TypeAlias = Dict[str, CompletionModelParameters]
 EmbeddingModelCollection: TypeAlias = Dict[str, EmbeddingModelParameters]
 OpenAILanguageModelName = Literal[
-    "gpt-5.6",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
@@ -568,7 +567,6 @@ class ModelCatalog:
                     )
                 },
             ),
-            snapshots=["gpt-5.6"],
         )
 
         self._add_model_to_catalog(

--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -61,11 +61,13 @@ class CompletionModelParameters:
         supports_minimal_reasoning: Whether the model supports minimal reasoning parameter. (Introduced with OpenAI gpt5 models)
         supports_disabled_reasoning: Whether the model supports disabling reasoning.
         supports_xhigh_reasoning: Whether the model supports xhigh reasoning effort.
+        supports_max_reasoning: Whether the model supports max reasoning effort.
         default_reasoning_effort: Default reasoning effort when a profile does not specify one.
         supported_reasoning_efforts: Set of provider-native reasoning efforts supported by the model.
         supported_thinking_levels: Set of thinking levels supported by the model (Gemini 3+).
             None means the model uses thinking_budget instead. Valid values: "high", "medium", "low", "minimal".
         uses_adaptive_thinking: Whether the model uses Anthropic adaptive thinking rather than manual thinking budgets.
+        requires_adaptive_thinking: Whether Anthropic requires adaptive thinking for all requests.
         supports_custom_temperature: Whether the model supports custom temperature.
         supports_verbosity: Whether the model supports verbosity. (Introduced with OpenAI gpt5 models)
         supports_pdf_parsing: Whether fenic can use this model to parse PDFs.
@@ -87,10 +89,12 @@ class CompletionModelParameters:
         supports_minimal_reasoning=False,
         supports_disabled_reasoning=True,
         supports_xhigh_reasoning=False,
+        supports_max_reasoning=False,
         default_reasoning_effort: Optional[str] = None,
         supported_reasoning_efforts: Optional[Set[str]] = None,
         supported_thinking_levels: Optional[Set[ThinkingLevelType]] = None,
         uses_adaptive_thinking: bool = False,
+        requires_adaptive_thinking: bool = False,
         supports_custom_temperature=True,
         supports_verbosity = False,
         supports_pdf_parsing = False,
@@ -111,10 +115,12 @@ class CompletionModelParameters:
         self.supports_minimal_reasoning = supports_minimal_reasoning
         self.supports_disabled_reasoning = supports_disabled_reasoning
         self.supports_xhigh_reasoning = supports_xhigh_reasoning
+        self.supports_max_reasoning = supports_max_reasoning
         self.default_reasoning_effort = default_reasoning_effort
         self.supported_reasoning_efforts = supported_reasoning_efforts
         self.supported_thinking_levels = supported_thinking_levels
         self.uses_adaptive_thinking = uses_adaptive_thinking
+        self.requires_adaptive_thinking = requires_adaptive_thinking
         self.supports_custom_temperature = supports_custom_temperature
         self.supports_verbosity = supports_verbosity
         self.supports_pdf_parsing = supports_pdf_parsing
@@ -126,7 +132,7 @@ class CompletionModelParameters:
         repr = (
             f"CompletionModelParameters(input_token_cost=${self.input_token_cost}, output_token_cost=${self.output_token_cost}, context_window_length={self.context_window_length}, max_output_tokens={self.max_output_tokens}, "
             f"max_temperature={self.max_temperature}, cached_input_token_write_cost=${self.cached_input_token_write_cost}, cached_input_token_read_cost=${self.cached_input_token_read_cost}, tiered_input_token_costs={self.tiered_input_token_costs}, "
-            f"supports_profiles={self.supports_profiles}, supports_reasoning={self.supports_reasoning}, supports_minimal_reasoning={self.supports_minimal_reasoning}, supports_xhigh_reasoning={self.supports_xhigh_reasoning}, supports_custom_temperature={self.supports_custom_temperature}, "
+            f"supports_profiles={self.supports_profiles}, supports_reasoning={self.supports_reasoning}, supports_minimal_reasoning={self.supports_minimal_reasoning}, supports_xhigh_reasoning={self.supports_xhigh_reasoning}, supports_max_reasoning={self.supports_max_reasoning}, supports_custom_temperature={self.supports_custom_temperature}, "
             f"supports_verbosity={self.supports_verbosity}, supported_parameters={self.supported_parameters})"
         )
         return repr
@@ -185,6 +191,10 @@ class EmbeddingModelParameters:
 CompletionModelCollection: TypeAlias = Dict[str, CompletionModelParameters]
 EmbeddingModelCollection: TypeAlias = Dict[str, EmbeddingModelParameters]
 OpenAILanguageModelName = Literal[
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.5-2026-04-23",
     "gpt-5.4",
@@ -243,6 +253,8 @@ GoogleDeveloperEmbeddingModelName = Literal[
 ]
 
 AnthropicLanguageModelName = Literal[
+    "claude-fable-5",
+    "claude-sonnet-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -362,6 +374,41 @@ class ModelCatalog:
 
     def _initialize_anthropic_models(self):
         """Initialize Anthropic models in the catalog."""
+        self._add_model_to_catalog(
+            ModelProvider.ANTHROPIC,
+            "claude-fable-5",
+            CompletionModelParameters(
+                input_token_cost=10.00 / 1_000_000,
+                cached_input_token_write_cost=12.50 / 1_000_000,
+                cached_input_token_read_cost=1.00 / 1_000_000,
+                output_token_cost=50.00 / 1_000_000,
+                context_window_length=1_000_000,
+                max_output_tokens=128_000,
+                supports_reasoning=False,
+                supported_reasoning_efforts=ANTHROPIC_OPUS_4_7_PLUS_EFFORTS,
+                uses_adaptive_thinking=True,
+                requires_adaptive_thinking=True,
+                supports_custom_temperature=False,
+            ),
+        )
+
+        self._add_model_to_catalog(
+            ModelProvider.ANTHROPIC,
+            "claude-sonnet-5",
+            CompletionModelParameters(
+                input_token_cost=3.00 / 1_000_000,
+                cached_input_token_write_cost=3.75 / 1_000_000,
+                cached_input_token_read_cost=0.30 / 1_000_000,
+                output_token_cost=15.00 / 1_000_000,
+                context_window_length=1_000_000,
+                max_output_tokens=128_000,
+                supports_reasoning=False,
+                supported_reasoning_efforts=ANTHROPIC_OPUS_4_7_PLUS_EFFORTS,
+                uses_adaptive_thinking=True,
+                supports_custom_temperature=False,
+            ),
+        )
+
         # Claude Opus 4.8 and 4.7 use adaptive thinking rather than manual thinking budgets.
         self._add_model_to_catalog(
             ModelProvider.ANTHROPIC,
@@ -495,6 +542,91 @@ class ModelCatalog:
 
     def _initialize_openai_models(self):
         """Initialize OpenAI models in the catalog."""
+        self._add_model_to_catalog(
+            ModelProvider.OPENAI,
+            "gpt-5.6-sol",
+            CompletionModelParameters(
+                input_token_cost=5.00 / 1_000_000,
+                cached_input_token_write_cost=6.25 / 1_000_000,
+                cached_input_token_read_cost=0.50 / 1_000_000,
+                output_token_cost=30.00 / 1_000_000,
+                context_window_length=1_050_000,
+                max_output_tokens=128_000,
+                supports_reasoning=True,
+                supports_minimal_reasoning=False,
+                supports_disabled_reasoning=True,
+                supports_xhigh_reasoning=True,
+                supports_max_reasoning=True,
+                supports_custom_temperature=True,
+                supports_verbosity=True,
+                supports_pdf_parsing=True,
+                tiered_token_costs={
+                    272_000: TieredTokenCost(
+                        input_token_cost=10.00 / 1_000_000,
+                        cached_input_token_read_cost=1.00 / 1_000_000,
+                        output_token_cost=45.00 / 1_000_000,
+                    )
+                },
+            ),
+            snapshots=["gpt-5.6"],
+        )
+
+        self._add_model_to_catalog(
+            ModelProvider.OPENAI,
+            "gpt-5.6-terra",
+            CompletionModelParameters(
+                input_token_cost=2.50 / 1_000_000,
+                cached_input_token_write_cost=3.125 / 1_000_000,
+                cached_input_token_read_cost=0.25 / 1_000_000,
+                output_token_cost=15.00 / 1_000_000,
+                context_window_length=1_050_000,
+                max_output_tokens=128_000,
+                supports_reasoning=True,
+                supports_minimal_reasoning=False,
+                supports_disabled_reasoning=True,
+                supports_xhigh_reasoning=True,
+                supports_max_reasoning=True,
+                supports_custom_temperature=True,
+                supports_verbosity=True,
+                supports_pdf_parsing=True,
+                tiered_token_costs={
+                    272_000: TieredTokenCost(
+                        input_token_cost=5.00 / 1_000_000,
+                        cached_input_token_read_cost=0.50 / 1_000_000,
+                        output_token_cost=22.50 / 1_000_000,
+                    )
+                },
+            ),
+        )
+
+        self._add_model_to_catalog(
+            ModelProvider.OPENAI,
+            "gpt-5.6-luna",
+            CompletionModelParameters(
+                input_token_cost=1.00 / 1_000_000,
+                cached_input_token_write_cost=1.25 / 1_000_000,
+                cached_input_token_read_cost=0.10 / 1_000_000,
+                output_token_cost=6.00 / 1_000_000,
+                context_window_length=1_050_000,
+                max_output_tokens=128_000,
+                supports_reasoning=True,
+                supports_minimal_reasoning=False,
+                supports_disabled_reasoning=True,
+                supports_xhigh_reasoning=True,
+                supports_max_reasoning=True,
+                supports_custom_temperature=True,
+                supports_verbosity=True,
+                supports_pdf_parsing=True,
+                tiered_token_costs={
+                    272_000: TieredTokenCost(
+                        input_token_cost=2.00 / 1_000_000,
+                        cached_input_token_read_cost=0.20 / 1_000_000,
+                        output_token_cost=9.00 / 1_000_000,
+                    )
+                },
+            ),
+        )
+
         self._add_model_to_catalog(
             ModelProvider.OPENAI,
             "gpt-4",

--- a/src/fenic/core/_inference/output_token_limits.py
+++ b/src/fenic/core/_inference/output_token_limits.py
@@ -31,6 +31,7 @@ OPENAI_REASONING_TOKEN_ESTIMATES: Final[dict[str, int]] = {
     "medium": 8192,
     "high": 16384,
     "xhigh": 32768,
+    "max": 65536,
 }
 
 OPENROUTER_REASONING_EFFORT_RATIOS: Final[dict[str, float]] = {
@@ -40,6 +41,7 @@ OPENROUTER_REASONING_EFFORT_RATIOS: Final[dict[str, float]] = {
     "medium": 0.50,
     "high": 0.80,
     "xhigh": 0.95,
+    "max": 0.95,
 }
 
 GOOGLE_THINKING_LEVEL_TOKEN_ESTIMATES: Final[dict[str, int]] = {

--- a/src/fenic/core/_resolved_session_config.py
+++ b/src/fenic/core/_resolved_session_config.py
@@ -26,8 +26,8 @@ from fenic.core.types.provider_routing import (
 )
 from fenic.core.types.semantic import ParsingEngine
 
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
-OpenRouterReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+OpenRouterReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 Verbosity = Literal["low", "medium", "high"]
 
 # --- Enums ---

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -66,6 +66,36 @@ def test_adaptive_effort_profile_uses_output_config():
     assert profile.output_config == {"effort": "xhigh"}
 
 
+def test_fable_default_profile_uses_required_adaptive_thinking():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-fable-5"
+    )
+    profile = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+    ).get_profile_by_name(None)
+
+    assert profile.thinking_enabled
+    assert profile.uses_adaptive_thinking
+    assert profile.thinking_config["type"] == "adaptive"
+
+
+def test_fable_empty_named_profile_uses_required_adaptive_thinking():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-fable-5"
+    )
+    profile = AnthropicCompletionsProfileManager(
+        model_parameters=params,
+        profile_configurations={
+            "default": ResolvedAnthropicModelProfile(),
+        },
+        default_profile_name="default",
+    ).get_profile_by_name(None)
+
+    assert profile.thinking_enabled
+    assert profile.uses_adaptive_thinking
+    assert profile.thinking_config["type"] == "adaptive"
+
+
 def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-5"

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -96,6 +96,24 @@ def test_fable_empty_named_profile_uses_required_adaptive_thinking():
     assert profile.thinking_config["type"] == "adaptive"
 
 
+def test_fable_effort_profile_reserves_adaptive_thinking_budget():
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-fable-5"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deep": ResolvedAnthropicModelProfile(effort="xhigh"),
+        },
+        default_profile_name="deep",
+    )
+    request = _make_request(max_completion_tokens=10_000)
+
+    profile = client._profile_manager.get_profile_by_name(None)
+    assert profile.thinking_token_budget == 121_600
+    assert client._get_max_output_token_request_limit(request) == 128_000
+
+
 def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     params = model_catalog.get_completion_model_parameters(
         ModelProvider.ANTHROPIC, "claude-opus-4-5"

--- a/tests/_inference/test_model_catalog.py
+++ b/tests/_inference/test_model_catalog.py
@@ -8,6 +8,7 @@ from fenic._inference.common_openai.openai_profile_manager import (
     OpenAICompletionsProfileManager,
 )
 from fenic.core._inference.model_catalog import (
+    ANTHROPIC_OPUS_4_7_PLUS_EFFORTS,
     AnthropicLanguageModelName,
     CohereEmbeddingModelName,
     CompletionModelParameters,
@@ -193,11 +194,34 @@ def test_latest_frontier_models_are_registered():
     """Sanity-check newly released frontier model IDs and snapshots."""
     catalog = model_catalog
 
+    openai_gpt_56_sol = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-sol")
+    openai_gpt_56_alias = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6")
+    openai_gpt_56_terra = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-terra")
+    openai_gpt_56_luna = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-luna")
+    assert openai_gpt_56_sol is openai_gpt_56_alias
+    assert openai_gpt_56_sol.context_window_length == 1_050_000
+    assert openai_gpt_56_sol.max_output_tokens == 128_000
+    assert openai_gpt_56_sol.supports_max_reasoning
+    assert openai_gpt_56_terra.input_token_cost == 2.50 / 1_000_000
+    assert openai_gpt_56_luna.output_token_cost == 6.00 / 1_000_000
+
     openai_gpt_55 = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.5")
     openai_gpt_55_snapshot = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.5-2026-04-23")
     assert openai_gpt_55 is openai_gpt_55_snapshot
     assert openai_gpt_55.supports_xhigh_reasoning
     assert openai_gpt_55.context_window_length == 1_050_000
+
+    anthropic_fable_5 = catalog.get_completion_model_parameters(ModelProvider.ANTHROPIC, "claude-fable-5")
+    assert anthropic_fable_5.context_window_length == 1_000_000
+    assert anthropic_fable_5.max_output_tokens == 128_000
+    assert anthropic_fable_5.uses_adaptive_thinking
+    assert anthropic_fable_5.supported_reasoning_efforts == ANTHROPIC_OPUS_4_7_PLUS_EFFORTS
+
+    anthropic_sonnet_5 = catalog.get_completion_model_parameters(ModelProvider.ANTHROPIC, "claude-sonnet-5")
+    assert anthropic_sonnet_5.context_window_length == 1_000_000
+    assert anthropic_sonnet_5.max_output_tokens == 128_000
+    assert anthropic_sonnet_5.uses_adaptive_thinking
+    assert anthropic_sonnet_5.supported_reasoning_efforts == ANTHROPIC_OPUS_4_7_PLUS_EFFORTS
 
     anthropic_opus_48 = catalog.get_completion_model_parameters(ModelProvider.ANTHROPIC, "claude-opus-4-8")
     assert anthropic_opus_48.context_window_length == 1_000_000

--- a/tests/_inference/test_model_catalog.py
+++ b/tests/_inference/test_model_catalog.py
@@ -195,10 +195,9 @@ def test_latest_frontier_models_are_registered():
     catalog = model_catalog
 
     openai_gpt_56_sol = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-sol")
-    openai_gpt_56_alias = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6")
     openai_gpt_56_terra = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-terra")
     openai_gpt_56_luna = catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6-luna")
-    assert openai_gpt_56_sol is openai_gpt_56_alias
+    assert catalog.get_completion_model_parameters(ModelProvider.OPENAI, "gpt-5.6") is None
     assert openai_gpt_56_sol.context_window_length == 1_050_000
     assert openai_gpt_56_sol.max_output_tokens == 128_000
     assert openai_gpt_56_sol.supports_max_reasoning

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -171,6 +171,30 @@ def test_openrouter_effort_estimate_uses_model_output_ratio():
     )
 
 
+def test_openrouter_max_effort_uses_maximum_output_ratio():
+    params = CompletionModelParameters(
+        input_token_cost=0,
+        output_token_cost=0,
+        context_window_length=1000,
+        max_output_tokens=1000,
+        supports_reasoning=True,
+        supports_disabled_reasoning=False,
+    )
+    model_config = ResolvedOpenRouterModelConfig(
+        model_name="openai/gpt-5.6-sol",
+        profiles={"max": ResolvedOpenRouterModelProfile(reasoning_effort="max")},
+    )
+
+    assert (
+        estimate_reasoning_tokens_for_resolved_profile(
+            model_config=model_config,
+            completion_parameters=params,
+            profile_name="max",
+        )
+        == 950
+    )
+
+
 def test_google_explicit_empty_budget_profile_estimates_no_reasoning_tokens():
     params = CompletionModelParameters(
         input_token_cost=0,

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -565,6 +565,12 @@ def test_model_profile_validation():
             language_models={"gpt-5.5": OpenAILanguageModel(model_name="gpt-5.5", profiles={"deep": OpenAILanguageModel.Profile(reasoning_effort="xhigh")}, rpm=100, tpm=1000)}
         )
     )
+    SessionConfig(
+        app_name="test_model_profile_validation",
+        semantic=SemanticConfig(
+            language_models={"gpt-5.6": OpenAILanguageModel(model_name="gpt-5.6", profiles={"deep": OpenAILanguageModel.Profile(reasoning_effort="max")}, rpm=100, tpm=1000)}
+        )
+    )
     # Test that older OpenAI reasoning models reject xhigh reasoning
     with pytest.raises(ConfigurationError, match="Model 'gpt-5.2' does not support 'xhigh' reasoning. Please set reasoning_effort on 'deep' to 'none', 'low', 'medium', or 'high' instead."):
         SessionConfig(
@@ -670,6 +676,7 @@ def test_model_profile_validation():
     OpenRouterLanguageModel.Profile(reasoning_effort="none")
     OpenRouterLanguageModel.Profile(reasoning_effort="minimal")
     OpenRouterLanguageModel.Profile(reasoning_effort="xhigh")
+    OpenRouterLanguageModel.Profile(reasoning_effort="max")
 
 def test_session_config_with_invalid_api_keys(tmp_path, monkeypatch):
     """Test that session configuration validation rejects models with invalid API keys."""

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -568,7 +568,7 @@ def test_model_profile_validation():
     SessionConfig(
         app_name="test_model_profile_validation",
         semantic=SemanticConfig(
-            language_models={"gpt-5.6": OpenAILanguageModel(model_name="gpt-5.6", profiles={"deep": OpenAILanguageModel.Profile(reasoning_effort="max")}, rpm=100, tpm=1000)}
+            language_models={"gpt-5.6-sol": OpenAILanguageModel(model_name="gpt-5.6-sol", profiles={"deep": OpenAILanguageModel.Profile(reasoning_effort="max")}, rpm=100, tpm=1000)}
         )
     )
     # Test that older OpenAI reasoning models reject xhigh reasoning


### PR DESCRIPTION
## Summary

Fenic can now use the GPT-5.6 Sol, Terra, and Luna tiers, including their 1.05M context window and `max` reasoning mode, as well as Claude Fable 5 and Sonnet 5. Claude Fable now always sends its required adaptive-thinking configuration, including when a profile is omitted or empty.

OpenRouter already discovers the new provider model aliases at runtime, including the GPT-5.6 `-pro` variants. Its gateway now exposes `max` reasoning effort, which Fenic accepts and reserves at the documented 95% output-token ratio.

## Validation

- `uv run --env-file .env --extra anthropic pytest tests/_inference/test_model_catalog.py tests/_inference/test_anthropic_profile_manager.py tests/api/test_session.py tests/_inference/test_output_token_limits.py -q` — 75 passed, 3 skipped.
- Live OpenRouter catalog integration passed; a public GPT-5.6 Sol configuration resolved dynamically and emitted `reasoning.effort: "max"`.
- `trunk check` and Python compilation passed for all changed files.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5.6](https://img.shields.io/badge/GPT-5.6-000000)
