### PR TITLE
fix(openrouter): guarantee structured tool outputs

### DIFF
--- a/docs/topics/openrouter.md
+++ b/docs/topics/openrouter.md
@@ -71,17 +71,18 @@ OpenRouter profiles support the following configuration options:
 
 ## Structured outputs with OpenRouter
 
-OpenRouter exposes multiple ways to request structured outputs, but support varies by model/provider. Frontier models (Anthropic, OpenAI, Gemini) have consistent support for structured outputs and will generally perform the same
-as if one were using the provider's native client. Non-Frontier models can very wildly, depending on the size/quality of the model, the model's capabilities, and the quality of the provider's inference harness. When selecting a model for
-a _fenic_ use case involving structured outputs, consider using a frontier or other popular model family (LLama3/4, Mistral, etc.). The more esoteric the choice of model, the less guarunteed your results will be.
+OpenRouter exposes multiple ways to request structured outputs, but support varies by model and provider. Frontier models (Anthropic, OpenAI, Gemini) generally behave similarly to their native clients. Other models can vary widely depending on the model's capabilities and the provider's inference harness. For _fenic_ use cases involving structured outputs, prefer a frontier or another widely used model family (Llama 3/4, Mistral, etc.).
 
 1. **Pydantic Structured Outputs (via Response Format)** [Available when the target model lists `structured_outputs` in its `supported_parameters`]
    - This option is generally preferred, the JSON Schema corresponding to the provided Pydantic Model is sent to the model, which constrains its output to JSON and (in theory) coerces the response into the proper format.
 
-2. **Forced Tool Calling (w/JSON Schema)**
-   - If the model supports tool calling but not structured outputs, we achieve a similar result by asking the model to return a tool call with a specific json format for the input, which is derived from the provided Pydantic model.
+2. **Forced Tool Calling (with JSON Schema)** [Available when the target model lists both `tools` and `tool_choice` in its `supported_parameters`]
+   - If native structured outputs are unavailable, or the profile uses `structured_output_strategy="prefer_tools"`, _fenic_ registers an `output_formatter` tool whose arguments follow the Pydantic model's JSON Schema and explicitly forces the model to call that tool.
+   - Merely listing a tool is not sufficient: OpenRouter otherwise defaults `tool_choice` to `auto`, which allows the model to return ordinary text instead of the required structured result.
 
-If no providers for the model support either `structured_outputs` or `tools`, and a semantic operation that requires structured output (like `semantic.extract`) is used, _fenic_ will fail fast before starting to send requests.
+If the model does not support native `structured_outputs` or the combination of `tools` and `tool_choice`, and a semantic operation that requires structured output (such as `semantic.extract`) is used, _fenic_ fails fast before sending requests.
+
+Forced tool choice is incompatible with manual extended thinking on Anthropic models. Through OpenRouter, manual thinking includes profiles with `reasoning_max_tokens` and effort-based reasoning on older Claude models that do not support adaptive thinking. In those cases, _fenic_ uses native structured outputs when they are available; otherwise, it fails fast with configuration guidance. Adaptive thinking supports forced tool choice.
 
 ## Rate limiting
 

--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -34,20 +34,30 @@ from fenic._inference.types import (
     FenicCompletionsResponse,
     ResponseUsage,
 )
-from fenic.core._inference.model_catalog import ModelProvider, model_catalog
+from fenic.core._inference.model_catalog import (
+    CompletionModelParameters,
+    ModelProvider,
+    model_catalog,
+)
 from fenic.core._inference.output_token_limits import (
     OPENROUTER_REASONING_EFFORT_RATIOS,
     validate_effective_output_token_limit,
 )
 from fenic.core._resolved_session_config import ResolvedAdaptiveTokenEstimationConfig
-from fenic.core.error import ConfigurationError, ValidationError
+from fenic.core.error import ConfigurationError, ExecutionError, ValidationError
 from fenic.core.metrics import LMMetrics
 
 TOOLS = "tools"
 
+TOOL_CHOICE = "tool_choice"
+
 STRUCTURED_OUTPUTS = "structured_outputs"
 
 RESPONSE_FORMAT = "response_format"
+
+OUTPUT_FORMATTER_TOOL_NAME = "output_formatter"
+
+ANTHROPIC_STRUCTURED_OUTPUTS_BETA_HEADER = "structured-outputs-2025-11-13"
 logger = logging.getLogger(__name__)
 
 
