### PR TITLE
chore(mcp): repair release deployment environment

### DIFF
--- a/.github/workflows/check_docs_mcp.yaml
+++ b/.github/workflows/check_docs_mcp.yaml
@@ -37,9 +37,18 @@ jobs:
           cache-dependency-glob: services/docs-mcp/uv.lock
       - name: install service
         run: uv sync --group dev
+      - name: verify exact release environment selection
+        run: |
+          fenic_version="$(
+            uv run --no-project python -c \
+              'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("../../pyproject.toml").read_text())["project"]["version"])'
+          )"
+          uv pip install --python .venv/bin/python "fenic[mcp]==${fenic_version}"
+          uv run --no-sync python -c \
+            "from fenic_mcp.release import assert_installed_fenic_version; assert_installed_fenic_version('${fenic_version}')"
       - name: test native MCP tools
-        run: uv run pytest
+        run: uv run --no-sync pytest
       - name: statically check Fenic pipelines
         run: |
-          uv run fenic check src/fenic_mcp/setup/populate_tables.py
-          uv run fenic check src/fenic_mcp/server/native.py
+          uv run --no-sync fenic check src/fenic_mcp/setup/populate_tables.py
+          uv run --no-sync fenic check src/fenic_mcp/server/native.py

--- a/.github/workflows/deploy_docs_mcp.yaml
+++ b/.github/workflows/deploy_docs_mcp.yaml
@@ -7,7 +7,13 @@ on:
         description: Fenic release version, with or without a v prefix
         required: true
         type: string
+  # checkov:skip=CKV_GHA_7:Validated version input selects an immutable PyPI release.
   workflow_dispatch:
+    inputs:
+      fenic_version:
+        description: Fenic release version, with or without a v prefix
+        required: true
+        type: string
 
 concurrency:
   group: docs-mcp-production
@@ -39,7 +45,6 @@ jobs:
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6
         with:
           python-version: "3.11"
-          activate-environment: true
           enable-cache: true
           cache-dependency-glob: services/docs-mcp/uv.lock
       - name: validate release input
@@ -70,7 +75,7 @@ jobs:
       - name: install service with exact Fenic release
         run: |
           uv sync --extra hf --group dev
-          uv pip install "fenic[mcp]==${FENIC_VERSION}"
+          uv pip install --python .venv/bin/python "fenic[mcp]==${FENIC_VERSION}"
           uv run --no-sync python -c \
             "from fenic_mcp.release import assert_installed_fenic_version; assert_installed_fenic_version('${FENIC_VERSION}')"
       - name: export release documentation to Hugging Face

--- a/services/docs-mcp/README.md
+++ b/services/docs-mcp/README.md
@@ -36,9 +36,9 @@ environment gates the workflow. It exports and verifies the versioned Hugging
 Face dataset, tests the native MCP contract, prepares the Modal volume, deploys
 an image pinned to `fenic[mcp]==$FENIC_VERSION`, and probes the public endpoint.
 
-The workflow is also manually dispatchable for safe reruns. Select the release
-tag in GitHub's **Run workflow** branch selector; the version is derived from
-that tag, and existing Hugging Face artifacts are verified and reused.
+The workflow is also manually dispatchable for safe reruns. Select `main` in
+GitHub's **Run workflow** branch selector and enter the release version.
+Existing Hugging Face artifacts are verified and reused.
 
 Configure these secrets on the GitHub `production` environment:
 

--- a/services/docs-mcp/pyproject.toml
+++ b/services/docs-mcp/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP documentation server for Fenic"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "griffe>=0.42.0",
+  "griffelib>=2.1.0",
   "fenic[mcp]>=0.10.0",
   "structlog>=24.1.0",
   "modal>=1.1.1",

