### PR TITLE
docs: clean up internal-doc exclusions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,10 @@ PySpark/pandas intuition. _(Developing fenic itself? See `CLAUDE.md`.)_
 
 Authored public documentation pages must be listed under `extra.llms.sections`
 in `mkdocs.yml`; generated API-reference pages are included automatically.
-When adding, renaming, or removing a docs page, update that list or explicitly
-mark the page `llms: false` and `noindex` if it is internal. Run
-`just docs-check` to validate the sitemap, metadata, Markdown alternatives, and
-LLM-facing assets before committing.
+When adding, renaming, or removing a docs page, update that list. Everything
+under `docs/` is public; put internal design and planning material under
+`specs/`. Run `just docs-check` to validate the sitemap, metadata, Markdown
+alternatives, and LLM-facing assets before committing.
 
 ## Full detail
 

--- a/docs/plans/.meta.yml
+++ b/docs/plans/.meta.yml
@@ -1,4 +1,0 @@
-llms: false
-robots: noindex, follow
-search:
-  exclude: true

--- a/docs/td-flow/.meta.yml
+++ b/docs/td-flow/.meta.yml
@@ -1,4 +1,0 @@
-llms: false
-robots: noindex, follow
-search:
-  exclude: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,8 +66,6 @@ nav:
   - API Reference
 not_in_nav: |
   /agents.md
-  /plans/
-  /td-flow/
 watch:
   - src/fenic/api
   - docs

--- a/scripts/validate_docs_site.py
+++ b/scripts/validate_docs_site.py
@@ -96,6 +96,8 @@ def main() -> None:
         _fail("sitemap.xml contains no URLs")
     if any(not url.startswith(_CANONICAL_ROOT) for url in urls):
         _fail("sitemap.xml contains a URL outside the canonical latest path")
+    # Everything under docs/ is public; guard against these internal trees
+    # being reintroduced instead of placing their content under specs/.
     if any("/plans/" in url or "/td-flow/" in url for url in urls):
         _fail("sitemap.xml contains internal planning documents")
 


### PR DESCRIPTION
## Summary

- remove the orphaned `docs/plans/.meta.yml` and `docs/td-flow/.meta.yml` files left after #336 moved internal artifacts into `specs/`
- remove the corresponding stale `not_in_nav` entries
- align `AGENTS.md` with the structural rule that everything under `docs/` is public and internal material belongs under `specs/`
- retain and document the sitemap regression guard against reintroducing the former internal paths

Follow-up to #335 and #336.

## Testing

- `trunk check AGENTS.md mkdocs.yml scripts/validate_docs_site.py`
- `GITHUB_ACTIONS=true DISABLE_MKDOCS_2_WARNING=true just docs-check`
- verified that neither `docs/plans/` nor `docs/td-flow/` remains

The generated docs validation covers 63 sitemap URLs, canonical metadata, Markdown alternatives, and LLM assets.