@@ -137,46 +147,85 @@ class OpenRouterBatchChatCompletionsClient(
         if request.temperature and self._model_parameters.supports_custom_temperature:
             common_params.update({"temperature": request.temperature})
 
+        used_tools = False
         try:
             if request.structured_output:
-                strategy = (
-                    self._profile_manager.get_profile_by_name(request.model_profile).structured_output_strategy
-                    or "prefer_response_format"
-                )
+                strategy = profile.structured_output_strategy or "prefer_response_format"
                 supports_structured = STRUCTURED_OUTPUTS in self._model_parameters.supported_parameters
                 supports_tools = TOOLS in self._model_parameters.supported_parameters
-                if supports_structured and supports_tools:
+                supports_tool_choice = (
+                    TOOL_CHOICE in self._model_parameters.supported_parameters
+                )
+                can_force_tools = supports_tools and supports_tool_choice
+                uses_incompatible_manual_thinking = (
+                    self._uses_incompatible_anthropic_manual_thinking(profile)
+                )
+                can_use_tools = (
+                    can_force_tools and not uses_incompatible_manual_thinking
+                )
+
+                if supports_structured and can_use_tools:
                     use_tools = strategy == "prefer_tools"
                 else:
-                    use_tools = supports_tools and not supports_structured
+                    use_tools = can_use_tools and not supports_structured
+
+                if (
+                    strategy == "prefer_tools"
+                    and supports_structured
+                    and supports_tools
+                    and not can_use_tools
+                ):
+                    logger.debug(
+                        "Model %s cannot guarantee structured output with forced "
+                        "tool calling for the selected profile. Falling back to "
+                        "native structured outputs.",
+                        self.model,
+                    )
 
                 if supports_structured and not use_tools:
                     common_params[RESPONSE_FORMAT] = request.structured_output.pydantic_model
                     response = await self._aio_client.chat.completions.parse(
                         **common_params, extra_body=profile.extra_body
                     )
-                elif supports_tools:
-                    response_schema = request.structured_output.json_schema
+                elif can_use_tools:
+                    used_tools = True
+                    response_schema = dict(request.structured_output.json_schema)
                     response_schema["additionalProperties"] = False
                     common_params[TOOLS] = [
                         {
                             "type": "function",
                             "function": {
-                                "name": "output_formatter",
+                                "name": OUTPUT_FORMATTER_TOOL_NAME,
                                 "description": "Format the output of the model to correspond strictly to the provided schema.",
-                                "parameters": request.structured_output.json_schema,
+                                "parameters": response_schema,
                                 "strict": True,
                             },
                         }
                     ]
+                    common_params[TOOL_CHOICE] = {
+                        "type": "function",
+                        "function": {"name": OUTPUT_FORMATTER_TOOL_NAME},
+                    }
+                    request_options = {}
+                    if self._can_enable_anthropic_strict_tools(profile):
+                        request_options["extra_headers"] = {
+                            "x-anthropic-beta": (
+                                ANTHROPIC_STRUCTURED_OUTPUTS_BETA_HEADER
+                            )
+                        }
                     response = await self._aio_client.chat.completions.create(
-                        **common_params, extra_body=profile.extra_body
+                        **common_params,
+                        extra_body=profile.extra_body,
+                        **request_options,
                     )
                 else:
                     return FatalException(
-                        ConfigurationError(
-                            f"Model {self.model} does not support structured outputs, or tool calling, but the current "
-                            f"request requires an output format. Select a different model that supports `structured_outputs`, or `tools`"
+                        self._structured_output_configuration_error(
+                            supports_tools=supports_tools,
+                            supports_tool_choice=supports_tool_choice,
+                            uses_incompatible_manual_thinking=(
+                                uses_incompatible_manual_thinking
+                            ),
                         )
                     )
             else:
@@ -193,6 +242,7 @@ class OpenRouterBatchChatCompletionsClient(
             )
             if maybe_exception:
                 return maybe_exception
+
             usage = response.usage
             cached_input_tokens = (
                 usage.prompt_tokens_details.cached_tokens
@@ -235,11 +285,50 @@ class OpenRouterBatchChatCompletionsClient(
                     output_tokens=total_output_tokens,
                 )
 
-            # If we used tool calls to generate the structured output, retrieve the content from the function args.
-            if request.structured_output and completion_choice.message.tool_calls:
-                completion = completion_choice.message.tool_calls[0].function.arguments
+            if used_tools:
+                tool_calls = completion_choice.message.tool_calls or []
+                if len(tool_calls) != 1:
+                    return TransientException(
+                        ExecutionError(
+                            f"The completion model {self.model_provider}/{self.model} "
+                            f"returned {len(tool_calls)} tool calls for a structured "
+                            "output request; expected exactly one call to "
+                            f"{OUTPUT_FORMATTER_TOOL_NAME}."
+                        )
+                    )
+                tool_call = tool_calls[0]
+                tool_function = getattr(tool_call, "function", None)
+                if (
+                    getattr(tool_call, "type", None) != "function"
+                    or tool_function is None
+                ):
+                    return TransientException(
+                        ExecutionError(
+                            f"The completion model {self.model_provider}/{self.model} "
+                            f"returned a {getattr(tool_call, 'type', None)!r} tool "
+                            "call for a structured output request; expected a "
+                            f"function call to {OUTPUT_FORMATTER_TOOL_NAME!r}."
+                        )
+                    )
+                tool_name = getattr(tool_function, "name", None)
+                if tool_name != OUTPUT_FORMATTER_TOOL_NAME:
+                    return TransientException(
+                        ExecutionError(
+                            f"The completion model {self.model_provider}/{self.model} "
+                            f"called {tool_name!r} for a structured output "
+                            f"request; expected {OUTPUT_FORMATTER_TOOL_NAME!r}."
+                        )
+                    )
+                validated_output = (
+                    request.structured_output.pydantic_model.model_validate_json(
+                        getattr(tool_function, "arguments", None),
+                        strict=True,
+                    )
+                )
+                completion = validated_output.model_dump_json(by_alias=True)
             else:
                 completion = completion_choice.message.content
+
             return FenicCompletionsResponse(
                 completion=completion,
                 logprobs=completion_choice.logprobs,
@@ -260,6 +349,95 @@ class OpenRouterBatchChatCompletionsClient(
             return TransientException(e)
         except OpenAIError as e:
             return FatalException(e)
+
+    def _uses_incompatible_anthropic_manual_thinking(
+        self,
+        profile: OpenRouterCompletionProfileConfiguration,
+    ) -> bool:
+        """Return whether forced tools conflict with Anthropic manual thinking."""
+        anthropic_models = [
+            model
+            for model in [self.model, *(profile.models or [])]
+            if self._is_anthropic_model(model)
+        ]
+        if not anthropic_models:
+            return False
+        if profile.reasoning_max_tokens is not None:
+            return True
+        thinking_enabled = profile.reasoning_effort not in (None, "none")
+        if not thinking_enabled:
+            return False
+        for model in anthropic_models:
+            parameters = self._get_model_parameters(model)
+            if parameters is None or not parameters.uses_adaptive_thinking:
+                return True
+        return False
+
+    def _can_enable_anthropic_strict_tools(
+        self,
+        profile: OpenRouterCompletionProfileConfiguration,
+    ) -> bool:
+        """Return whether strict tools are supported by all Anthropic candidates."""
+        anthropic_models = [
+            model
+            for model in [self.model, *(profile.models or [])]
+            if self._is_anthropic_model(model)
+        ]
+        if not anthropic_models:
+            return False
+        for model in anthropic_models:
+            parameters = self._get_model_parameters(model)
+            if (
+                parameters is None
+                or STRUCTURED_OUTPUTS not in parameters.supported_parameters
+            ):
+                return False
+        return True
+
+    def _get_model_parameters(
+        self,
+        model: str,
+    ) -> Optional[CompletionModelParameters]:
+        """Return cached OpenRouter parameters for a primary or fallback model."""
+        if model == self.model:
+            return self._model_parameters
+        return model_catalog.get_completion_model_parameters(
+            ModelProvider.OPENROUTER,
+            model,
+        )
+
+    @staticmethod
+    def _is_anthropic_model(model: str) -> bool:
+        """Return whether an OpenRouter model ID targets Anthropic."""
+        return model.removeprefix("~").startswith("anthropic/")
+
+    def _structured_output_configuration_error(
+        self,
+        *,
+        supports_tools: bool,
+        supports_tool_choice: bool,
+        uses_incompatible_manual_thinking: bool,
+    ) -> ConfigurationError:
+        """Build an actionable error for an unavailable structured-output strategy."""
+        if supports_tools and not supports_tool_choice:
+            return ConfigurationError(
+                f"Model {self.model} supports tools but not `tool_choice`, so "
+                "fenic cannot force the formatter required for structured output. "
+                "Select a model that supports `structured_outputs`, or both `tools` "
+                "and `tool_choice`."
+            )
+        if supports_tools and uses_incompatible_manual_thinking:
+            return ConfigurationError(
+                f"Model {self.model} cannot combine forced tool calling with "
+                "Anthropic manual thinking for structured output. Disable reasoning "
+                "for this profile, use adaptive thinking, or select a model that "
+                "supports native `structured_outputs`."
+            )
+        return ConfigurationError(
+            f"Model {self.model} does not support a guaranteed structured-output "
+            "strategy. Select a model that supports `structured_outputs`, or both "
+            "`tools` and `tool_choice`."
+        )
 
     def estimate_tokens_for_request(
         self, request: FenicCompletionsRequest

--- a/src/fenic/_inference/openrouter/openrouter_provider.py
+++ b/src/fenic/_inference/openrouter/openrouter_provider.py
@@ -82,6 +82,10 @@ class OpenRouterModelProvider(ModelProviderClass):
     ) -> Optional[CompletionModelParameters]:
         pricing = model_obj.get("pricing") or {}
         top_provider = model_obj.get("top_provider") or {}
+        model_id = model_obj.get("id")
+        reasoning = model_obj.get("reasoning") or {}
+        if not isinstance(reasoning, dict):
+            reasoning = {}
 
         try:
             input_cost = float(pricing.get("prompt", 0.0))
@@ -116,6 +120,14 @@ class OpenRouterModelProvider(ModelProviderClass):
         )
         supports_custom_temperature = "temperature" in supported_params
         supports_verbosity = "verbosity" in supported_params
+        uses_adaptive_thinking = (
+            isinstance(model_id, str)
+            and model_id.removeprefix("~").startswith("anthropic/")
+            and bool(reasoning.get("supported_efforts"))
+        )
+        requires_adaptive_thinking = (
+            uses_adaptive_thinking and reasoning.get("mandatory") is True
+        )
 
         return CompletionModelParameters(
             input_token_cost=input_cost,
@@ -125,6 +137,8 @@ class OpenRouterModelProvider(ModelProviderClass):
             cached_input_token_read_cost=cached_read_cost,
             supports_profiles=True,
             supports_reasoning=supports_reasoning,
+            uses_adaptive_thinking=uses_adaptive_thinking,
+            requires_adaptive_thinking=requires_adaptive_thinking,
             supports_custom_temperature=supports_custom_temperature,
             supports_verbosity=supports_verbosity,
             supports_pdf_parsing=True, # Even if the model doesn't support pdf file processing, OpenRouter can use its separate processing engines

--- a/tests/_inference/test_model_catalog.py
+++ b/tests/_inference/test_model_catalog.py
@@ -70,7 +70,7 @@ def mock_openrouter_models(monkeypatch):
                 "context_length": 128_000,
                 "max_completion_tokens": 16_384,
             },
-            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty", "stop", "logit_bias", "seed", "logprobs", "top_logprobs", "response_format", "structured_output"],
+            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty", "stop", "logit_bias", "seed", "logprobs", "top_logprobs", "response_format", "structured_outputs"],
         },
         {
             "id": "openai/gpt-5",
@@ -83,7 +83,7 @@ def mock_openrouter_models(monkeypatch):
                 "max_completion_tokens": 128_000,
             },
             # Include reasoning/verbosity but omit temperature to match base flags
-            "supported_parameters": ["tools", "tool_choice", "max_tokens", "response_format", "structured_output", "reasoning", "verbosity"],
+            "supported_parameters": ["tools", "tool_choice", "max_tokens", "response_format", "structured_outputs", "reasoning", "verbosity"],
         },
         {
             "id": "anthropic/claude-sonnet-4",
@@ -108,7 +108,7 @@ def mock_openrouter_models(monkeypatch):
                 "context_length": 1_048_576,
                 "max_completion_tokens": 65_536,
             },
-            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "stop", "seed", "logprobs", "top_logprobs", "response_format", "structured_output", "reasoning"],
+            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "stop", "seed", "logprobs", "top_logprobs", "response_format", "structured_outputs", "reasoning"],
         },
         {
             "id": "google/gemini-2.5-pro",
@@ -120,7 +120,7 @@ def mock_openrouter_models(monkeypatch):
                 "context_length": 1_048_576,
                 "max_completion_tokens": 65_536,
             },
