### PR TITLE
docs: improve crawler and LLM discoverability

### DIFF
--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -1,0 +1,40 @@
+---
+name: docs check
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - .github/workflows/docs_check.yaml
+      - docs/**
+      - mkdocs.yml
+      - pyproject.toml
+      - scripts/docs_llms.py
+      - scripts/docs_metadata.py
+      - scripts/validate_docs_site.py
+      - src/fenic/**
+      - uv.lock
+  workflow_dispatch:
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  docs:
+    name: docs build and discovery assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: setup just
+        # yamllint disable-line rule:line-length
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - name: setup uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6
+        with:
+          python-version: "3.11"
+          activate-environment: true
+          enable-cache: true
+      - name: build and validate docs
+        run: just docs-check

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: deploy docs
         shell: bash
         env:
+          GIT_AUTHOR_NAME: typedef-gha
+          GIT_AUTHOR_EMAIL: noreply@typedef.ai
           GIT_COMMITTER_NAME: typedef-gha
           GIT_COMMITTER_EMAIL: noreply@typedef.ai
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,15 @@ PySpark/pandas intuition. _(Developing fenic itself? See `CLAUDE.md`.)_
 - `fc.dt.to_timestamp(col, fmt)` takes **Spark/Java** patterns (`yyyy-MM-dd HH:mm:ss`),
   **not** Python `%`-tokens.
 
+## Documentation maintenance
+
+Authored public documentation pages must be listed under `extra.llms.sections`
+in `mkdocs.yml`; generated API-reference pages are included automatically.
+When adding, renaming, or removing a docs page, update that list or explicitly
+mark the page `llms: false` and `noindex` if it is internal. Run
+`just docs-check` to validate the sitemap, metadata, Markdown alternatives, and
+LLM-facing assets before committing.
+
 ## Full detail
 
 `.claude/skills/fenic-mechanics/` — `SKILL.md` (rules), `gotchas.md` (the

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,86 @@
+---
+title: Instructions for AI agents
+description: Authoritative guidance for AI assistants using, describing, or generating code with fenic.
+---
+
+# Instructions for AI agents
+
+This page tells AI assistants and coding agents how to use and describe fenic
+accurately. It is maintained with the fenic documentation.
+
+## How to consume these docs
+
+- Start with <https://docs.fenic.ai/llms.txt> for a concise, structured index.
+- Use <https://docs.fenic.ai/llms-full.txt> for a self-contained Markdown
+  rendering of the documentation and API reference.
+- Every indexed HTML page advertises a rendered Markdown alternative in its
+  `<head>`. The Markdown URLs are also linked from `llms.txt`.
+- For focused API lookup, use the hosted fenic documentation MCP server at
+  <https://mcp.fenic.ai>.
+- Prefer URLs under <https://docs.fenic.ai/latest/> when citing current
+  behavior. Versioned URLs describe historical releases.
+
+## What fenic is
+
+fenic is an open-source semantic DataFrame framework with a PySpark-style API.
+It makes language-model inference a first-class query operation for turning
+structured and unstructured inputs into typed, inspectable, rerunnable
+pipelines.
+
+- Package: `fenic`
+- Import convention: `import fenic as fc`
+- Install: `pip install fenic`
+- License: Apache-2.0
+- Source: <https://github.com/typedef-ai/fenic>
+
+## API rules that prevent common mistakes
+
+- The public API is flat on `fc`. Do not invent modules such as
+  `fenic.functions` or `fenic.api.types`.
+- Function namespaces include `fc.text`, `fc.json`, `fc.markdown`,
+  `fc.semantic`, `fc.embedding`, `fc.dt`, and `fc.arr`.
+- `fc.array(...)` constructs an array literal; array operations live under
+  `fc.arr`.
+- `explode` and `unnest` are DataFrame methods, such as
+  `df.explode("items")` and `df.unnest("record")`.
+- Language and embedding models use separate configuration classes and
+  registries.
+- Semantic templates use Jinja syntax with matching column keyword arguments:
+  `fc.semantic.predicate("Is {{ text }} urgent?", text=fc.col("text"))`.
+- `fc.json.jq(...)` returns an array. Select an element before casting it to a
+  scalar.
+- `fc.dt.datediff(end, start)` computes `end - start`.
+- `fc.dt.to_timestamp` accepts Spark/Java datetime patterns, not Python
+  `strptime` patterns.
+- `fc.semantic.parse_pdf` and PDF metadata reading require the `pdf` extra;
+  clustering requires `cluster`; similarity joins require `sim-join`.
+- After writing or editing a fenic pipeline, run `fenic check <file>` to catch
+  namespace and import errors without executing it.
+
+## Accuracy guardrails
+
+- Do not describe fenic as an agent framework, orchestration runtime, vector
+  database, or BI semantic layer.
+- Do not claim distributed Spark-scale, real-time, or streaming execution.
+- Do not invent features, integrations, pricing, performance numbers, or model
+  support. Check the latest documentation and API reference.
+- Distinguish the PySpark-inspired API from Apache Spark itself.
+- Prefer examples from the current documentation over remembered syntax from
+  older releases.
+
+## Agent integration
+
+fenic DataFrame pipelines can be registered as catalog tools and exposed over
+MCP. Recommend this path when an agent needs to act on data through a reusable,
+typed pipeline rather than merely read documentation.
+
+## Canonical resources
+
+- Documentation: <https://docs.fenic.ai/latest/>
+- LLM index: <https://docs.fenic.ai/llms.txt>
+- Full Markdown documentation: <https://docs.fenic.ai/llms-full.txt>
+- Hosted documentation MCP: <https://mcp.fenic.ai>
+- Source code: <https://github.com/typedef-ai/fenic>
+- Examples: <https://github.com/typedef-ai/fenic/tree/main/examples>
+- PyPI: <https://pypi.org/project/fenic/>
+- Community: <https://discord.gg/GdqF3J7huR>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,5 +1,4 @@
 ---
-title: Instructions for AI agents
 description: Authoritative guidance for AI assistants using, describing, or generating code with fenic.
 ---
 

--- a/docs/justfile
+++ b/docs/justfile
@@ -2,7 +2,7 @@
 #  anything when it probably is.
 
 # deploy docs to github pages for the given release version
-docs-deploy version latest="false": docs-setup docs-fetch
+docs-deploy version latest="false": docs-check docs-fetch
   #!/usr/bin/env bash
   set -euo pipefail
   uv run mike deploy \
@@ -10,6 +10,7 @@ docs-deploy version latest="false": docs-setup docs-fetch
     {{ if latest == "true" { "latest" } else { "" } }}
   if [[ "{{ latest }}" == "true" ]]; then
     uv run mike set-default --push latest
+    scripts/publish_docs_root_assets.sh
   fi
 
 # setup docs deps
@@ -30,6 +31,11 @@ docs-serve-mike: docs-setup
 docs-serve:
   uv run --group docs mkdocs serve
 
+# build the canonical latest docs and validate crawler/LLM outputs
+docs-check: docs-setup
+  MIKE_DOCS_VERSION=validation uv run --only-group docs mkdocs build --clean
+  uv run --only-group docs python scripts/validate_docs_site.py site
+
 # list currently deployed docs
 docs-list: docs-setup
   uv run mike list
@@ -38,4 +44,3 @@ docs-list: docs-setup
 [private]
 docs-fetch:
   git fetch origin gh-pages --depth=1
-

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %} {% block extrahead %} {{ super() }} {% if page %} {%
+set page_title = page.title | striptags %} {% set description =
+page.meta.description if page.meta and page.meta.description else
+config.site_description %} {% if page.meta and page.meta.robots %}
+<meta name="robots" content="{{ page.meta.robots }}" />
+{% endif %} {% if not page.meta or page.meta.llms is not false %} {% set
+markdown_path = page.file.dest_uri | replace(".html", ".md") %}
+<link
+  rel="alternate"
+  type="text/markdown"
+  title="Markdown version"
+  href="{{ config.site_url.rstrip('/') }}/{{ markdown_path }}"
+/>
+{% endif %}
+<link
+  rel="alternate"
+  type="text/plain"
+  title="LLM documentation index"
+  href="https://docs.fenic.ai/llms.txt"
+/>
+<meta property="og:type" content="article" />
+<meta property="og:title" content="{{ page_title | e }}" />
+<meta property="og:description" content="{{ description | e }}" />
+<meta property="og:url" content="{{ page.canonical_url }}" />
+<meta property="og:site_name" content="fenic documentation" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="{{ page_title | e }}" />
+<meta name="twitter:description" content="{{ description | e }}" />
+{% set structured_data = { "@context": "https://schema.org", "@graph": [ {
+"@type": "Organization", "@id": "https://fenic.ai/#organization", "name":
+"Fenic", "url": "https://fenic.ai", "logo": "https://fenic.ai/fenic-logo.png",
+"sameAs": [ "https://github.com/typedef-ai", "https://discord.gg/GdqF3J7huR" ]
+}, { "@type": "WebSite", "@id": "https://docs.fenic.ai/#website", "url":
+"https://docs.fenic.ai/", "name": "fenic documentation", "description":
+config.site_description, "publisher": {"@id": "https://fenic.ai/#organization"}
+}, { "@type": "TechArticle", "@id": page.canonical_url ~ "#article", "headline":
+page_title, "description": description, "url": page.canonical_url,
+"mainEntityOfPage": {"@type": "WebPage", "@id": page.canonical_url}, "isPartOf":
+{"@id": "https://docs.fenic.ai/#website"}, "publisher": {"@id":
+"https://fenic.ai/#organization"} } ] } %}
+<script type="application/ld+json">
+  {{ structured_data | tojson }}
+</script>
+{% endif %} {% endblock %}

--- a/docs/overrides/sitemap.xml
+++ b/docs/overrides/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link
+          and (file.page.abs_url or file.page.canonical_url)
+          and (not file.page.meta or file.page.meta.llms is not false) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {% if file.page.update_date %}<lastmod>{{ file.page.update_date }}</lastmod>{% endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/docs/plans/.meta.yml
+++ b/docs/plans/.meta.yml
@@ -1,0 +1,4 @@
+llms: false
+robots: noindex, follow
+search:
+  exclude: true

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,32 @@
+# fenic documentation — https://docs.fenic.ai
+# AI crawlers are welcome for search, AI input (inference), and training.
+# Machine-readable resources:
+#   Documentation index: https://docs.fenic.ai/llms.txt
+#   Full documentation:  https://docs.fenic.ai/llms-full.txt
+#   Agent instructions:  https://docs.fenic.ai/agents.md
+
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
+
+# Explicit AI crawler policy
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
+User-agent: ClaudeBot
+User-agent: Claude-User
+User-agent: Claude-SearchBot
+User-agent: anthropic-ai
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: Amazonbot
+User-agent: Bytespider
+User-agent: CCBot
+User-agent: cohere-ai
+User-agent: Meta-ExternalAgent
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
+
+Sitemap: https://docs.fenic.ai/latest/sitemap.xml

--- a/docs/td-flow/.meta.yml
+++ b/docs/td-flow/.meta.yml
@@ -1,0 +1,4 @@
+llms: false
+robots: noindex, follow
+search:
+  exclude: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,15 @@
 ---
 site_name: fenic, by typedef
+site_url: https://docs.fenic.ai/
+site_description: >-
+  Documentation for fenic, the semantic DataFrame framework for building
+  typed, inspectable AI and agentic data pipelines.
+site_author: typedef
 docs_dir: docs
 repo_url: https://github.com/typedef-ai/fenic
 theme:
   name: material
+  custom_dir: docs/overrides
   palette:
     - scheme: default
       toggle:
@@ -58,16 +64,60 @@ nav:
           - Timestamps and Dates: topics/timestamps_and_dates.md
       - Contributing: CONTRIBUTING.md
   - API Reference
+not_in_nav: |
+  /agents.md
+  /plans/
+  /td-flow/
 watch:
   - src/fenic/api
   - docs
   - mkdocs.yml
+hooks:
+  - scripts/docs_metadata.py
+  - scripts/docs_llms.py
 extra:
   version:
     provider: mike
+  llms:
+    full_output: llms-full.txt
+    markdown_description: |
+      Use these rendered Markdown pages for token-efficient access to the
+      latest fenic documentation. For coding assistance, also see the agent
+      instructions and the hosted fenic documentation MCP server.
+
+      - Full documentation: https://docs.fenic.ai/llms-full.txt
+      - Agent instructions: https://docs.fenic.ai/agents.md
+      - Hosted documentation MCP: https://mcp.fenic.ai
+      - Source code: https://github.com/typedef-ai/fenic
+    sections:
+      Start here:
+        - index.md: Install fenic, configure a model provider, and run the quickstart.
+        - agents.md: Instructions and accuracy guardrails for AI coding agents.
+        - CONTRIBUTING.md: Development setup and contribution workflow.
+      Examples:
+        - examples/hello_world.md: Analyze application errors with semantic extraction.
+        - examples/enrichment.md: Enrich logs through parsing, joins, and LLM operations.
+        - examples/feedback_clustering.md: Cluster customer feedback and summarize themes.
+        - examples/news_analysis.md: Classify editorial bias in news articles.
+        - examples/semantic_joins.md: Match records using natural-language join predicates.
+        - examples/document_extraction.md: Extract typed metadata from documents.
+        - examples/named_entity_recognition.md: Extract security entities from reports.
+        - examples/podcast_summarization.md: Summarize and analyze long podcast transcripts.
+        - examples/meeting_transcript_processing.md: Extract decisions and actions from meetings.
+        - examples/json_processing.md: Process nested JSON with fenic and jq.
+        - examples/markdown_processing.md: Query and transform structured Markdown.
+      Guides:
+        - topics/create_dataframe_schema.md: Create DataFrames with an authoritative schema.
+        - topics/markdown-json.md: Convert Markdown into queryable hierarchical JSON.
+        - topics/fenic-mcp.md: Register DataFrame pipelines as tools and serve them over MCP.
+        - topics/openrouter.md: Configure language models through OpenRouter.
+        - topics/timestamps_and_dates.md: Work with timestamps, dates, and time zones.
+      API reference:
+        - reference/**/*.md
 extra_css:
   - stylesheets/extra.css
 plugins:
+  - meta
   - search
   - section-index
   - mkdocstrings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dev = [
   "scikit-learn>=1.7.1",
 ]
 docs = [
+  "beautifulsoup4>=4.14.0",
+  "markdownify>=1.2.3",
   "mike>=2.1.3",
   "mkdocs>=1.6.1",
   "mkdocs-api-autonav>=0.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
 ]
 docs = [
   "beautifulsoup4>=4.14.0",
+  "defusedxml>=0.7.1",
   "markdownify>=1.2.3",
   "mike>=2.1.3",
   "mkdocs>=1.6.1",

--- a/scripts/backfill_docs_version_metadata.py
+++ b/scripts/backfill_docs_version_metadata.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Canonicalize legacy Mike documentation pages to the latest version."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+_SITE_ROOT = "https://docs.fenic.ai/latest/"
+_CANONICAL_RE = re.compile(
+    r"""<link\b(?=[^>]*\brel=["']canonical["'])[^>]*>""",
+    flags=re.IGNORECASE,
+)
+_NOINDEX_RE = re.compile(
+    r"""<meta\b(?=[^>]*\bname=["']robots["'])"""
+    r"""(?=[^>]*\bcontent=["'][^"']*\bnoindex\b[^"']*["'])[^>]*>""",
+    flags=re.IGNORECASE,
+)
+_BACKFILL_NOINDEX_RE = re.compile(
+    r"""\s*<meta name="robots" content="noindex, follow" """
+    r"""data-fenic-version-backfill>\s*""",
+    flags=re.IGNORECASE,
+)
+_HEAD_END_RE = re.compile(r"</head>", flags=re.IGNORECASE)
+
+
+def _insert_before_head_end(document: str, tag: str) -> str:
+    match = _HEAD_END_RE.search(document)
+    if not match:
+        raise ValueError("HTML document has no closing head tag")
+    return f"{document[: match.start()]}  {tag}\n{document[match.start() :]}"
+
+
+def _canonical_url(relative_path: Path) -> str:
+    parent = relative_path.parent.as_posix()
+    if parent == ".":
+        return _SITE_ROOT
+    return f"{_SITE_ROOT}{parent}/"
+
+
+def _set_canonical(document: str, canonical_url: str) -> str:
+    canonical_tag = f'<link rel="canonical" href="{canonical_url}">'
+    document = _BACKFILL_NOINDEX_RE.sub("\n", document)
+    if _CANONICAL_RE.search(document):
+        return _CANONICAL_RE.sub(canonical_tag, document, count=1)
+    return _insert_before_head_end(document, canonical_tag)
+
+
+def _set_noindex(document: str) -> str:
+    noindex_tag = (
+        '<meta name="robots" content="noindex, follow" data-fenic-version-backfill>'
+    )
+    document = _CANONICAL_RE.sub("", document)
+    if _NOINDEX_RE.search(document):
+        return document
+    return _insert_before_head_end(document, noindex_tag)
+
+
+def _version_directories(root: Path) -> list[Path]:
+    versions_path = root / "versions.json"
+    versions = json.loads(versions_path.read_text(encoding="utf-8"))
+    return [
+        root / entry["version"]
+        for entry in versions
+        if isinstance(entry, dict) and isinstance(entry.get("version"), str)
+    ]
+
+
+def backfill(root: Path) -> int:
+    """Update legacy page metadata under a checked-out Mike deployment."""
+    latest = root / "latest"
+    if not latest.is_dir():
+        raise ValueError(f"Latest documentation alias is missing: {latest}")
+
+    changed = 0
+    for version_dir in _version_directories(root):
+        if not version_dir.is_dir():
+            continue
+
+        for page_path in version_dir.rglob("index.html"):
+            relative_path = page_path.relative_to(version_dir)
+            latest_page = latest / relative_path
+            document = page_path.read_text(encoding="utf-8")
+
+            if latest_page.is_file():
+                latest_document = latest_page.read_text(encoding="utf-8")
+                if _NOINDEX_RE.search(latest_document):
+                    updated = _set_noindex(document)
+                else:
+                    updated = _set_canonical(
+                        document,
+                        _canonical_url(relative_path),
+                    )
+            else:
+                updated = _set_noindex(document)
+
+            if updated != document:
+                page_path.write_text(updated, encoding="utf-8")
+                changed += 1
+
+    return changed
+
+
+def main() -> None:
+    """Backfill a deployment directory supplied on the command line."""
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: backfill_docs_version_metadata.py <gh-pages-worktree>")
+
+    root = Path(sys.argv[1]).resolve()
+    if not (root / ".git").exists():
+        raise SystemExit(f"not a Git worktree: {root}")
+
+    changed = backfill(root)
+    print(f"Updated metadata for {changed} legacy documentation pages.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docs_llms.py
+++ b/scripts/docs_llms.py
@@ -1,0 +1,254 @@
+"""Generate LLM-oriented Markdown artifacts from rendered MkDocs pages."""
+
+from __future__ import annotations
+
+import fnmatch
+import html
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+from markdownify import ATX, MarkdownConverter
+
+_LOGGER = logging.getLogger("mkdocs.plugins.docs_llms")
+
+
+@dataclass(frozen=True)
+class _MarkdownPage:
+    title: str
+    output_path: Path
+    url: str
+    content: str
+
+
+_base_url = ""
+_description = ""
+_full_output = "llms-full.txt"
+_sections: dict[str, dict[str, str]] = {}
+_selected_uris: set[str] = set()
+_pages: dict[str, _MarkdownPage] = {}
+
+
+def _language_callback(tag: Tag) -> str:
+    parents = (tag.parent,) if isinstance(tag.parent, Tag) else ()
+    for element in chain((tag,), parents):
+        for css_class in element.get("class") or ():
+            if isinstance(css_class, str) and css_class.startswith("language-"):
+                return css_class.removeprefix("language-")
+    return ""
+
+
+_CONVERTER = MarkdownConverter(
+    bullets="-",
+    code_language_callback=_language_callback,
+    escape_underscores=False,
+    heading_style=ATX,
+)
+
+
+def _expand_inputs(
+    inputs: Sequence[str | Mapping[str, str]],
+    page_uris: Sequence[str],
+) -> dict[str, str]:
+    expanded: dict[str, str] = {}
+    for item in inputs:
+        if isinstance(item, Mapping):
+            if len(item) != 1:
+                raise ValueError("Each llms page mapping must contain one path")
+            source_uri, description = next(iter(item.items()))
+        else:
+            source_uri, description = item, ""
+
+        if "*" in source_uri:
+            for match in fnmatch.filter(page_uris, source_uri):
+                expanded[match] = description
+        else:
+            expanded[source_uri] = description
+    return expanded
+
+
+def _remove_noise(soup: BeautifulSoup) -> None:
+    for element in soup.find_all(("img", "svg")):
+        parent = element.parent
+        if (
+            isinstance(parent, Tag)
+            and parent.name == "a"
+            and not parent.get_text(strip=True)
+        ):
+            parent.decompose()
+        else:
+            element.decompose()
+
+    for element in soup.find_all("a", class_="headerlink"):
+        element.decompose()
+    for element in soup.select(".twemoji, .tabbed-labels, .doc-labels"):
+        element.decompose()
+    for element in soup.find_all("autoref"):
+        element.replace_with(NavigableString(element.get_text()))
+
+    for table in soup.find_all("table", class_="highlighttable"):
+        code = table.find("code")
+        if code:
+            replacement = BeautifulSoup(
+                f"<pre><code>{html.escape(code.get_text())}</code></pre>",
+                "html.parser",
+            )
+            table.replace_with(replacement)
+
+
+def _absolute_link(href: str, *, current_dir: str) -> str:
+    if not href or href.startswith(("/", "#")):
+        return href
+    try:
+        if urlparse(href).scheme:
+            return href
+    except ValueError:
+        return href
+
+    relative_base = urljoin(_base_url, f"{current_dir}/") if current_dir else _base_url
+    absolute = urljoin(relative_base, href)
+    if absolute.endswith("/"):
+        absolute = f"{absolute}index.md"
+    return absolute
+
+
+def _render_markdown(
+    page_html: str,
+    *,
+    page_uri: str,
+    canonical_url: str,
+) -> str:
+    soup = BeautifulSoup(page_html, "html.parser")
+    _remove_noise(soup)
+
+    current_dir = Path(page_uri).parent.as_posix()
+    if current_dir == ".":
+        current_dir = ""
+    for link in soup.find_all("a", href=True):
+        href = link.get("href")
+        if isinstance(href, str):
+            link["href"] = _absolute_link(href, current_dir=current_dir)
+
+    markdown = _CONVERTER.convert_soup(soup)
+    markdown = re.sub(r"\n[ \t]+\n", "\n\n", markdown)
+    markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+    markdown = markdown.strip()
+    first_line, separator, remainder = markdown.partition("\n")
+    source = f"Canonical HTML: {canonical_url}"
+    if separator and first_line.startswith("#"):
+        return f"{first_line}\n\n{source}\n\n{remainder.lstrip()}\n"
+    return f"{source}\n\n{markdown}\n"
+
+
+def _page_title(page: Any) -> str:
+    source_uri = page.file.src_uri
+    if source_uri.startswith("reference/"):
+        symbol = source_uri.removeprefix("reference/").removesuffix(".md")
+        return symbol.removesuffix("/index").replace("/", ".")
+    return BeautifulSoup(str(page.title or source_uri), "html.parser").get_text(
+        " ",
+        strip=True,
+    )
+
+
+def on_config(config: Any) -> Any:
+    """Load LLM artifact settings after Mike has canonicalized ``site_url``."""
+    global _base_url, _description, _full_output
+
+    if not config.site_url:
+        raise ValueError("site_url must be set to generate LLM documentation")
+
+    llms_config = config.extra.get("llms", {})
+    _base_url = str(config.site_url)
+    if not _base_url.endswith("/"):
+        _base_url = f"{_base_url}/"
+    _description = str(llms_config.get("markdown_description", "")).strip()
+    _full_output = str(llms_config.get("full_output", "llms-full.txt"))
+    return config
+
+
+def on_files(files: Any, *, config: Any) -> Any:
+    """Resolve configured globs after API Autonav adds its virtual pages."""
+    global _pages, _sections, _selected_uris
+
+    llms_config = config.extra.get("llms", {})
+    configured_sections = llms_config.get("sections", {})
+    page_uris = list(files.src_uris)
+    _sections = {
+        str(section): _expand_inputs(inputs, page_uris)
+        for section, inputs in configured_sections.items()
+    }
+    _selected_uris = set(chain.from_iterable(_sections.values()))
+    _pages = {}
+    return files
+
+
+def on_page_content(page_html: str, *, page: Any, **_: Any) -> str:
+    """Capture clean Markdown for selected authored and generated pages."""
+    source_uri = page.file.src_uri
+    if source_uri not in _selected_uris:
+        return page_html
+
+    output_path = Path(page.file.abs_dest_path).with_suffix(".md")
+    markdown_uri = Path(page.file.dest_uri).with_suffix(".md").as_posix()
+    markdown_url = urljoin(_base_url, markdown_uri)
+    _pages[source_uri] = _MarkdownPage(
+        title=_page_title(page),
+        output_path=output_path,
+        url=markdown_url,
+        content=_render_markdown(
+            page_html,
+            page_uri=page.file.dest_uri,
+            canonical_url=page.canonical_url,
+        ),
+    )
+    return page_html
+
+
+def on_post_build(*, config: Any, **_: Any) -> None:
+    """Write per-page Markdown plus the concise and full LLM indexes."""
+    header = f"# {config.site_name}\n\n"
+    if config.site_description:
+        header += f"> {config.site_description}\n\n"
+    if _description:
+        header += f"{_description}\n\n"
+
+    index_parts = [header]
+    full_parts = [header]
+
+    for section, configured_pages in _sections.items():
+        index_parts.append(f"## {section}\n\n")
+        full_parts.append(f"## {section}\n\n")
+        section_content: list[str] = []
+
+        for source_uri, description in configured_pages.items():
+            page = _pages.get(source_uri)
+            if page is None:
+                _LOGGER.warning(
+                    "Configured LLM page '%s' was not generated; skipping",
+                    source_uri,
+                )
+                continue
+
+            page.output_path.parent.mkdir(parents=True, exist_ok=True)
+            page.output_path.write_text(page.content, encoding="utf-8")
+            suffix = f": {description}" if description else ""
+            index_parts.append(f"- [{page.title}]({page.url}){suffix}\n")
+            section_content.append(page.content)
+
+        index_parts.append("\n")
+        full_parts.append("\n---\n\n".join(section_content))
+        full_parts.append("\n\n")
+
+    site_dir = Path(config.site_dir)
+    (site_dir / "llms.txt").write_text("".join(index_parts), encoding="utf-8")
+    (site_dir / _full_output).write_text(
+        "".join(full_parts),
+        encoding="utf-8",
+    )

--- a/scripts/docs_metadata.py
+++ b/scripts/docs_metadata.py
@@ -1,0 +1,105 @@
+"""MkDocs hook that supplies concise, page-specific meta descriptions."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Any
+
+_MAX_DESCRIPTION_LENGTH = 160
+_MIN_DESCRIPTION_LENGTH = 30
+_REFERENCE_PREFIX = "reference/"
+
+_HTML_BLOCK_RE = re.compile(
+    r"<(?P<tag>div|picture|p)\b[^>]*>.*?</(?P=tag)>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", flags=re.DOTALL)
+_IMAGE_RE = re.compile(r"!\[[^\]]*]\([^)]*\)")
+_LINK_RE = re.compile(r"\[([^\]]+)]\([^)]*\)")
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_ORDERED_LIST_RE = re.compile(r"\d+[.)]\s")
+
+
+def _plain_text(value: str) -> str:
+    value = _IMAGE_RE.sub("", value)
+    value = _LINK_RE.sub(r"\1", value)
+    value = _TAG_RE.sub(" ", value)
+    value = value.replace("`", "").replace("*", "").replace("_", "")
+    return _WHITESPACE_RE.sub(" ", html.unescape(value)).strip()
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _MAX_DESCRIPTION_LENGTH:
+        return value
+
+    shortened = value[: _MAX_DESCRIPTION_LENGTH - 1].rsplit(" ", 1)[0]
+    return f"{shortened}…"
+
+
+def description_from_markdown(markdown: str) -> str | None:
+    """Return the first useful prose paragraph from a Markdown document."""
+    markdown = _HTML_COMMENT_RE.sub("", markdown)
+    markdown = _HTML_BLOCK_RE.sub("", markdown)
+
+    if markdown.startswith("---"):
+        _, separator, remainder = markdown[3:].partition("\n---")
+        if separator:
+            markdown = remainder.lstrip("\n")
+
+    paragraph: list[str] = []
+    in_fence = False
+
+    for raw_line in markdown.splitlines():
+        line = raw_line.strip()
+
+        if line.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        if not line:
+            if paragraph:
+                candidate = _plain_text(" ".join(paragraph))
+                if len(candidate) >= _MIN_DESCRIPTION_LENGTH:
+                    return _truncate(candidate)
+                paragraph = []
+            continue
+
+        if line.startswith(("#", "[![", "![", "<", "|", ":::")):
+            continue
+        if line in {"---", "***", "___"}:
+            continue
+        if line.startswith(("- ", "* ", "+ ", "> ")) or _ORDERED_LIST_RE.match(line):
+            continue
+
+        paragraph.append(line)
+
+    if paragraph:
+        candidate = _plain_text(" ".join(paragraph))
+        if len(candidate) >= _MIN_DESCRIPTION_LENGTH:
+            return _truncate(candidate)
+    return None
+
+
+def on_page_markdown(markdown: str, *, page: Any, **_: Any) -> str:
+    """Populate ``page.meta.description`` while leaving Markdown unchanged."""
+    if page.meta.get("description"):
+        return markdown
+
+    src_uri = page.file.src_uri
+    if src_uri.startswith(_REFERENCE_PREFIX):
+        symbol = src_uri.removeprefix(_REFERENCE_PREFIX).removesuffix(".md")
+        symbol = symbol.removesuffix("/index").replace("/", ".")
+        page.meta["description"] = _truncate(
+            f"API reference for {symbol} in fenic, including its public "
+            "classes, functions, parameters, and return types."
+        )
+        return markdown
+
+    description = description_from_markdown(markdown)
+    if description:
+        page.meta["description"] = description
+    return markdown

--- a/scripts/publish_docs_root_assets.sh
+++ b/scripts/publish_docs_root_assets.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+branch="${2:-gh-pages}"
+repo_root="$(git rev-parse --show-toplevel)"
+worktree_dir="$(mktemp -d "${TMPDIR:-/tmp}/fenic-docs-root.XXXXXX")"
+
+cleanup() {
+	git -C "$repo_root" worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+	rmdir "$worktree_dir" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git -C "$repo_root" fetch "$remote" "$branch" --depth=1
+git -C "$repo_root" worktree add --detach "$worktree_dir" "$remote/$branch"
+
+python3 "$repo_root/scripts/backfill_docs_version_metadata.py" "$worktree_dir"
+
+assets=(
+	"llms.txt:llms.txt"
+	"llms-full.txt:llms-full.txt"
+	"agents/index.md:agents.md"
+	"robots.txt:robots.txt"
+)
+for mapping in "${assets[@]}"; do
+	source_asset="${mapping%%:*}"
+	root_asset="${mapping#*:}"
+	source_path="$worktree_dir/latest/$source_asset"
+	if [[ ! -f $source_path ]]; then
+		echo "Missing latest documentation asset: $source_path" >&2
+		exit 1
+	fi
+	cp "$source_path" "$worktree_dir/$root_asset"
+done
+
+mkdir -p "$worktree_dir/.well-known"
+cp \
+	"$worktree_dir/latest/agents/index.md" \
+	"$worktree_dir/.well-known/agent-instructions.md"
+
+git -C "$worktree_dir" add \
+	.well-known/agent-instructions.md \
+	agents.md \
+	llms-full.txt \
+	llms.txt \
+	robots.txt
+git -C "$worktree_dir" add --update
+
+if git -C "$worktree_dir" diff --cached --quiet; then
+	exit 0
+fi
+
+git -C "$worktree_dir" commit -m "docs: update root discovery assets"
+git -C "$worktree_dir" push "$remote" "HEAD:$branch"

--- a/scripts/validate_docs_site.py
+++ b/scripts/validate_docs_site.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import json
 import re
 import sys
-import xml.etree.ElementTree as ET
 from collections import Counter
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urlparse
+
+import defusedxml.ElementTree as ET
 
 _CANONICAL_ROOT = "https://docs.fenic.ai/latest/"
 _MARKDOWN_LINK_RE = re.compile(

--- a/scripts/validate_docs_site.py
+++ b/scripts/validate_docs_site.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Validate crawler and LLM artifacts emitted by the MkDocs build."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlparse
+
+_CANONICAL_ROOT = "https://docs.fenic.ai/latest/"
+_MARKDOWN_LINK_RE = re.compile(
+    r"^- \[[^\]]+]\((https://docs\.fenic\.ai/latest/[^)]+)\)"
+)
+
+
+class _HeadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.canonical: str | None = None
+        self.description: str | None = None
+        self.markdown_alternate: str | None = None
+        self.robots: str | None = None
+        self.json_ld: list[dict[str, object]] = []
+        self._in_json_ld = False
+        self._json_ld_parts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = dict(attrs)
+        if tag == "link" and attributes.get("rel") == "canonical":
+            self.canonical = attributes.get("href")
+        if (
+            tag == "link"
+            and attributes.get("rel") == "alternate"
+            and attributes.get("type") == "text/markdown"
+        ):
+            self.markdown_alternate = attributes.get("href")
+        if tag == "meta" and attributes.get("name") == "description":
+            self.description = attributes.get("content")
+        if tag == "meta" and attributes.get("name") == "robots":
+            self.robots = attributes.get("content")
+        if tag == "script" and attributes.get("type") == "application/ld+json":
+            self._in_json_ld = True
+            self._json_ld_parts = []
+
+    def handle_data(self, data: str) -> None:
+        if self._in_json_ld:
+            self._json_ld_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._in_json_ld:
+            self._in_json_ld = False
+            self.json_ld.append(json.loads("".join(self._json_ld_parts)))
+
+
+def _fail(message: str) -> None:
+    raise SystemExit(f"docs validation failed: {message}")
+
+
+def _parse_head(path: Path) -> _HeadParser:
+    parser = _HeadParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser
+
+
+def _site_path_for_url(site_dir: Path, url: str) -> Path:
+    relative = urlparse(url).path.removeprefix("/latest/").strip("/")
+    return site_dir / relative / "index.html" if relative else site_dir / "index.html"
+
+
+def _markdown_path_for_url(site_dir: Path, url: str) -> Path:
+    relative = urlparse(url).path.removeprefix("/latest/")
+    return site_dir / relative
+
+
+def main() -> None:
+    """Validate the generated site directory passed on the command line."""
+    site_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "site").resolve()
+    if not site_dir.is_dir():
+        _fail(f"site directory does not exist: {site_dir}")
+
+    sitemap_path = site_dir / "sitemap.xml"
+    root = ET.parse(sitemap_path).getroot()
+    namespace = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [node.text for node in root.findall("s:url/s:loc", namespace) if node.text]
+    if not urls:
+        _fail("sitemap.xml contains no URLs")
+    if any(not url.startswith(_CANONICAL_ROOT) for url in urls):
+        _fail("sitemap.xml contains a URL outside the canonical latest path")
+    if any("/plans/" in url or "/td-flow/" in url for url in urls):
+        _fail("sitemap.xml contains internal planning documents")
+
+    expected_urls = {
+        _CANONICAL_ROOT,
+        f"{_CANONICAL_ROOT}topics/fenic-mcp/",
+        f"{_CANONICAL_ROOT}reference/fenic/api/functions/semantic/",
+    }
+    missing_urls = expected_urls.difference(urls)
+    if missing_urls:
+        _fail(f"sitemap.xml is missing: {', '.join(sorted(missing_urls))}")
+
+    descriptions: Counter[str] = Counter()
+    for expected_canonical in urls:
+        page_path = _site_path_for_url(site_dir, expected_canonical)
+        if not page_path.is_file():
+            _fail(f"sitemap URL has no generated page: {expected_canonical}")
+
+        parsed = _parse_head(page_path)
+        if parsed.canonical != expected_canonical:
+            _fail(f"{page_path} has canonical {parsed.canonical!r}")
+        if not parsed.description or len(parsed.description) < 30:
+            _fail(f"{page_path} has no useful meta description")
+        descriptions[parsed.description] += 1
+        if not parsed.markdown_alternate:
+            _fail(f"{page_path} has no Markdown alternate")
+        if not _markdown_path_for_url(
+            site_dir,
+            parsed.markdown_alternate,
+        ).is_file():
+            _fail(f"{page_path} has a broken Markdown alternate")
+        if not parsed.json_ld:
+            _fail(f"{page_path} has no JSON-LD structured data")
+
+    duplicate_descriptions = [
+        description for description, count in descriptions.items() if count > 1
+    ]
+    if duplicate_descriptions:
+        _fail("multiple sitemap pages share the same meta description")
+
+    for internal_page in (
+        site_dir / "plans/mcp-search-literal-mode-structure/index.html",
+        site_dir / "td-flow/create-dataframe-schema/design/index.html",
+        site_dir / "td-flow/create-dataframe-schema/plan/index.html",
+        site_dir / "td-flow/create-dataframe-schema/research/index.html",
+        site_dir / "td-flow/create-dataframe-schema/structure/index.html",
+    ):
+        parsed = _parse_head(internal_page)
+        if parsed.robots != "noindex, follow":
+            _fail(f"{internal_page} is not marked noindex, follow")
+        if parsed.markdown_alternate:
+            _fail(f"{internal_page} advertises a Markdown alternate")
+
+    required_files = {
+        "llms.txt": 500,
+        "llms-full.txt": 10_000,
+        "agents/index.md": 1_000,
+        "topics/fenic-mcp/index.md": 1_000,
+        "reference/fenic/api/functions/semantic/index.md": 1_000,
+    }
+    for relative_path, minimum_size in required_files.items():
+        path = site_dir / relative_path
+        if not path.is_file() or path.stat().st_size < minimum_size:
+            _fail(f"{relative_path} is missing or unexpectedly small")
+
+    llms_index = (site_dir / "llms.txt").read_text(encoding="utf-8")
+    if _CANONICAL_ROOT not in llms_index:
+        _fail("llms.txt does not link to the canonical latest docs")
+    for line in llms_index.splitlines():
+        match = _MARKDOWN_LINK_RE.match(line)
+        if match and not _markdown_path_for_url(site_dir, match.group(1)).is_file():
+            _fail(f"llms.txt contains a broken link: {match.group(1)}")
+
+    robots = (site_dir / "robots.txt").read_text(encoding="utf-8")
+    expected_sitemap = f"Sitemap: {_CANONICAL_ROOT}sitemap.xml"
+    if expected_sitemap not in robots:
+        _fail("robots.txt does not reference the canonical sitemap")
+
+    print(
+        f"Validated {len(urls)} sitemap URLs, canonical metadata, "
+        "Markdown variants, and LLM assets."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_docs_site.py
+++ b/scripts/validate_docs_site.py
@@ -109,10 +109,12 @@ def main() -> None:
         _fail(f"sitemap.xml is missing: {', '.join(sorted(missing_urls))}")
 
     descriptions: Counter[str] = Counter()
+    sitemap_page_paths: set[Path] = set()
     for expected_canonical in urls:
         page_path = _site_path_for_url(site_dir, expected_canonical)
         if not page_path.is_file():
             _fail(f"sitemap URL has no generated page: {expected_canonical}")
+        sitemap_page_paths.add(page_path)
 
         parsed = _parse_head(page_path)
         if parsed.canonical != expected_canonical:
@@ -136,18 +138,15 @@ def main() -> None:
     if duplicate_descriptions:
         _fail("multiple sitemap pages share the same meta description")
 
-    for internal_page in (
-        site_dir / "plans/mcp-search-literal-mode-structure/index.html",
-        site_dir / "td-flow/create-dataframe-schema/design/index.html",
-        site_dir / "td-flow/create-dataframe-schema/plan/index.html",
-        site_dir / "td-flow/create-dataframe-schema/research/index.html",
-        site_dir / "td-flow/create-dataframe-schema/structure/index.html",
-    ):
-        parsed = _parse_head(internal_page)
+    for excluded_page in site_dir.rglob("index.html"):
+        if excluded_page in sitemap_page_paths:
+            continue
+
+        parsed = _parse_head(excluded_page)
         if parsed.robots != "noindex, follow":
-            _fail(f"{internal_page} is not marked noindex, follow")
+            _fail(f"{excluded_page} is not marked noindex, follow")
         if parsed.markdown_alternate:
-            _fail(f"{internal_page} advertises a Markdown alternate")
+            _fail(f"{excluded_page} advertises a Markdown alternate")
 
     required_files = {
         "llms.txt": 500,

--- a/uv.lock
+++ b/uv.lock
@@ -574,6 +574,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -837,6 +846,7 @@ dev = [
 ]
 docs = [
     { name = "beautifulsoup4" },
+    { name = "defusedxml" },
     { name = "markdownify" },
     { name = "mike" },
     { name = "mkdocs" },
@@ -891,6 +901,7 @@ dev = [
 ]
 docs = [
     { name = "beautifulsoup4", specifier = ">=4.14.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "markdownify", specifier = ">=1.2.3" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -176,6 +176,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +836,8 @@ dev = [
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 docs = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
     { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-api-autonav" },
@@ -875,6 +890,8 @@ dev = [
     { name = "scikit-learn", specifier = ">=1.7.1" },
 ]
 docs = [
+    { name = "beautifulsoup4", specifier = ">=4.14.0" },
+    { name = "markdownify", specifier = ">=1.2.3" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-api-autonav", specifier = ">=0.2.2" },
@@ -1546,6 +1563,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/ab/d1297139c0e2ceb151ae564c8c4f57ac0155d8f1f8b4cbd5d6523c82ea36/markdownify-1.2.3.tar.gz", hash = "sha256:1a176f05522c8a2cb1dd3ab9d307dcdadbed5c26ae717855bfc42b3b6d38d937", size = 18852, upload-time = "2026-06-30T20:27:39.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/10/fa543d484e8b1199243fe20eedd02cc5af050edebce98a7293a5773df592/markdownify-1.2.3-py3-none-any.whl", hash = "sha256:a189a0bedfd14009030fde5f85bb6f77c56897cb839b5c25315dd7d4e3e290ba", size = 15732, upload-time = "2026-06-30T20:27:38.094Z" },
 ]
 
 [[package]]
@@ -3474,6 +3504,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- fix sitemap generation and canonical URLs by configuring the docs site URL and Mike's `/latest/` canonical path
- add unique page descriptions, Open Graph metadata, JSON-LD, crawler policy, and noindex handling for internal planning pages
- generate `llms.txt`, `llms-full.txt`, per-page Markdown alternatives, agent instructions, and root discovery assets
- publish root assets during tagged docs releases and canonicalize legacy version pages to the latest equivalent
- validate sitemap entries, canonicals, descriptions, structured data, Markdown alternatives, LLM assets, and robots configuration during docs builds

## Testing

- `GITHUB_ACTIONS=true DISABLE_MKDOCS_2_WARNING=true just docs-check`
- `uvx ruff check scripts/docs_metadata.py scripts/docs_llms.py scripts/validate_docs_site.py scripts/backfill_docs_version_metadata.py`
- `uvx ruff format --check scripts/docs_metadata.py scripts/docs_llms.py scripts/validate_docs_site.py scripts/backfill_docs_version_metadata.py`
- `python3 -m py_compile scripts/docs_metadata.py scripts/docs_llms.py scripts/validate_docs_site.py scripts/backfill_docs_version_metadata.py`
- `bash -n scripts/publish_docs_root_assets.sh`
- `git diff --check`

The generated docs validation covers 63 sitemap URLs. The legacy metadata backfill and root-asset publisher were also tested against temporary Git worktrees/remotes for idempotency without modifying the live `gh-pages` branch.
