### PR TITLE
docs: move td-flow artifacts out of the published docs site into specs/

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -6,9 +6,9 @@ Anything in this directory is written for maintainers and agents working in this
 
 ## Layout
 
-| Path | Contents |
-| --- | --- |
-| `specs/*.md` | Standalone design documents (e.g. `llm_cache_design.md`) |
+| Path                           | Contents                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| `specs/*.md`                   | Standalone design documents (e.g. `llm_cache_design.md`)                        |
 | `specs/td-flow/<workflow_id>/` | td-flow phase artifacts — `research.md`, `design.md`, `structure.md`, `plan.md` |
 
 ## td-flow artifacts live here, not in `docs/`

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,22 @@
+# specs/
+
+Internal engineering specs and planning artifacts. **Not part of the published docs site.**
+
+Anything in this directory is written for maintainers and agents working in this repo — design notes, td-flow workflow artifacts, and similar. It is deliberately outside `docs/` so it is never built, indexed, sitemapped, or included in the LLM-facing docs assets (`llms.txt`, `llms-full.txt`, per-page Markdown alternatives).
+
+## Layout
+
+| Path | Contents |
+| --- | --- |
+| `specs/*.md` | Standalone design documents (e.g. `llm_cache_design.md`) |
+| `specs/td-flow/<workflow_id>/` | td-flow phase artifacts — `research.md`, `design.md`, `structure.md`, `plan.md` |
+
+## td-flow artifacts live here, not in `docs/`
+
+**`specs/td-flow/` is the canonical location for td-flow artifacts in this repo.** They were previously written to `docs/td-flow/` and `docs/plans/`, which meant internal planning documents were built into the public documentation site and had to be individually excluded from search, the sitemap, and the LLM assets.
+
+If you are running a td-flow phase in this repo, write the artifact to `specs/td-flow/<workflow_id>/<phase>.md`. Do not create `docs/td-flow/` or `docs/plans/`.
+
+## Why not just `noindex` them under `docs/`?
+
+Because it is a per-directory exclusion that has to be remembered and re-applied every time someone adds an internal doc, and a missed one is silently published. Keeping internal material out of `docs/` entirely makes the rule structural: **everything under `docs/` is public; everything here is not.**

--- a/specs/td-flow/create-dataframe-schema/design.md
+++ b/specs/td-flow/create-dataframe-schema/design.md
@@ -6,7 +6,7 @@ size_class: high-risk
 status: approved
 portability_level: 2
 source_inputs:
-  - docs/td-flow/create-dataframe-schema/research.md
+  - specs/td-flow/create-dataframe-schema/research.md
 last_updated: 2026-06-26
 ---
 
@@ -105,7 +105,7 @@ None.
 **Next step (paste into a fresh tab):**
 
 > Use the `td-structure` skill. The design is approved at
-> `docs/td-flow/create-dataframe-schema/design.md` (track: engineering, size: high-risk).
+> `specs/td-flow/create-dataframe-schema/design.md` (track: engineering, size: high-risk).
 > Build the vertically-sliced structure outline from the chosen approach. Use the
 > design + the research findings — do not read the research Questions section as a
 > spec.
@@ -117,5 +117,5 @@ None.
 **Non-goals / out of scope:** Partial schemas, Pydantic schema shortcuts, new cloud protocol changes, a new source node, broad recasting of all source columns during execution, and content validation for tagged string logical types such as `JsonType`/`MarkdownType`.
 **Evidence summary:** Research showed `create_dataframe` currently has no schema parameter and normalizes all supported inputs through Polars before `InMemorySource`; `InMemorySource` already supports preserved schemas and plan serde stores wrapper-level schemas; fenic-to-Polars conversion already maps all fenic data types to physical dtypes; local in-memory execution currently applies generic ingestion coercion that converts fixed-size arrays to lists.
 **Known weak assumptions:** Structure should pressure-test the exact implementation of embedding-path preservation in `InMemorySourceExec`, and confirm whether strict physical coercion should use existing fenic cast semantics or Polars casts for each supported schema type.
