### PR TITLE
chore(mcp): tolerate Modal rollout propagation

### DIFF
--- a/services/docs-mcp/src/fenic_mcp/verify_deployment.py
+++ b/services/docs-mcp/src/fenic_mcp/verify_deployment.py
@@ -2,8 +2,11 @@
 
 import argparse
 import asyncio
+import logging
 
 from fastmcp import Client
+
+logger = logging.getLogger(__name__)
 
 EXPECTED_TOOLS = {
     "get_api_tree",
@@ -14,7 +17,7 @@ EXPECTED_TOOLS = {
 }
 
 
-async def verify_deployment(url: str) -> None:
+async def _verify_once(url: str) -> None:
     """Verify discovery, search, and representative entity lookup."""
     async with Client(url) as client:
         tools = await client.list_tools()
@@ -48,12 +51,48 @@ async def verify_deployment(url: str) -> None:
             raise RuntimeError(f"Entity lookup failed for {qualified_name}")
 
 
+async def verify_deployment(
+    url: str,
+    *,
+    attempts: int = 12,
+    retry_delay_seconds: float = 5,
+) -> None:
+    """Verify a deployment, allowing time for the new Modal revision to propagate."""
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            await _verify_once(url)
+            return
+        except Exception:
+            if attempt == attempts:
+                raise
+            logger.warning(
+                "Deployment verification failed (attempt %d/%d); retrying in %.1fs",
+                attempt,
+                attempts,
+                retry_delay_seconds,
+                exc_info=True,
+            )
+            await asyncio.sleep(retry_delay_seconds)
+
+
 def main() -> None:
     """Run the production MCP verification probe."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", default="https://mcp.fenic.ai/")
+    parser.add_argument("--attempts", type=int, default=12)
+    parser.add_argument("--retry-delay-seconds", type=float, default=5)
     args = parser.parse_args()
-    asyncio.run(verify_deployment(args.url))
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(
+        verify_deployment(
+            args.url,
+            attempts=args.attempts,
+            retry_delay_seconds=args.retry_delay_seconds,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/services/docs-mcp/tests/test_verify_deployment.py
+++ b/services/docs-mcp/tests/test_verify_deployment.py
@@ -1,0 +1,57 @@
+"""Tests for the production deployment probe."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fenic_mcp import verify_deployment
+
+
+@pytest.mark.asyncio
+async def test_verify_deployment_retries_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale Modal revision is retried before the probe succeeds."""
+    verify_once = AsyncMock(side_effect=[RuntimeError("old revision"), None])
+    sleep = AsyncMock()
+    monkeypatch.setattr(verify_deployment, "_verify_once", verify_once)
+    monkeypatch.setattr(verify_deployment.asyncio, "sleep", sleep)
+
+    await verify_deployment.verify_deployment(
+        "https://mcp.fenic.ai/",
+        attempts=2,
+        retry_delay_seconds=5,
+    )
+
+    assert verify_once.await_count == 2  # nosec B101
+    sleep.assert_awaited_once_with(5)
+
+
+@pytest.mark.asyncio
+async def test_verify_deployment_raises_final_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final verification failure is reported after retries are exhausted."""
+    verify_once = AsyncMock(side_effect=RuntimeError("old revision"))
+    sleep = AsyncMock()
+    monkeypatch.setattr(verify_deployment, "_verify_once", verify_once)
+    monkeypatch.setattr(verify_deployment.asyncio, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="old revision"):
+        await verify_deployment.verify_deployment(
+            "https://mcp.fenic.ai/",
+            attempts=2,
+            retry_delay_seconds=0,
+        )
+
+    assert verify_once.await_count == 2  # nosec B101
+    sleep.assert_awaited_once_with(0)
+
+
+@pytest.mark.asyncio
+async def test_verify_deployment_rejects_zero_attempts() -> None:
+    """At least one deployment verification attempt is required."""
+    with pytest.raises(ValueError, match="attempts must be at least 1"):
+        await verify_deployment.verify_deployment(
+            "https://mcp.fenic.ai/",
+            attempts=0,
+        )


### PR DESCRIPTION
## Summary
- retry the production MCP verification while a new Modal revision propagates
- reconnect and repeat the complete contract, search, and entity checks on every attempt
- cover transient success, terminal failure, and invalid retry configuration

## Validation
- `trunk check --fix services/docs-mcp/src/fenic_mcp/verify_deployment.py services/docs-mcp/tests/test_verify_deployment.py`
- `uv run --project services/docs-mcp --no-sync pytest services/docs-mcp/tests/test_verify_deployment.py services/docs-mcp/tests/test_native_server.py`
- live production verification against `https://mcp.fenic.ai/`