### PR TITLE
[experiment] execution engine: memory-bounded + incremental (stacked branches, do not review)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94.1"

--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -33,6 +33,11 @@ from fenic._inference.rate_limit_strategy import (
     RateLimitStrategy,
     TokenEstimate,
 )
+from fenic._inference.request_lifecycle import (
+    RequestLifecycleCollector,
+    RequestLifecycleEvent,
+    RequestLifecycleEventType,
+)
 from fenic._inference.token_counter import (
     TokenCounter,
     Tokenizable,
@@ -81,8 +86,11 @@ class QueueItem(Generic[RequestT]):
     future: Future
     estimated_tokens: TokenEstimate
     batch_id: str
+    operation_name: str
+    request_index: int
     request_timeout: float
     request_fingerprint: Optional[str] = None
+    was_rate_limited: bool = False
 
 
 class ModelClient(Generic[RequestT, ResponseT], ABC):
@@ -146,6 +154,9 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
             enabled=_ate.enabled,
             safety_margin=_ate.safety_margin,
         )
+        self._request_lifecycle_collector: Optional[RequestLifecycleCollector] = None
+        self._request_lifecycle_execution_id: Optional[str] = None
+        self._request_lifecycle_lock = threading.Lock()
         # Async queues
         self.request_queue = asyncio.Queue(maxsize=queue_size)
         self.retry_queue = asyncio.Queue()  # No size limit to avoid deadlocking
@@ -222,6 +233,50 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
             int: The number of tokens in the object
         """
         return self.token_counter.count_tokens(messages, ignore_file=ignore_file)
+
+    def set_request_lifecycle_collector(
+        self,
+        collector: Optional[RequestLifecycleCollector],
+        *,
+        execution_id: Optional[str] = None,
+    ) -> None:
+        """Set optional lifecycle instrumentation for a benchmark execution.
+
+        Collectors can receive calls on both the submitting thread and the shared
+        event-loop thread, so callers must provide a thread-safe collector. Errors
+        raised by a collector are logged and never affect model execution.
+        """
+        with self._request_lifecycle_lock:
+            self._request_lifecycle_collector = collector
+            self._request_lifecycle_execution_id = execution_id
+
+    def _emit_request_lifecycle_event(
+        self, event: RequestLifecycleEventType, queue_item: QueueItem[RequestT]
+    ) -> None:
+        # The normal product path has no collector. Avoid lock acquisition there;
+        # a collector attached concurrently observes subsequent transitions.
+        if self._request_lifecycle_collector is None:
+            return
+
+        with self._request_lifecycle_lock:
+            collector = self._request_lifecycle_collector
+            execution_id = self._request_lifecycle_execution_id
+
+        try:
+            collector(
+                RequestLifecycleEvent(
+                    event=event,
+                    timestamp_ns=time.monotonic_ns(),
+                    execution_id=execution_id,
+                    batch_id=queue_item.batch_id,
+                    request_index=queue_item.request_index,
+                    operation_name=queue_item.operation_name,
+                    model=self.model,
+                    provider=self.model_provider.value,
+                )
+            )
+        except Exception:
+            logger.warning("Request lifecycle collector raised an exception", exc_info=True)
 
     def get_profile_hash_for_request(self, request: RequestT) -> Optional[str]:
         """Get a hash of the resolved profile configuration for a request.