--- a/services/docs-mcp/src/fenic_mcp/modal_setup.py
+++ b/services/docs-mcp/src/fenic_mcp/modal_setup.py
@@ -20,7 +20,7 @@ def _fenic_requirement() -> str:
 image = (
     modal.Image.debian_slim()
     .pip_install(
-        "griffe>=0.42.0",
+        "griffelib>=2.1.0",
         _fenic_requirement(),
         "structlog>=24.1.0",
         "modal>=1.1.1",

--- a/services/docs-mcp/uv.lock
+++ b/services/docs-mcp/uv.lock
@@ -1028,7 +1028,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fenic", extra = ["mcp"] },
-    { name = "griffe" },
+    { name = "griffelib" },
     { name = "modal" },
     { name = "structlog" },
 ]
@@ -1052,7 +1052,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fenic", extras = ["mcp"], specifier = ">=0.10.0" },
-    { name = "griffe", specifier = ">=0.42.0" },
+    { name = "griffelib", specifier = ">=2.1.0" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.20.0" },
     { name = "modal", specifier = ">=1.1.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
@@ -1205,32 +1205,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
-]
-
-[[package]]
-name = "griffe"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffecli" },
-    { name = "griffelib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/44/63913c007814cab5ba9d36f25ad40dfc640c2e2931d195bd2d05f774a5d6/griffe-2.1.0.tar.gz", hash = "sha256:c58845df5a364feaabd05ee8c767b97b03e478da8aa18b9923553c812fb0d955", size = 244879, upload-time = "2026-06-19T12:05:41.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/fb/3c65d392feae6c36dc2b55a14dd8270b7b35a3171c93b71a4d2ee4abf241/griffe-2.1.0-py3-none-any.whl", hash = "sha256:2ccdab17fb9cd76f278d7b5611cfc8f68cbe846d8d48df63dff80b62ecfa6f65", size = 5140, upload-time = "2026-06-19T12:05:39.913Z" },
-]
-
-[[package]]
-name = "griffecli"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-    { name = "griffelib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/c6/90f85d47af96300d629b38c25b71aad9467a620cac964a39280e822efc8a/griffecli-2.1.0.tar.gz", hash = "sha256:2ff68dbee9395fdb668b10374c51683392d697b226ac60159798f4add1ee716c", size = 56913, upload-time = "2026-06-19T12:05:43.119Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/2f/513232ec1d5f5da182e4ce45a11427e37dd210844a9e2bca451fc9661fb3/griffecli-2.1.0-py3-none-any.whl", hash = "sha256:6e22b1423d562ddc510997b4be1fe89de59e19dcff78831c0f4bfc3b8134a718", size = 9500, upload-time = "2026-06-19T12:05:37.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Docs MCP releases now install and validate the requested Fenic wheel in the same service environment used for extraction, testing, and deployment. This prevents the release lockfile from silently restoring an older Fenic version.

The PR check reproduces the exact-version override before running the native MCP contract. Manual runs now accept a validated release version, allowing the corrected workflow on `main` to redeploy an existing release without publishing a new Fenic wheel. The service also uses Griffe's library-only `griffelib` distribution, avoiding the CLI-package collision exposed by the corrected release environment.

Failed release run: https://github.com/typedef-ai/fenic/actions/runs/30489017600/job/90705275331

## Validation

- Reproduced the original mismatched `VIRTUAL_ENV` conditions and verified the service environment reports Fenic 0.12.0.
- `uv run --no-sync pytest`: 7 passed.
- Both docs MCP Fenic static checks completed successfully.
- `trunk check --fix`: no issues.
- Pre-PR correctness, standards, testing-fidelity, and adversarial workflow review found no actionable issues.

## Post-Deploy Monitoring & Validation

- Rerun the v0.12.0 `build and release` workflow and confirm `install service with exact Fenic release` reports 0.12.0.
- Confirm Hugging Face export verification, Modal preparation/deployment, and the production endpoint probe all complete successfully.
- Watch the deployment logs for `Expected fenic`, `ImportError`, `griffe`, or `griffelib`.
- Healthy signal: `https://mcp.fenic.ai/` passes the MCP probe and tool discovery after deployment.
- Roll back or stop the deployment if the installed version differs from the tag, Griffe imports fail, or the endpoint probe fails.
- Validation window: the rerun and first 30 minutes after deployment; owner: release operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