-            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "stop", "seed", "logprobs", "top_logprobs", "response_format", "structured_output", "reasoning"],
+            "supported_parameters": ["tools", "tool_choice", "max_tokens", "temperature", "top_p", "stop", "seed", "logprobs", "top_logprobs", "response_format", "structured_outputs", "reasoning"],
         },
     ]
 

--- a/tests/_inference/test_openrouter_structured_output.py
+++ b/tests/_inference/test_openrouter_structured_output.py
@@ -1,0 +1,551 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from fenic._inference.model_client import FatalException, TransientException
+from fenic._inference.openrouter.openrouter_batch_chat_completions_client import (
+    ANTHROPIC_STRUCTURED_OUTPUTS_BETA_HEADER,
+    OpenRouterBatchChatCompletionsClient,
+)
+from fenic._inference.openrouter.openrouter_profile_manager import (
+    OpenRouterCompletionsProfileManager,
+)
+from fenic._inference.openrouter.openrouter_provider import OpenRouterModelProvider
+from fenic._inference.types import FenicCompletionsRequest, LMRequestMessages
+from fenic.core._inference.model_catalog import (
+    CompletionModelParameters,
+    ModelProvider,
+    model_catalog,
+)
+from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
+from fenic.core._resolved_session_config import ResolvedOpenRouterModelProfile
+from fenic.core.metrics import LMMetrics
+
+
+class _Answer(BaseModel):
+    answer: bool
+
+
+class _FakeCompletions:
+    def __init__(self, response):
+        self.response = response
+        self.create_calls = []
+        self.parse_calls = []
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return self.response
+
+    async def parse(self, **kwargs):
+        self.parse_calls.append(kwargs)
+        return self.response
+
+
+def _tool_call(
+    arguments: str = '{"answer":true}',
+    *,
+    name: str = "output_formatter",
+):
+    return SimpleNamespace(
+        id="call-1",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _custom_tool_call():
+    return SimpleNamespace(
+        id="call-1",
+        type="custom",
+        custom=SimpleNamespace(name="output_formatter", input="{}"),
+    )
+
+
+def _response(*, content=None, tool_calls=None):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    refusal=None,
+                    tool_calls=tool_calls,
+                ),
+                finish_reason="tool_calls" if tool_calls else "stop",
+                logprobs=None,
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=2,
+            prompt_tokens_details=None,
+            completion_tokens=1,
+            completion_tokens_details=None,
+            model_extra={"cost": 0.0},
+        ),
+    )
+
+
+def _request(*, profile=None):
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="system", examples=[], user="question"),
+        max_completion_tokens=64,
+        top_logprobs=None,
+        structured_output=ResolvedResponseFormat.from_pydantic_model(_Answer),
+        temperature=None,
+        model_profile=profile,
+    )
+
+
+def _client(
+    supported_parameters,
+    response,
+    *,
+    model="test/model",
+    prefer_tools=False,
+    reasoning_effort=None,
+    reasoning_max_tokens=None,
+    uses_adaptive_thinking=False,
+    max_output_tokens=256,
+):
+    parameters = CompletionModelParameters(
+        input_token_cost=0.0,
+        output_token_cost=0.0,
+        context_window_length=8_192,
+        max_output_tokens=max_output_tokens,
+        supports_reasoning="reasoning" in supported_parameters,
+        uses_adaptive_thinking=uses_adaptive_thinking,
+        supported_parameters=set(supported_parameters),
+    )
+    profiles = None
+    default_profile_name = None
+    if (
+        prefer_tools
+        or reasoning_effort is not None
+        or reasoning_max_tokens is not None
+    ):
+        profiles = {
+            "tools": ResolvedOpenRouterModelProfile(
+                structured_output_strategy=(
+                    "prefer_tools" if prefer_tools else None
+                ),
+                reasoning_effort=reasoning_effort,
+                reasoning_max_tokens=reasoning_max_tokens,
+            )
+        }
+        default_profile_name = "tools"
+
+    completions = _FakeCompletions(response)
+    client = OpenRouterBatchChatCompletionsClient.__new__(
+        OpenRouterBatchChatCompletionsClient
+    )
+    client.model = model
+    client.model_provider = ModelProvider.OPENROUTER
+    client.model_provider_class = SimpleNamespace(_base_url=None)
+    client._model_parameters = parameters
+    client._profile_manager = OpenRouterCompletionsProfileManager(
+        model_parameters=parameters,
+        profile_configurations=profiles,
+        default_profile_name=default_profile_name,
+    )
+    client._aio_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=completions)
+    )
+    client._metrics = LMMetrics()
+    return client, completions
+
+
+def test_native_response_format_is_the_default_when_both_strategies_are_supported():
+    client, completions = _client(
+        {"structured_outputs", "tools", "tool_choice"},
+        _response(content='{"answer":true}'),
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert result.completion == '{"answer":true}'
+    assert not completions.create_calls
+    assert len(completions.parse_calls) == 1
+    payload = completions.parse_calls[0]
+    assert payload["response_format"] is _Answer
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+@pytest.mark.parametrize(
+    ("supported_parameters", "prefer_tools"),
+    [
+        ({"tools", "tool_choice"}, False),
+        ({"structured_outputs", "tools", "tool_choice"}, True),
+    ],
+    ids=["tools-only-model", "prefer-tools-profile"],
+)
+def test_tool_strategy_forces_the_named_formatter(
+    supported_parameters, prefer_tools
+):
+    client, completions = _client(
+        supported_parameters,
+        _response(tool_calls=[_tool_call()]),
+        prefer_tools=prefer_tools,
+    )
+
+    result = asyncio.run(
+        client.make_single_request(
+            _request(profile="tools" if prefer_tools else None)
+        )
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert not completions.parse_calls
+    assert len(completions.create_calls) == 1
+    payload = completions.create_calls[0]
+    assert payload["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "output_formatter"},
+    }
+    assert "parallel_tool_calls" not in payload
+    assert "extra_headers" not in payload
+    assert payload["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "output_formatter",
+                "description": (
+                    "Format the output of the model to correspond strictly to "
+                    "the provided schema."
+                ),
+                "parameters": _Answer.model_json_schema()
+                | {"additionalProperties": False},
+                "strict": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "tool_calls",
+    [
+        None,
+        [],
+        [_tool_call(name="some_other_tool")],
+        [_tool_call(), _tool_call()],
+        [_custom_tool_call()],
+        [_tool_call(arguments="not json")],
+        [_tool_call(arguments='{"answer":"true"}')],
+    ],
+    ids=[
+        "missing-tool-calls",
+        "empty-tool-calls",
+        "wrong-tool",
+        "multiple-tool-calls",
+        "custom-tool-call",
+        "malformed-json",
+        "schema-invalid-arguments",
+    ],
+)
+def test_malformed_formatter_response_is_transient(tool_calls):
+    client, completions = _client(
+        {"tools", "tool_choice"},
+        _response(content="unstructured fallback", tool_calls=tool_calls),
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert isinstance(result, TransientException)
+    assert len(completions.create_calls) == 1
+    assert client.get_metrics().num_requests == 1
+
+
+def test_tool_only_model_without_tool_choice_is_rejected_before_dispatch():
+    client, completions = _client(
+        {"tools"},
+        _response(tool_calls=[_tool_call()]),
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert isinstance(result, FatalException)
+    assert "tool_choice" in str(result.exception)
+    assert not completions.create_calls
+    assert not completions.parse_calls
+
+
+def test_prefer_tools_falls_back_to_native_when_tool_choice_is_unavailable():
+    client, completions = _client(
+        {"structured_outputs", "tools"},
+        _response(content='{"answer":true}'),
+        prefer_tools=True,
+    )
+
+    result = asyncio.run(
+        client.make_single_request(_request(profile="tools"))
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert not completions.create_calls
+    assert len(completions.parse_calls) == 1
+
+
+def test_anthropic_tool_strategy_enables_strict_tool_beta():
+    client, completions = _client(
+        {"structured_outputs", "tools", "tool_choice", "reasoning"},
+        _response(tool_calls=[_tool_call()]),
+        model="anthropic/claude-opus-5",
+        prefer_tools=True,
+        uses_adaptive_thinking=True,
+    )
+
+    result = asyncio.run(
+        client.make_single_request(_request(profile="tools"))
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert completions.create_calls[0]["extra_headers"] == {
+        "x-anthropic-beta": ANTHROPIC_STRUCTURED_OUTPUTS_BETA_HEADER
+    }
+
+
+def test_anthropic_fallback_model_enables_strict_tool_beta():
+    adaptive_fallback = "anthropic/test-adaptive-strict-fallback"
+    model_catalog.add_model(
+        ModelProvider.OPENROUTER,
+        adaptive_fallback,
+        CompletionModelParameters(
+            input_token_cost=0.0,
+            output_token_cost=0.0,
+            context_window_length=8_192,
+            max_output_tokens=256,
+            supports_reasoning=True,
+            uses_adaptive_thinking=True,
+            supported_parameters={
+                "structured_outputs",
+                "tools",
+                "tool_choice",
+                "reasoning",
+            },
+        ),
+    )
+    parameters = {"structured_outputs", "tools", "tool_choice"}
+    client, completions = _client(
+        parameters,
+        _response(tool_calls=[_tool_call()]),
+        prefer_tools=True,
+    )
+    client._profile_manager = OpenRouterCompletionsProfileManager(
+        model_parameters=client._model_parameters,
+        profile_configurations={
+            "fallback": ResolvedOpenRouterModelProfile(
+                models=[adaptive_fallback],
+                structured_output_strategy="prefer_tools",
+            )
+        },
+        default_profile_name="fallback",
+    )
+
+    result = asyncio.run(client.make_single_request(_request(profile="fallback")))
+
+    assert result.completion == '{"answer":true}'
+    assert completions.create_calls[0]["extra_headers"] == {
+        "x-anthropic-beta": ANTHROPIC_STRUCTURED_OUTPUTS_BETA_HEADER
+    }
+
+
+def test_unsupported_anthropic_fallback_does_not_enable_strict_tool_beta():
+    old_fallback = "anthropic/test-no-strict-tool-fallback"
+    model_catalog.add_model(
+        ModelProvider.OPENROUTER,
+        old_fallback,
+        CompletionModelParameters(
+            input_token_cost=0.0,
+            output_token_cost=0.0,
+            context_window_length=8_192,
+            max_output_tokens=256,
+            supported_parameters={"tools", "tool_choice"},
+        ),
+    )
+    client, completions = _client(
+        {"structured_outputs", "tools", "tool_choice"},
+        _response(tool_calls=[_tool_call()]),
+    )
+    client._profile_manager = OpenRouterCompletionsProfileManager(
+        model_parameters=client._model_parameters,
+        profile_configurations={
+            "fallback": ResolvedOpenRouterModelProfile(
+                models=[old_fallback],
+                structured_output_strategy="prefer_tools",
+            )
+        },
+        default_profile_name="fallback",
+    )
+
+    result = asyncio.run(client.make_single_request(_request(profile="fallback")))
+
+    assert result.completion == '{"answer":true}'
+    assert "extra_headers" not in completions.create_calls[0]
+
+
+def test_anthropic_manual_thinking_uses_native_structured_output_when_available():
+    client, completions = _client(
+        {"structured_outputs", "tools", "tool_choice", "reasoning"},
+        _response(content='{"answer":true}'),
+        model="anthropic/claude-sonnet-4",
+        prefer_tools=True,
+    )
+
+    result = asyncio.run(
+        client.make_single_request(_request(profile="tools"))
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert not completions.create_calls
+    assert len(completions.parse_calls) == 1
+
+
+def test_anthropic_manual_thinking_without_native_output_is_rejected():
+    client, completions = _client(
+        {"tools", "tool_choice", "reasoning"},
+        _response(tool_calls=[_tool_call()]),
+        model="anthropic/claude-sonnet-4",
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert isinstance(result, FatalException)
+    assert "manual thinking" in str(result.exception)
+    assert not completions.create_calls
+    assert not completions.parse_calls
+
+
+def test_anthropic_adaptive_thinking_can_force_formatter():
+    client, completions = _client(
+        {"tools", "tool_choice", "reasoning"},
+        _response(tool_calls=[_tool_call()]),
+        model="anthropic/claude-opus-5",
+        uses_adaptive_thinking=True,
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert result.completion == '{"answer":true}'
+    assert len(completions.create_calls) == 1
+
+
+def test_anthropic_reasoning_budget_uses_native_output_on_adaptive_model():
+    client, completions = _client(
+        {"structured_outputs", "tools", "tool_choice", "reasoning"},
+        _response(content='{"answer":true}'),
+        model="anthropic/claude-opus-4.6",
+        prefer_tools=True,
+        reasoning_max_tokens=1_024,
+        uses_adaptive_thinking=True,
+        max_output_tokens=4_096,
+    )
+
+    result = asyncio.run(
+        client.make_single_request(_request(profile="tools"))
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert not completions.create_calls
+    assert len(completions.parse_calls) == 1
+
+
+def test_anthropic_manual_thinking_fallback_prevents_forced_formatter():
+    old_fallback = "anthropic/test-manual-thinking-fallback"
+    model_catalog.add_model(
+        ModelProvider.OPENROUTER,
+        old_fallback,
+        CompletionModelParameters(
+            input_token_cost=0.0,
+            output_token_cost=0.0,
+            context_window_length=8_192,
+            max_output_tokens=256,
+            supports_reasoning=True,
+            uses_adaptive_thinking=False,
+            supported_parameters={"tools", "tool_choice", "reasoning"},
+        ),
+    )
+    client, completions = _client(
+        {"tools", "tool_choice", "reasoning"},
+        _response(tool_calls=[_tool_call()]),
+        model="anthropic/test-adaptive-primary",
+        uses_adaptive_thinking=True,
+    )
+    client._profile_manager = OpenRouterCompletionsProfileManager(
+        model_parameters=client._model_parameters,
+        profile_configurations={
+            "fallback": ResolvedOpenRouterModelProfile(models=[old_fallback])
+        },
+        default_profile_name="fallback",
+    )
+
+    result = asyncio.run(client.make_single_request(_request(profile="fallback")))
+
+    assert isinstance(result, FatalException)
+    assert "manual thinking" in str(result.exception)
+    assert not completions.create_calls
+
+
+def test_disabling_reasoning_allows_forced_formatter_on_older_anthropic_model():
+    client, completions = _client(
+        {"tools", "tool_choice", "reasoning"},
+        _response(tool_calls=[_tool_call()]),
+        model="anthropic/claude-sonnet-4",
+        reasoning_effort="none",
+    )
+
+    result = asyncio.run(
+        client.make_single_request(_request(profile="tools"))
+    )
+
+    assert result.completion == '{"answer":true}'
+    assert len(completions.create_calls) == 1
+    assert "extra_headers" not in completions.create_calls[0]
+
+
+@pytest.mark.parametrize(
+    (
+        "model_id",
+        "reasoning",
+        "uses_adaptive_thinking",
+        "requires_adaptive_thinking",
+    ),
+    [
+        (
+            "anthropic/test-model",
+            {
+                "supported_efforts": ["high", "medium", "low"],
+                "mandatory": True,
+            },
+            True,
+            True,
+        ),
+        (
+            "~anthropic/test-model",
+            {"supported_efforts": ["high", "medium", "low"]},
+            True,
+            False,
+        ),
+        ("anthropic/test-model", {"mandatory": False}, False, False),
+        ("anthropic/test-model", "malformed", False, False),
+    ],
+)
+def test_openrouter_translates_anthropic_thinking_mode(
+    model_id,
+    reasoning,
+    uses_adaptive_thinking,
+    requires_adaptive_thinking,
+):
+    parameters = OpenRouterModelProvider()._translate_model(
+        {
+            "id": model_id,
+            "pricing": {"prompt": "0", "completion": "0"},
+            "context_length": 1_024,
+            "top_provider": {"max_completion_tokens": 256},
+            "supported_parameters": ["reasoning"],
+            "reasoning": reasoning,
+        }
+    )
+
+    assert parameters.uses_adaptive_thinking is uses_adaptive_thinking
+    assert parameters.requires_adaptive_thinking is requires_adaptive_thinking


### PR DESCRIPTION
## Summary

- Require `tool_choice` and force the named formatter when OpenRouter uses tool-based structured output.
- Strictly validate and canonicalize formatter arguments, retry malformed responses, and fail fast when no guaranteed structured-output strategy exists.
- Distinguish Anthropic manual and adaptive thinking, and enable strict tool schemas only when every Anthropic candidate advertises support.
- Document the behavior and add payload-, response-, fallback-, and model-metadata regression coverage.

## Why

OpenRouter defaults unforced tool selection to `auto`. A model could therefore return ordinary text instead of calling the formatter, allowing invalid structured results to reach downstream semantic operators as nulls. This is independent of #342, which fixes the native Anthropic client.

## Validation

- `uv run pytest -q tests/_inference/test_openrouter_structured_output.py tests/_inference/test_model_catalog.py` — 39 passed
- `uv run pytest -q tests/_inference --ignore=tests/_inference/cache/test_cache_end_to_end_semantic.py` — 165 passed, 8 skipped
- `just docs-check`
- `trunk check` on all changed files
- `uv lock --check`
- `git diff --check`

The ignored cache file contains two end-to-end tests that require `OPENAI_API_KEY`; the unfiltered inference run failed only during setup of those two tests because no key is configured.