-**Next artifact:** `docs/td-flow/create-dataframe-schema/structure.md`
+**Next artifact:** `specs/td-flow/create-dataframe-schema/structure.md`
 **Rollback if:** building the structure exposes the chosen approach is infeasible — ROLLBACK to design.

--- a/specs/td-flow/create-dataframe-schema/plan.md
+++ b/specs/td-flow/create-dataframe-schema/plan.md
@@ -6,9 +6,9 @@ size_class: high-risk
 status: approved
 portability_level: 3
 source_inputs:
-  - docs/td-flow/create-dataframe-schema/structure.md
-  - docs/td-flow/create-dataframe-schema/research.md
-  - docs/td-flow/create-dataframe-schema/design.md
+  - specs/td-flow/create-dataframe-schema/structure.md
+  - specs/td-flow/create-dataframe-schema/research.md
+  - specs/td-flow/create-dataframe-schema/design.md
 last_updated: 2026-06-26
 ---
 
@@ -938,7 +938,7 @@ None. The behavior is observable through logical schema assertions and Polars ph
 
 **Implemented head:** pending commit
 
-**Spec source:** `docs/td-flow/create-dataframe-schema/plan.md`
+**Spec source:** `specs/td-flow/create-dataframe-schema/plan.md`
 
 **Verification summary:** `uv run --env-file .env uv run pytest tests/api/test_session.py tests/_backends/local/functions/test_jq.py tests/_backends/local/functions/test_markdown.py -k "schema" -q` (22 passed, 53 deselected); `uv run --env-file .env uv run pytest tests/_logical_plan/serde/test_plan_serde.py -k "explicit_schema or basic_plan" -q` (4 passed, 38 deselected); `uv run --env-file .env uv run pytest tests/_logical_plan/test_plan_equality.py -k "schema_mismatch or inmemory_source" -q` (3 passed, 24 deselected); `uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp` (success); `uv run --env-file .env uv run pytest tests/_backends/cloud/test_cloud_execution.py -k "explicit_schema or simple_count" -q` (2 passed, 6 deselected); `uv run pytest tests/_backends/test_ingestion_coercion.py -q` (11 passed, 0 failed, 0 skipped); `uv run pytest tests/_backends/local/test_transpiler.py -k "source_plan" -q` (1 passed, 9 deselected); `uv run pytest tests/api/test_session.py -k "embedding_schema or create_dataframe_with_schema" -q` (17 passed, 37 deselected); `uv run pytest tests/_logical_plan/serde/test_plan_serde.py -k "embedding or explicit_schema" -q` (4 passed, 40 deselected); `uv run trunk check --fix` (no issues)
 
@@ -973,7 +973,7 @@ None.
 **Next step (paste into a fresh tab):**
 
 > Use the `td-implement` skill. The plan is approved at
-> `docs/td-flow/create-dataframe-schema/plan.md` (track: engineering, size: high-risk).
+> `specs/td-flow/create-dataframe-schema/plan.md` (track: engineering, size: high-risk).
 > Implement Phase 1 from the plan, run the repo's verification, then pause for my
 > approval before committing or advancing.
 > If this is Codex: I explicitly permit optional subagent use for this phase

--- a/specs/td-flow/create-dataframe-schema/research.md
+++ b/specs/td-flow/create-dataframe-schema/research.md
@@ -8,7 +8,7 @@ status: approved
 portability_level: 3
 recommended_track: engineering
 source_inputs:
-  - docs/td-flow/create-dataframe-schema/research.md (Research Questions section)
+  - specs/td-flow/create-dataframe-schema/research.md (Research Questions section)
   - src/fenic/api/session/session.py
   - src/fenic/core/types/query_result.py
   - src/fenic/core/_logical_plan/plans/source.py
@@ -153,7 +153,7 @@ None.
 **Next step (paste into a fresh tab after research approval):**
 
 > Use the `td-design` skill. Research is approved at