@@ -587,7 +642,10 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
 
         # Submit requests and get futures
         request_futures, num_unique_requests, total_token_estimate = self._submit_batch_requests(
-            requests, batch_id, request_timeout=request_timeout or DEFAULT_MODEL_CLIENT_TIMEOUT
+            requests,
+            batch_id,
+            operation_name,
+            request_timeout=request_timeout or DEFAULT_MODEL_CLIENT_TIMEOUT,
         )
 
         logger.info(
@@ -604,9 +662,12 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         return responses
 
     def _submit_batch_requests(
-        self, requests: List[Optional[RequestT]], batch_id: str
-    ,
-                             request_timeout: float) -> tuple[List[Future], int, TokenEstimate]:
+        self,
+        requests: List[Optional[RequestT]],
+        batch_id: str,
+        operation_name: str,
+        request_timeout: float,
+    ) -> tuple[List[Future], int, TokenEstimate]:
         """Submit all requests in a batch and return futures, unique request count, and token estimate.
 
         Args:
@@ -713,9 +774,12 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
                         future=req_future,
                         estimated_tokens=estimated_tokens,
                         batch_id=batch_id,
+                        operation_name=operation_name,
+                        request_index=idx,
                         request_fingerprint=request_fingerprint,
                         request_timeout=request_timeout,
                     )
+                    self._emit_request_lifecycle_event("queued", queue_item)
                     enqueue_future: Future = asyncio.run_coroutine_threadsafe(
                         self._enqueue_request(queue_item),
                         self._event_loop,
@@ -782,6 +846,9 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
                             self._track_inflight_task(task)
                             processed_requests.append(queue_item)
                         else:
+                            if not queue_item.was_rate_limited:
+                                self._emit_request_lifecycle_event("rate_limited", queue_item)
+                                queue_item.was_rate_limited = True
                             # Sleep for a short duration to wait for rate limit to refill to avoid busy-waiting
                             await asyncio.sleep(MILLISECOND_IN_SECONDS)
 
@@ -809,6 +876,7 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         try:
             try:
                 timeout = queue_item.request_timeout or DEFAULT_MODEL_CLIENT_TIMEOUT
+                self._emit_request_lifecycle_event("dispatched", queue_item)
                 maybe_response = await asyncio.wait_for(
                     self.make_single_request(queue_item.request),
                     timeout=timeout,
@@ -817,16 +885,28 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
                 logger.warning(
                     f"Request for model {self.model} in batch {queue_item.batch_id} timed out after {timeout} seconds. Retrying."
                 )
+                self._emit_request_lifecycle_event("retried", queue_item)
                 await self.retry_queue.put(queue_item)
                 return
 
             await self._handle_response(queue_item, maybe_response)
+            if isinstance(maybe_response, TransientException):
+                event: RequestLifecycleEventType = (
+                    "failed" if self.num_backoffs >= self.max_backoffs else "retried"
+                )
+            elif isinstance(maybe_response, FatalException):
+                event = "failed"
+            else:
+                event = "settled"
+            self._emit_request_lifecycle_event(event, queue_item)
         except asyncio.CancelledError:
             logger.debug(f"Request {queue_item.request} was cancelled")
             self._register_thread_exception(queue_item, asyncio.CancelledError)
+            self._emit_request_lifecycle_event("failed", queue_item)
             raise
         except Exception as e:
             self._register_thread_exception(queue_item, e)
+            self._emit_request_lifecycle_event("failed", queue_item)
             raise
 
     async def _handle_response(

--- a/src/fenic/_inference/request_lifecycle.py
+++ b/src/fenic/_inference/request_lifecycle.py
@@ -1,0 +1,157 @@
+"""Request lifecycle events used by execution-performance instrumentation.
+
+The collector is intentionally optional: normal execution does not retain events. A
+benchmark can attach a collector to a model client, label it with an execution ID,
+and use these events to distinguish provider idle time from time spent queued.
+"""
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from math import ceil
+from typing import Literal, Optional
+
+RequestLifecycleEventType = Literal[
+    "queued",
+    "rate_limited",
+    "dispatched",
+    "settled",
+    "retried",
+    "failed",
+]
+RequestLifecycleCollector = Callable[["RequestLifecycleEvent"], None]
+
+
+@dataclass(frozen=True)
+class RequestLifecycleEvent:
+    """One physical provider-request lifecycle transition.
+
+    ``batch_id`` identifies the model-client batch. ``execution_id`` is supplied by
+    an instrumented execution, so callers can correlate multiple semantic operators.
+    Timestamps use :func:`time.monotonic_ns` and are comparable only within one process.
+    """
+
+    event: RequestLifecycleEventType
+    timestamp_ns: int
+    execution_id: Optional[str]
+    batch_id: str
+    request_index: int
+    operation_name: str
+    model: str
+    provider: str
+
+
+@dataclass(frozen=True)
+class IdleGapMetrics:
+    """Provider idle and queue-delay totals reconstructed from lifecycle events."""
+
+    idle_gap_count: int
+    total_idle_gap_ns: int
+    total_non_rate_limited_idle_gap_ns: int
+    p50_idle_gap_ns: Optional[int]
+    p95_idle_gap_ns: Optional[int]
+    total_queue_delay_ns: int
+    total_rate_limited_ns: int
+    idle_fraction: float
+
+
+@dataclass
+class _LifecycleState:
+    inflight_requests: set[tuple[str, int]]
+    queued_at_ns: dict[tuple[str, int], int]
+    rate_limited_at_ns: dict[tuple[str, int], int]
+    first_dispatch_ns: Optional[int] = None
+    last_settlement_ns: Optional[int] = None
+    final_timestamp_ns: Optional[int] = None
+
+
+def compute_idle_gap_metrics(events: Iterable[RequestLifecycleEvent]) -> IdleGapMetrics:
+    """Summarize idle intervals for each execution/model/provider stream.
+
+    An idle interval starts only after all in-flight requests in a stream have
+    settled or failed, and ends at the next dispatch. Queue delay is reported as
+    the time from ``queued`` to ``dispatched``. A ``rate_limited`` transition
+    identifies the portion of an idle interval that must not be attributed to
+    upstream execution; the gross interval and its non-rate-limited remainder
+    are both returned. Retry backoff stays in-flight, so it is excluded from both
+    idle and queue delay; the metrics do not partition elapsed time under retries.
+    B0 and B1 comparisons must use this same treatment.
+    """
+
+    states: dict[tuple[Optional[str], str, str], _LifecycleState] = defaultdict(
+        lambda: _LifecycleState(set(), {}, {})
+    )
+    idle_gaps_ns: list[int] = []
+    non_rate_limited_idle_gaps_ns: list[int] = []
+    queue_delays_ns: list[int] = []
+    rate_limited_delays_ns: list[int] = []
+    stream_durations_ns: list[int] = []
+
+    ordered_events = sorted(events, key=lambda event: event.timestamp_ns)
+    for event in ordered_events:
+        stream = (event.execution_id, event.model, event.provider)
+        state = states[stream]
+        request = (event.batch_id, event.request_index)
+        state.final_timestamp_ns = event.timestamp_ns
+
+        if event.event == "queued":
+            state.queued_at_ns[request] = event.timestamp_ns
+            continue
+
+        if event.event == "rate_limited":
+            state.rate_limited_at_ns.setdefault(request, event.timestamp_ns)
+            continue
+
+        if event.event == "dispatched":
+            queued_at_ns = state.queued_at_ns.get(request)
+            if queued_at_ns is not None:
+                queue_delays_ns.append(event.timestamp_ns - queued_at_ns)
+
+            rate_limited_at_ns = state.rate_limited_at_ns.pop(request, None)
+
+            if not state.inflight_requests and state.last_settlement_ns is not None:
+                idle_gap_ns = event.timestamp_ns - state.last_settlement_ns
+                idle_gaps_ns.append(idle_gap_ns)
+                if rate_limited_at_ns is None:
+                    non_rate_limited_idle_gaps_ns.append(idle_gap_ns)
+                else:
+                    rate_limited_ns = event.timestamp_ns - max(
+                        rate_limited_at_ns, state.last_settlement_ns
+                    )
+                    rate_limited_delays_ns.append(rate_limited_ns)
+                    non_rate_limited_idle_gaps_ns.append(idle_gap_ns - rate_limited_ns)
+
+            state.inflight_requests.add(request)
+            if state.first_dispatch_ns is None:
+                state.first_dispatch_ns = event.timestamp_ns
+            continue
+
+        if event.event in {"settled", "failed"}:
+            state.inflight_requests.discard(request)
+            if not state.inflight_requests:
+                state.last_settlement_ns = event.timestamp_ns
+
+    for state in states.values():
+        if state.first_dispatch_ns is None or state.final_timestamp_ns is None:
+            continue
+        stream_durations_ns.append(state.final_timestamp_ns - state.first_dispatch_ns)
+
+    total_idle_gap_ns = sum(idle_gaps_ns)
+    total_duration_ns = sum(stream_durations_ns)
+    sorted_idle_gaps_ns = sorted(idle_gaps_ns)
+
+    def percentile(percentile: float) -> Optional[int]:
+        if not sorted_idle_gaps_ns:
+            return None
+        return sorted_idle_gaps_ns[ceil(percentile * len(sorted_idle_gaps_ns)) - 1]
+
+    return IdleGapMetrics(
+        idle_gap_count=len(idle_gaps_ns),
+        total_idle_gap_ns=total_idle_gap_ns,
+        total_non_rate_limited_idle_gap_ns=sum(non_rate_limited_idle_gaps_ns),
+        p50_idle_gap_ns=percentile(0.50),
+        p95_idle_gap_ns=percentile(0.95),
+        total_queue_delay_ns=sum(queue_delays_ns),
+        total_rate_limited_ns=sum(rate_limited_delays_ns),
+        idle_fraction=total_idle_gap_ns / total_duration_ns if total_duration_ns else 0.0,
+    )

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -715,7 +715,7 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
         ColumnField("distance", DoubleType),
     ]
 
-    result = df.drop("left_vec", "right_vec").to_polars()
+    result = df.drop("left_vec", "right_vec").to_polars().sort(["left_id", "right_id"])
     assert result.schema == pl.Schema(
         {
             "left_id": pl.Int64,
@@ -729,8 +729,8 @@ def test_semantic_sim_join_custom_embeddings_golden_output(local_session):
     assert result.to_dicts() == [
         {"left_id": 1, "left_label": "x", "right_id": 10, "right_label": "near-x", "distance": 1.0},
         {"left_id": 1, "left_label": "x", "right_id": 20, "right_label": "near-y", "distance": 81.0},
-        {"left_id": 2, "left_label": "y", "right_id": 20, "right_label": "near-y", "distance": 1.0},
         {"left_id": 2, "left_label": "y", "right_id": 10, "right_label": "near-x", "distance": 81.0},
+        {"left_id": 2, "left_label": "y", "right_id": 20, "right_label": "near-y", "distance": 1.0},
     ]
 
 

--- a/tests/_inference/test_request_lifecycle.py
+++ b/tests/_inference/test_request_lifecycle.py
@@ -1,0 +1,181 @@
+from fenic._inference import model_client as model_client_module
+from fenic._inference.model_client import ModelClient
+from fenic._inference.rate_limit_strategy import (
+    TokenEstimate,
+    UnifiedTokenRateLimitStrategy,
+)
+from fenic._inference.request_lifecycle import (
+    RequestLifecycleEvent,
+    compute_idle_gap_metrics,
+)
+from fenic._inference.token_counter import TiktokenTokenCounter
+from fenic._inference.types import (
+    FenicCompletionsRequest,
+    FenicCompletionsResponse,
+    LMRequestMessages,
+)
+from fenic.core._inference.model_catalog import ModelProvider
+from fenic.core.metrics import LMMetrics
+
+
+class _StubProviderClass:
+    _base_url = None
+
+
+class _FakeCompletionsClient(ModelClient[FenicCompletionsRequest, FenicCompletionsResponse]):
+    def __init__(self):
+        super().__init__(
+            model="fake-model",
+            model_provider=ModelProvider.OPENAI,
+            model_provider_class=_StubProviderClass(),
+            rate_limit_strategy=UnifiedTokenRateLimitStrategy(rpm=1_000, tpm=1_000_000),
+            token_counter=TiktokenTokenCounter(model_name="gpt-4o-mini"),
+        )
+        self._metrics = LMMetrics()
+
+    async def make_single_request(self, request):
+        return FenicCompletionsResponse(completion="fake", logprobs=None)
+
+    def estimate_tokens_for_request(self, request) -> TokenEstimate:
+        return TokenEstimate(input_tokens=1, output_tokens=1)
+
+    def get_metrics(self) -> LMMetrics:
+        return self._metrics
+
+    def reset_metrics(self):
+        self._metrics = LMMetrics()
+
+    def _get_max_output_token_request_limit(self, request):
+        return request.max_completion_tokens
+
+
+def _request():
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="system", examples=[], user="user"),
+        max_completion_tokens=16,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=0.0,
+    )
+
+
+def test_lifecycle_events_label_serial_requests_and_measure_idle_gap(monkeypatch):
+    timestamps = iter((100, 110, 120, 140, 150, 160))
+    monkeypatch.setattr(model_client_module.time, "monotonic_ns", lambda: next(timestamps))
+
+    client = _FakeCompletionsClient()
+    events = []
+    client.set_request_lifecycle_collector(events.append, execution_id="p0-fake-execution")
+    try:
+        client.make_batch_requests([_request()], operation_name="semantic.map")
+        client.make_batch_requests([_request()], operation_name="semantic.extract")
+    finally:
+        client.shutdown()
+
+    assert [event.event for event in events] == [
+        "queued",
+        "dispatched",
+        "settled",
+        "queued",
+        "dispatched",
+        "settled",
+    ]
+    assert {event.execution_id for event in events} == {"p0-fake-execution"}
+    assert {event.model for event in events} == {"fake-model"}
+    assert [event.operation_name for event in events] == [
+        "semantic.map",
+        "semantic.map",
+        "semantic.map",
+        "semantic.extract",
+        "semantic.extract",
+        "semantic.extract",
+    ]
+
+    metrics = compute_idle_gap_metrics(events)
+    assert metrics.idle_gap_count == 1
+    assert metrics.total_idle_gap_ns == 30
+    assert metrics.total_non_rate_limited_idle_gap_ns == 30
+    assert metrics.p50_idle_gap_ns == 30
+    assert metrics.p95_idle_gap_ns == 30
+    assert metrics.total_queue_delay_ns == 20
+    assert metrics.total_rate_limited_ns == 0
+    assert metrics.idle_fraction == 0.6
+
+
+def test_idle_metrics_exclude_rate_limited_wait_from_attribution():
+    def event(name, timestamp):
+        return RequestLifecycleEvent(
+            event=name,
+            timestamp_ns=timestamp,
+            execution_id="p0-fake-execution",
+            batch_id="batch-1" if timestamp < 140 else "batch-2",
+            request_index=0,
+            operation_name="semantic.map" if timestamp < 140 else "semantic.extract",
+            model="fake-model",
+            provider="openai",
+        )
+
+    metrics = compute_idle_gap_metrics(
+        [
+            event("queued", 100),
+            event("dispatched", 110),
+            event("settled", 120),
+            event("queued", 140),
+            event("rate_limited", 150),
+            event("dispatched", 160),
+            event("settled", 170),
+        ]
+    )
+
+    assert metrics.total_idle_gap_ns == 40
+    assert metrics.total_rate_limited_ns == 10
+    assert metrics.total_non_rate_limited_idle_gap_ns == 30
+
+
+def test_lifecycle_marks_rate_limited_wait_once(monkeypatch):
+    timestamps = iter((100, 110, 120, 130))
+    monkeypatch.setattr(model_client_module.time, "monotonic_ns", lambda: next(timestamps))
+
+    client = _FakeCompletionsClient()
+    checks = iter((False, True))
+    monkeypatch.setattr(client, "_check_and_consume_rate_limit", lambda _: next(checks))
+    events = []
+    client.set_request_lifecycle_collector(events.append, execution_id="p0-rate-limit")
+    try:
+        client.make_batch_requests([_request()], operation_name="semantic.map")
+    finally:
+        client.shutdown()
+
+    assert [event.event for event in events] == [
+        "queued",
+        "rate_limited",
+        "dispatched",
+        "settled",
+    ]
+
+
+def test_idle_metrics_do_not_count_retry_backoff_as_execution_idle():
+    def event(name, timestamp):
+        return RequestLifecycleEvent(
+            event=name,
+            timestamp_ns=timestamp,
+            execution_id="p0-fake-execution",
+            batch_id="batch-1",
+            request_index=0,
+            operation_name="semantic.map",
+            model="fake-model",
+            provider="openai",
+        )
+
+    metrics = compute_idle_gap_metrics(
+        [
+            event("queued", 100),
+            event("dispatched", 110),
+            event("retried", 120),
+            event("dispatched", 140),
+            event("settled", 150),
+        ]
+    )
+
+    assert metrics.idle_gap_count == 0
+    assert metrics.total_idle_gap_ns == 0


### PR DESCRIPTION
## Execution-engine experiment anchor — FINAL

This draft remains the single branches-only anchor for
`fenic-exec-engine-breakdown-v1`. No new PRs or conventional reviewer requests
were created; formal gates were requested in committed lane records and fulfilled
by Herd Command. The extended charter is complete and the stack is on stand-down
for Captain return review.

```text
P0 @834f5c08d LAND
 └─ P1a @c8d797aaf LAND
    └─ P1b @c8d797aaf LAND (no-op)
       └─ B0 @c7967d092 LAND
          └─ P1c @743e09b6734 LAND
             └─ B0+1c @574a743 LAND
                └─ B1 @bd7d89b LAND
                   └─ Validation @9098734 REPORT ACCEPTED
                      └─ TD-3334 @54ea844 ACCEPTED NO-OP
                         └─ TD-3384 @f0fcc14 + 9e0ce56 LAND
                            └─ TD-3385 @72323f7 + 7295e02 LAND (no-op)
                               └─ Mixed workload @b2de73a LAND-WITH-FOLLOWUPS
                                  └─ TD-3383 @0b66160 ACCEPTED NO-OP
                                     └─ Closing record @c1c166a
```

| Node | Final disposition / receipt |
| --- | --- |
| P0 foundation | LAND — `.context/td-review/p0-foundation-review-2026-08-05.md` |
| P1a sim-join | LAND — `.context/td-review/p1a-sim-join-c8d797a.md` |
| P1b reduce residual | LAND no-op — `.context/outbox/p1b-reduce-residual-c8d797a.md` |
| B0 stream | LAND — `.context/td-review/b0-model-stream-c7967d0-review-2026-08-06.md` |
| P1c semantic.join | LAND — `.context/td-review/p1c-semantic-join-review-2026-08-06-delta.md` |
| B0+1c adapter | LAND — `.context/td-review/b0-1c-stream-adapter-receipt-2026-08-05.md` |
| B1 fusion | LAND — `.context/td-review/b1-two-op-fusion-review-2026-08-05.md` |
| Validation | Report accepted — `.context/outbox/fenic-exec-engine-validation-report-2026-08-06.md` |
| TD-3334 | Accepted no-op — `.context/outbox/td3334-n-op-fusion-lane-record-2026-08-06.md` |
| TD-3384 | LAND — `.context/td-review/td3384-eager-noop-review-2026-08-06.md` |
| TD-3385 | LAND with directed closure — `.context/outbox/td3385-polars-embedding-benchmark-lane-record-2026-08-06.md` |
| Mixed workload | LAND-WITH-FOLLOWUPS; direct closure at `b2de73a` — `.context/td-review/mixed-workload-review-2026-08-06.md`, `.context/outbox/mixed-complexity-workload-lane-record-2026-08-06.md` |
| TD-3383 | Accepted no-op at `0b66160` — `.context/outbox/td3383-collect-show-count-pushdown-lane-record-2026-08-06.md` |

The final closing report is
`.context/outbox/fenic-exec-engine-breakdown-v1-2026-08-06-closing-digest.md`
at `c1c166a`; it includes the full review history, premise kills, experiment
results, and stand-down record. The local extensions consumed $0.00 provider
spend. Mixed-workload fusion was engaged but had no material fused/unfused
effect in the governor-bound simulator; TD-3383 demonstrated that even the
narrow `show(10)` source-prefix candidate changes Polars first/last formatting,
so generic local action pushdown remains intentionally deferred.
