### PR TITLE
fix(anthropic): force formatter with adaptive thinking

### DIFF
--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -180,8 +180,12 @@ class AnthropicBatchCompletionsClient(
         if request.structured_output:
             tool_param = self.create_response_format_tool(request.structured_output)
             messages_creation_payload.update({"tools": [tool_param]})
-            if not profile_configuration.thinking_enabled:
-                # Anthropic does not allow forced tool use if thinking is enabled.
+            if (
+                not profile_configuration.thinking_enabled
+                or profile_configuration.uses_adaptive_thinking
+            ):
+                # Forced tool choice is incompatible with manual extended thinking,
+                # but is supported with adaptive thinking.
                 messages_creation_payload.update(
                     {
                         "tool_choice": ToolChoiceToolParam(

--- a/tests/_inference/test_anthropic_profile_manager.py
+++ b/tests/_inference/test_anthropic_profile_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+from pydantic import BaseModel
 
 pytest.importorskip("anthropic")
 
@@ -16,31 +17,52 @@ from fenic.core._inference.model_catalog import ModelProvider, model_catalog
 from fenic.core._inference.output_token_limits import (
     ANTHROPIC_ADAPTIVE_THINKING_EFFORT_RATIOS,
 )
+from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
 from fenic.core._resolved_session_config import ResolvedAnthropicModelProfile
 from fenic.core.error import ValidationError
 
 
-def _make_anthropic_client(params, profiles, default_profile_name):
+class _StructuredResult(BaseModel):
+    answer: str
+
+
+def _make_anthropic_client(
+    params, profiles, default_profile_name, model_name="claude-opus-4-8"
+):
     client = AnthropicBatchCompletionsClient.__new__(AnthropicBatchCompletionsClient)
     client.model_provider = ModelProvider.ANTHROPIC
-    client.model = "claude-opus-4-8"
+    client.model = model_name
     client._model_parameters = params
     client._profile_manager = AnthropicCompletionsProfileManager(
         model_parameters=params,
         profile_configurations=profiles,
         default_profile_name=default_profile_name,
     )
+    client._output_formatter_tool_name = "output_formatter"
+    client._output_formatter_tool_description = "Format structured output."
     return client
 
 
-def _make_request(max_completion_tokens):
+def _make_request(max_completion_tokens, structured_output=None):
     return FenicCompletionsRequest(
         messages=LMRequestMessages(system="", examples=[], user="hello"),
         max_completion_tokens=max_completion_tokens,
         top_logprobs=None,
-        structured_output=None,
+        structured_output=structured_output,
         temperature=None,
     )
+
+
+def _capture_structured_output_payload(client, request, monkeypatch):
+    captured_payload = {}
+
+    async def capture(payload):
+        captured_payload.update(payload)
+        return None, None
+
+    monkeypatch.setattr(client, "_handle_structured_output_streaming_response", capture)
+    asyncio.run(client.make_single_request(request))
+    return captured_payload
 
 
 @pytest.mark.parametrize("model_name", ["claude-opus-4-8", "claude-opus-5"])
@@ -136,6 +158,61 @@ def test_manual_thinking_budget_profile_still_uses_budget_tokens():
     assert profile.thinking_config["type"] == "enabled"
     assert profile.thinking_config["budget_tokens"] == 2048
     assert profile.output_config == {"effort": "high"}
+
+
+def test_adaptive_thinking_structured_output_forces_formatter_tool(monkeypatch):
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-5"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "deep": ResolvedAnthropicModelProfile(effort="high"),
+        },
+        default_profile_name="deep",
+        model_name="claude-opus-5",
+    )
+    request = _make_request(
+        max_completion_tokens=512,
+        structured_output=ResolvedResponseFormat.from_pydantic_model(
+            _StructuredResult, generate_struct_type=False
+        ),
+    )
+
+    payload = _capture_structured_output_payload(client, request, monkeypatch)
+
+    assert payload["thinking"] == {"type": "adaptive"}
+    assert payload["output_config"] == {"effort": "high"}
+    assert payload["tool_choice"] == {
+        "name": "output_formatter",
+        "type": "tool",
+    }
+
+
+def test_manual_thinking_structured_output_does_not_force_formatter_tool(monkeypatch):
+    params = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, "claude-opus-4-5"
+    )
+    client = _make_anthropic_client(
+        params,
+        profiles={
+            "budget": ResolvedAnthropicModelProfile(thinking_token_budget=2048),
+        },
+        default_profile_name="budget",
+        model_name="claude-opus-4-5",
+    )
+    request = _make_request(
+        max_completion_tokens=512,
+        structured_output=ResolvedResponseFormat.from_pydantic_model(
+            _StructuredResult, generate_struct_type=False
+        ),
+    )
+
+    payload = _capture_structured_output_payload(client, request, monkeypatch)
+
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    assert "tools" in payload
+    assert "tool_choice" not in payload
 
 
 def test_adaptive_effort_profile_caps_request_limit_at_model_window():


### PR DESCRIPTION
## Summary

- force the structured-output formatter tool for adaptive-thinking Anthropic profiles, including Opus 5 effort profiles
- continue omitting forced tool choice for manual extended thinking, where Anthropic does not support it
- add payload-level regressions for both adaptive and manual thinking

## Context

Follow-up to #337. The client previously treated all thinking modes alike and omitted `tool_choice` whenever thinking was enabled. With adaptive thinking, automatic tool selection can return text instead of invoking the formatter; the structured-output stream handler then produces an empty completion that semantic operators can turn into null.

## Validation

- `uv run --extra anthropic pytest tests/_inference/test_anthropic_profile_manager.py -q` — 16 passed
- inference tests excluding the credential-dependent end-to-end cache file — 162 passed, 4 skipped
- Ruff, Trunk, pre-commit secret checks, and `git diff --check` passed