-> `docs/td-flow/create-dataframe-schema/research.md` (track: engineering, size: high-risk).
+> `specs/td-flow/create-dataframe-schema/research.md` (track: engineering, size: high-risk).
 > Design-stage trigger(s) held: new or changed public API/schema contract. Choose
 > the approach, weigh alternatives, and fix the cross-cutting contracts before the structure.
 > Use this research doc's Findings — the `## Research Questions` section is provenance, not a spec.
@@ -166,5 +166,5 @@ None.
 **Non-goals / out of scope:** The originating ticket was not read; this document does not prescribe implementation changes.
 **Evidence summary:** Public input and normalization flow: `src/fenic/api/session/session.py:132-220`; logical schema and serde flow: `src/fenic/core/_logical_plan/plans/source.py:21-65`, `src/fenic/core/_serde/proto/plan_serde.py:38-90`, `src/fenic/core/_serde/proto/plans/source.py:34-56`; conversion/coercion flow: `src/fenic/core/_utils/schema.py:31-190`, `src/fenic/_backends/local/physical_plan/utils.py:6-53`; explicit-schema APIs: `src/fenic/api/io/reader.py:70-152`, `src/fenic/_backends/local/catalog.py:416-459`.
 **Known weak assumptions:** None.
-**Next artifact:** `docs/td-flow/create-dataframe-schema/design.md`
+**Next artifact:** `specs/td-flow/create-dataframe-schema/design.md`
 **Rollback if:** the research questions are found to be too narrow for the intended API/schema change.

--- a/specs/td-flow/create-dataframe-schema/structure.md
+++ b/specs/td-flow/create-dataframe-schema/structure.md
@@ -6,8 +6,8 @@ size_class: high-risk
 status: approved
 portability_level: 3
 source_inputs:
-  - docs/td-flow/create-dataframe-schema/research.md
-  - docs/td-flow/create-dataframe-schema/design.md
+  - specs/td-flow/create-dataframe-schema/research.md
+  - specs/td-flow/create-dataframe-schema/design.md
 last_updated: 2026-06-26
 ---
 
@@ -188,7 +188,7 @@ None.
 
 **Implemented head:** pending commit
 
-**Spec source:** `docs/td-flow/create-dataframe-schema/structure.md`
+**Spec source:** `specs/td-flow/create-dataframe-schema/structure.md`
 
 **Verification summary:** same as plan-phase coverage in `create-dataframe-schema-plan.md` (targeted pytest commands in-phase 3 and phase 4 all passed).
 
@@ -250,7 +250,7 @@ None.
 **Next step (paste into a fresh tab):**
 
 > Use the `td-plan` skill. The structure is approved at
-> `docs/td-flow/create-dataframe-schema/structure.md` (track: engineering, size: high-risk).
+> `specs/td-flow/create-dataframe-schema/structure.md` (track: engineering, size: high-risk).
 > Deepen it into a full implementation plan with per-file code examples and dual
 > success criteria.
 > If this is Codex: I explicitly permit optional subagent use for this phase
@@ -261,5 +261,5 @@ None.
 **Non-goals / out of scope:** Partial schemas, Pydantic schema shortcuts, new cloud protocol fields, a new source node, broad source recasting, tagged-string content validation, and user-facing docs in this implementation pass.
 **Evidence summary:** `Session.create_dataframe` currently normalizes supported inputs before `InMemorySource.from_session_state`; `InMemorySource.from_schema` already stores explicit schemas and participates in equality/serde; wrapper-level plan serde already carries logical schema; `convert_custom_schema_to_polars_schema` maps fenic schemas to Polars dtypes including `EmbeddingType`; local `InMemorySourceExec` currently applies generic ingestion coercions that turn fixed-size arrays into lists.
 **Known weak assumptions:** The Plan should pressure-test duplicate schema validation before Polars schema conversion, cloud test setup through `just sync-cloud`, and the exact recursive mechanism for preserving only embedding-typed physical paths without changing no-schema array behavior.
-**Next artifact:** `docs/td-flow/create-dataframe-schema/plan.md`
+**Next artifact:** `specs/td-flow/create-dataframe-schema/plan.md`
 **Rollback if:** deepening exposes that the outline is infeasible — ROLLBACK to research/design.

