### PR TITLE
ci: support package size tests on Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Issues = "https://github.com/typedef-ai/fenic/issues"
 [dependency-groups]
 dev = [
   "pytest>=8.3.5",
+  "tomli>=2.0.0; python_version < '3.11'",
   "maturin>=1.8.6",
   "requests>=2.32.0",
   "ipykernel>=6.29.0",

--- a/tools/package_size_matrix.py
+++ b/tools/package_size_matrix.py
@@ -20,7 +20,10 @@ from dataclasses import asdict, dataclass
 from importlib import metadata
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 DEFAULT_COMBOS = [
     "core",

--- a/uv.lock
+++ b/uv.lock
@@ -843,6 +843,7 @@ dev = [
     { name = "requests" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 docs = [
     { name = "beautifulsoup4" },
@@ -898,6 +899,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 docs = [
     { name = "beautifulsoup4", specifier = ">=4.14.0" },


### PR DESCRIPTION
## Summary

Python 3.10 local test jobs can load the package-size harness again. The harness now uses the `tomli` backport when the standard-library `tomllib` module is unavailable, with the backport declared only for Python versions below 3.11.

## Validation

- All three package-size tests passed in an isolated Python 3.10 environment.
- Ruff lint and `git diff --check` passed.
- The repository commit hooks passed.
- A full local test invocation was blocked before pytest by an unrelated local Rust compiler incompatibility.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