--- a/specs/td-flow/mcp-search-literal-mode-structure.md
+++ b/specs/td-flow/mcp-search-literal-mode-structure.md
@@ -143,7 +143,7 @@ None.
 **Next step (paste into a fresh tab):**
 
 > Use the `td-implement` skill. Structure is ready at
-> `docs/plans/mcp-search-literal-mode-structure.md` (track: engineering, size: lightweight).
+> `specs/td-flow/mcp-search-literal-mode-structure.md` (track: engineering, size: lightweight).
 > Implement the phases in order. Run `mise install` if needed so the `just` tool from `mise.toml` is on PATH; then use the repo `just` recipes normally. After editing any fenic pipeline examples, run `fenic check <file>`; this plan does not currently require editing fenic pipeline examples.
 
 **Approved decisions:** add `search_mode` to generated Search Content and Search Summary; accepted values are `"regex"` and `"literal"`; default is `"regex"`; regex mode keeps `Column.rlike(...)`; literal mode uses `Column.contains(...)`; server wrapper changes are not expected because generated signatures already flow through FastMCP.
@@ -156,7 +156,7 @@ None.
 ## Implementation Notes
 
 **Implemented head:** `ff6ad44`
-**Spec source:** `docs/plans/mcp-search-literal-mode-structure.md`
+**Spec source:** `specs/td-flow/mcp-search-literal-mode-structure.md`
 **Verification summary:** `uv run --env-file .env pytest tests/api/mcp/test_tool_generation.py tests/api/mcp/test_server.py` passed with 14 tests; `uv run --env-file .env ruff check src/fenic/api/mcp/_tool_generation_utils.py src/fenic/api/mcp/tools.py tests/api/mcp/test_tool_generation.py tests/api/mcp/test_server.py tests/api/mcp/utils.py` passed. Live generated-callable checks confirmed literal vs regex Search Summary counts and FastMCP `search_mode` schema defaults.
 **Deliberate tradeoffs / rejected approaches:** Kept regex as the default for backward compatibility; reused existing `Column.contains(...)` and `Column.rlike(...)` rather than adding a new expression; left unrelated generated-tool normalization quirks out of scope.
 **Deviations from spec:** None.


### PR DESCRIPTION
Internal td-flow planning artifacts were living under `docs/` and therefore being built into the public documentation site. This moves them to `specs/` — which already holds internal design docs (`llm_cache_design.md`, `adaptive_token_estimation_design.md`) and is not part of the docs build.

## What moved

| From | To |
| --- | --- |
| `docs/td-flow/create-dataframe-schema/{research,design,structure,plan}.md` | `specs/td-flow/create-dataframe-schema/` |
| `docs/plans/mcp-search-literal-mode-structure.md` | `specs/td-flow/mcp-search-literal-mode-structure.md` |

`docs/td-flow/` and `docs/plans/` are now gone. The artifacts self-referential paths were rewritten; no skill, CI workflow, or config referenced these paths, so nothing else needed updating (verified by grep).

Also adds `specs/README.md` establishing **`specs/td-flow/<workflow_id>/` as the canonical location** for td-flow artifacts in this repo — without that, the next td-flow run simply recreates `docs/td-flow/`.

## Relationship to #335

#335 handles these same directories by adding `docs/plans/.meta.yml` and `docs/td-flow/.meta.yml` with `robots: noindex`, `llms: false`, `search.exclude: true`. That works, but it is a per-directory exclusion that must be remembered and re-applied for every future internal doc — and a missed one is silently published.

This PR makes the boundary structural instead: **everything under `docs/` is public; internal material lives in `specs/`.**

The two PRs touch the same directories, so whichever lands second needs a trivial rebase. If this one lands first, the two `.meta.yml` files in #335 become unnecessary and can be dropped. Happy to sequence either way — flagging so it is not a surprise.

## Note

`docs/plans/mcp-search-literal-mode-structure.md` is a td-flow structure artifact written flat rather than in a workflow directory, so it was consolidated under `specs/td-flow/` with its filename preserved. Easy to relocate if you would rather it sat elsewhere.