### PR TITLE
perf(local): avoid redundant DataFrame work and bound sim-join memory

### DIFF
--- a/docs/topics/create_dataframe_schema.md
+++ b/docs/topics/create_dataframe_schema.md
@@ -166,11 +166,18 @@ provider — the `embedding_model` on the type is metadata.)
 
 ## Relationship to Schema-Free Ingestion
 
-The no-schema path is unchanged and fully behavior-compatible:
+The no-schema path retains its existing schema semantics:
 
 - Empty lists are still rejected.
 - Types are still inferred from the data.
 - Fixed-size arrays are still normalized to `pl.List`.
+
+Its object-identity behavior differs for schema-free Polars inputs: when the
+input already has Fenic-compatible physical dtypes, local execution can retain
+and return the same Polars frame instead of copying it. If ingestion must
+normalize an array, timestamp, or nested dtype, it materializes a new frame.
+Supplying an explicit schema also applies its authoritative ordering and casts,
+so it does not use this schema-free pass-through path.
 
 Only supplying a `schema` opts you into authoritative names, ordering, coercion,
 and logical-type/embedding preservation. For related ingestion-normalization

--- a/docs/topics/timestamps_and_dates.md
+++ b/docs/topics/timestamps_and_dates.md
@@ -14,9 +14,12 @@ Both types and related functionality follow similar patterns to PySpark, except 
 ## Key Features
 
 - **Microsecond precision**: Timestamps support up to 1/1,000,000 second precision
-- **UTC-first design**: All timestamps are normalized to UTC during ingestion
+- **UTC-first design**: Timestamps that need conversion are normalized to UTC
+  during ingestion; already canonical UTC Polars columns can pass through
+  unchanged
 - **Automatic timezone conversion**: Timezone-aware inputs are converted to UTC automatically
-- **Consistent behavior**: Same behavior across all data sources (Parquet, CSV, in-memory DataFrames, tables)
+- **Consistent values**: All data sources expose the same UTC timestamp
+  semantics, although their materialization and copy behavior can differ
 - **Rich date/time functions**: Comprehensive set of functions for temporal operations
 - **Timezone conversion utilities**: Functions to work with local timezones while maintaining UTC storage
 
@@ -192,7 +195,10 @@ The same behavior applies to:
 
 - **Parquet files**: Timestamps stored with timezone metadata, automatically converted to UTC on read
 - **Fenic tables** (DuckDB): DuckDB session timezone is always UTC, ensuring consistency
-- **In-memory DataFrames**: Polars DataFrames with timezone-aware or naive timestamps are normalized to UTC
+- **In-memory DataFrames**: Polars DataFrames with timezone-aware or naive
+  timestamps are normalized to UTC when needed. An already canonical
+  `Datetime("us", "UTC")` column can pass through without copying the input
+  frame.
 
 ### SQL Queries
 
@@ -241,6 +247,12 @@ This behavior ensures:
 ### Timezone Conversion During Ingestion
 
 Fenic automatically handles different timezone inputs:
+
+For a schema-free in-memory Polars DataFrame that already uses Fenic's canonical
+microsecond UTC dtype, ingestion does not perform a conversion and local
+collection may alias the original frame. Naive timestamps, non-UTC timestamps,
+or non-microsecond precision still require normalization and produce a new
+frame.
 
 ```python
 import datetime

--- a/src/fenic/_backends/local/physical_plan/transform.py
+++ b/src/fenic/_backends/local/physical_plan/transform.py
@@ -23,6 +23,27 @@ from fenic._backends.local.physical_plan.base import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_identity_projection(
+    projections: List[pl.Expr], columns: List[str]
+) -> bool:
+    """Return whether projections preserve every input column in its current order."""
+    return len(projections) == len(columns) and all(
+        projection.meta.is_column()
+        and projection.meta.output_name() == column
+        for projection, column in zip(projections, columns, strict=True)
+    )
+
+
+def _align_union_right_dataframe(
+    left_df: pl.DataFrame, right_df: pl.DataFrame
+) -> pl.DataFrame:
+    """Align only a differently ordered right side to the left union schema."""
+    if right_df.columns == left_df.columns:
+        return right_df
+    return right_df.select(left_df.columns)
+
+
 @dataclass(frozen=True)
 class SeriesLiteralCheck:
     column_name: str
@@ -55,6 +76,8 @@ class ProjectionExec(PhysicalPlan):
                         f"{check.expected_length}, but the DataFrame has {df_height} rows. "
                         "Series data must match the DataFrame height."
                     )
+        if _is_identity_projection(self.projections, child_df.columns):
+            return child_df
         return child_df.select(self.projections)
 
 
@@ -138,8 +161,8 @@ class UnionExec(PhysicalPlan):
         left_df = child_dfs[0]
         right_df = child_dfs[1]
 
-        # Align right dataframe columns with left dataframe
-        right_df_aligned = right_df.select(left_df.columns)
+        # Align the right dataframe only when its column order differs.
+        right_df_aligned = _align_union_right_dataframe(left_df, right_df)
         combined = pl.concat([left_df, right_df_aligned], how="vertical")
         return combined
 

--- a/src/fenic/_backends/local/physical_plan/utils.py
+++ b/src/fenic/_backends/local/physical_plan/utils.py
@@ -37,7 +37,8 @@ def apply_ingestion_coercions(
             physical fixed-size array representation.
 
     Returns:
-        A new Polars DataFrame with all coercions applied to conform to Fenic-compatible types.
+        The original DataFrame when no coercion is needed; otherwise a new
+        DataFrame with coercions applied to conform to Fenic-compatible types.
     """
 
     logical_fields = (
@@ -46,7 +47,7 @@ def apply_ingestion_coercions(
         else {}
     )
 
-    expressions = []
+    target_dtypes: dict[str, pl.DataType] = {}
     for col_name in df.columns:
         dtype = df[col_name].dtype
         target_dtype = _build_target_dtype(
@@ -56,11 +57,19 @@ def apply_ingestion_coercions(
         )
 
         if target_dtype != dtype:
-            expressions.append(pl.col(col_name).cast(target_dtype))
-        else:
-            expressions.append(pl.col(col_name))
+            target_dtypes[col_name] = target_dtype
 
-    return df.select(expressions)
+    if not target_dtypes:
+        return df
+
+    return df.select(
+        [
+            pl.col(col_name).cast(target_dtypes[col_name])
+            if col_name in target_dtypes
+            else pl.col(col_name)
+            for col_name in df.columns
+        ]
+    )
 
 
 def _build_target_dtype(

--- a/src/fenic/_backends/local/semantic_operators/sim_join.py
+++ b/src/fenic/_backends/local/semantic_operators/sim_join.py
@@ -26,6 +26,7 @@ RIGHT_ON_COL_NAME = "__right_on__"
 LEFT_ID_COL_NAME = "__left_id__"
 RIGHT_ID_COL_NAME = "__right_id__"
 MATCH_RESULT_COL_NAME = "__match_result__"
+DEFAULT_LEFT_BATCH_SIZE = 1_024
 
 class SimJoin:
     def __init__(
@@ -34,6 +35,7 @@ class SimJoin:
         right: pl.DataFrame,
         k: int,
         similarity_metric: SemanticSimilarityMetric,
+        left_batch_size: int = DEFAULT_LEFT_BATCH_SIZE,
         include_left_on: bool = True,
         include_right_on: bool = True,
     ):
@@ -41,6 +43,9 @@ class SimJoin:
         self.right = right.with_row_index(RIGHT_ID_COL_NAME)
         self.k = k
         self.similarity_metric = similarity_metric
+        if left_batch_size <= 0:
+            raise ValueError("left_batch_size must be positive")
+        self.left_batch_size = left_batch_size
         self.include_left_on = include_left_on
         self.include_right_on = include_right_on
 
@@ -96,47 +101,59 @@ class SimJoin:
             if len(right) > 5000:
                 tbl.create_index(metric=self.similarity_metric)
 
-            # Define UDF to perform search for each row
-            def search_vectors(left_embedding, left_id):
-                results = tbl.search(left_embedding).distance_type(self.similarity_metric).limit(self.k).to_list()
-
-                # Create list of structs with search results
-                matches = []
-                for result in results:
-                    matches.append(
-                        {
-                            LEFT_ID_COL_NAME: left_id,
-                            RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
-                            DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
-                        }
-                    )
-                return matches
-
-            # TODO(rohitrastogi): Do some experiments to see if sending concurrent requests to LanceDB
-            # using a thread pool is faster than sending requests sequentially. Vector search is CPU bound and LanceDB
-            # releases the GIL, so I'm not sure there will be any performance gains.
-            # FYI, LanceDB doesn't support batch vector search. If you pass a batch of vectors, it doesn't
-            # actually search in parallel.
-            return (
-                left.select(
-                    pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
-                    .map_elements(
-                        lambda x: search_vectors(x[LEFT_ON_COL_NAME], x[LEFT_ID_COL_NAME]),
-                        return_dtype=pl.List(
-                            pl.Struct(
-                                {
-                                    LEFT_ID_COL_NAME: pl.Int32,
-                                    RIGHT_ID_COL_NAME: pl.Int32,
-                                    DISTANCE_COL_NAME: pl.Float64,
-                                }
-                            )
-                        ),
-                    )
-                    .alias(MATCH_RESULT_COL_NAME)
+            # The final N×k result remains materialized by contract, but each
+            # search/explode transform is bounded to a narrow left-side slice.
+            match_chunks = [
+                self._search_left_batch(
+                    left.slice(offset, self.left_batch_size), tbl
                 )
-                .explode(MATCH_RESULT_COL_NAME)
-                .unnest(MATCH_RESULT_COL_NAME)
+                for offset in range(0, len(left), self.left_batch_size)
+            ]
+            return pl.concat(match_chunks)
+
+    def _search_left_batch(self, left_batch: pl.DataFrame, table: "Table") -> pl.DataFrame:
+        """Search one bounded left-side slice and return narrow match rows."""
+
+        def search_vectors(left_embedding, left_id):
+            results = (
+                table.search(left_embedding)
+                .distance_type(self.similarity_metric)
+                .limit(self.k)
+                .to_list()
             )
+            return [
+                {
+                    LEFT_ID_COL_NAME: left_id,
+                    RIGHT_ID_COL_NAME: result[RIGHT_ID_COL_NAME],
+                    DISTANCE_COL_NAME: result[DISTANCE_COL_NAME],
+                }
+                for result in results
+            ]
+
+        # LanceDB does not support parallel vector-batch searches. Keep these
+        # per-row searches local to this slice so the transient explode is bounded.
+        return (
+            left_batch.select(
+                pl.struct([pl.col(LEFT_ON_COL_NAME), pl.col(LEFT_ID_COL_NAME)])
+                .map_elements(
+                    lambda value: search_vectors(
+                        value[LEFT_ON_COL_NAME], value[LEFT_ID_COL_NAME]
+                    ),
+                    return_dtype=pl.List(
+                        pl.Struct(
+                            {
+                                LEFT_ID_COL_NAME: pl.Int32,
+                                RIGHT_ID_COL_NAME: pl.Int32,
+                                DISTANCE_COL_NAME: pl.Float64,
+                            }
+                        )
+                    ),
+                )
+                .alias(MATCH_RESULT_COL_NAME)
+            )
+            .explode(MATCH_RESULT_COL_NAME)
+            .unnest(MATCH_RESULT_COL_NAME)
+        )
 
     def _empty_result_with_schema(
         self, left: pl.DataFrame, right: pl.DataFrame

--- a/src/fenic/api/dataframe/dataframe.py
+++ b/src/fenic/api/dataframe/dataframe.py
@@ -261,7 +261,9 @@ class DataFrame:
             data_type: The type of data to return
 
         Returns:
-            QueryResult: A QueryResult with materialized data and query metrics
+            QueryResult: A QueryResult with materialized data and query metrics.
+                For ``data_type="polars"``, a no-op local plan may return a frame
+                that aliases its in-memory Polars input rather than copying it.
         """
         result: Tuple[pl.DataFrame, QueryMetrics] = self._session_state.execution.collect(self._logical_plan)
         df, metrics = result
@@ -288,7 +290,9 @@ class DataFrame:
         materialized into a Polars DataFrame.
 
         Returns:
-            pl.DataFrame: A Polars DataFrame with materialized results
+            pl.DataFrame: A Polars DataFrame with materialized results. A no-op
+                local plan may return a frame that aliases its in-memory Polars
+                input rather than copying it.
         """
         return self.collect("polars").data
 

--- a/src/fenic/api/session/session.py
+++ b/src/fenic/api/session/session.py
@@ -154,7 +154,9 @@ class Session:
                 embedding arrays through local and cloud execution.
 
         Returns:
-            A new DataFrame instance
+            A DataFrame instance. With schema-free Polars input, local execution
+            passes through the input frame when no ingestion coercion is needed,
+            so collected Polars results may alias it rather than copy it.
 
         Raises:
             ValidationError: If the input format is unsupported or the provided

--- a/tests/_backends/local/dataframe/test_semantic_sim_join.py
+++ b/tests/_backends/local/dataframe/test_semantic_sim_join.py
@@ -802,6 +802,59 @@ def test_semantic_sim_join_empty_result_can_skip_normalized_vector_columns():
     )
 
 
+def test_semantic_sim_join_batches_left_searches_without_changing_matches(monkeypatch):
+    left, right = _create_direct_sim_join_inputs()
+    observed_batch_sizes = []
+    original_search_batch = sim_join_module.SimJoin._search_left_batch
+
+    def record_search_batch(self, left_batch, table):
+        observed_batch_sizes.append(len(left_batch))
+        return original_search_batch(self, left_batch, table)
+
+    monkeypatch.setattr(
+        sim_join_module.SimJoin, "_search_left_batch", record_search_batch
+    )
+
+    result = sim_join_module.SimJoin(
+        left, right, k=2, similarity_metric="l2", left_batch_size=1
+    ).execute()
+
+    assert observed_batch_sizes == [1, 1]
+    assert result.select(
+        "left_payload", "right_payload", sim_join_module.DISTANCE_COL_NAME
+    ).sort(["left_payload", "right_payload"]).to_dicts() == [
+        {
+            "left_payload": "x",
+            "right_payload": "near-x",
+            sim_join_module.DISTANCE_COL_NAME: 1.0,
+        },
+        {
+            "left_payload": "x",
+            "right_payload": "near-y",
+            sim_join_module.DISTANCE_COL_NAME: 81.0,
+        },
+        {
+            "left_payload": "y",
+            "right_payload": "near-x",
+            sim_join_module.DISTANCE_COL_NAME: 81.0,
+        },
+        {
+            "left_payload": "y",
+            "right_payload": "near-y",
+            sim_join_module.DISTANCE_COL_NAME: 1.0,
+        },
+    ]
+
+
+def test_semantic_sim_join_rejects_non_positive_left_batch_size():
+    left, right = _create_direct_sim_join_inputs()
+
+    with pytest.raises(ValueError, match="left_batch_size must be positive"):
+        sim_join_module.SimJoin(
+            left, right, k=1, similarity_metric="l2", left_batch_size=0
+        )
+
+
 def test_semantic_sim_join_with_incompatible_embeddings(local_session):
     df = local_session.create_dataframe(
         {

--- a/tests/_backends/local/physical_plan/test_eager_noop_fast_paths.py
+++ b/tests/_backends/local/physical_plan/test_eager_noop_fast_paths.py
@@ -1,0 +1,175 @@
+from datetime import datetime, timezone
+
+import polars as pl
+
+from fenic._backends.local.physical_plan.transform import (
+    ProjectionExec,
+    _align_union_right_dataframe,
+)
+from fenic._backends.local.physical_plan.utils import apply_ingestion_coercions
+from fenic.core.types import (
+    ColumnField,
+    EmbeddingType,
+    Schema,
+    StringType,
+    StructField,
+    StructType,
+)
+
+
+def test_ingestion_coercions_return_original_wide_dataframe_when_no_types_change():
+    for df in (
+        pl.DataFrame(
+            {
+                "id": [1, 2],
+                "name": ["first", "second"],
+                "score": [1.5, 2.5],
+            }
+        ),
+        pl.DataFrame(schema={"id": pl.Int64, "name": pl.String}),
+    ):
+        result = apply_ingestion_coercions(df, coerce_array=True)
+
+        assert result is df
+        assert result.schema == df.schema
+        assert result.equals(df)
+
+
+def test_ingestion_coercions_keep_fully_normalized_datetime_struct_and_embedding_identity():
+    embedding_type = EmbeddingType(dimensions=2, embedding_model="test")
+    logical_schema = Schema(
+        [
+            ColumnField(
+                "payload",
+                StructType([StructField("state", StringType)]),
+            ),
+            ColumnField("embedding", embedding_type),
+        ]
+    )
+    df = pl.DataFrame(
+        {
+            "timestamp": [datetime(2025, 1, 1, tzinfo=timezone.utc)],
+            "payload": [{"state": "ready"}],
+            "embedding": [[1.0, 2.0]],
+        },
+        schema={
+            "timestamp": pl.Datetime(time_unit="us", time_zone="UTC"),
+            "payload": pl.Struct([pl.Field("state", pl.String)]),
+            "embedding": pl.Array(pl.Float32, 2),
+        },
+    )
+
+    result = apply_ingestion_coercions(
+        df,
+        coerce_array=True,
+        logical_schema=logical_schema,
+    )
+
+    assert result is df
+    assert result.schema == df.schema
+    assert result.equals(df)
+
+
+def test_ingestion_coercions_still_materialize_when_array_normalization_is_needed():
+    df = pl.DataFrame(
+        {"values": [[1, 2], [3, 4]]},
+        schema={"values": pl.Array(pl.Int64, 2)},
+    )
+
+    result = apply_ingestion_coercions(df, coerce_array=True)
+
+    assert result is not df
+    assert result.schema == {"values": pl.List(pl.Int64)}
+    assert result.to_dicts() == df.to_dicts()
+
+
+def test_same_order_union_keeps_right_dataframe_without_an_alignment_select():
+    for left, right, expected in (
+        (
+            pl.DataFrame({"id": [1], "name": ["left"]}),
+            pl.DataFrame({"id": [2], "name": ["right"]}),
+            [{"id": 1, "name": "left"}, {"id": 2, "name": "right"}],
+        ),
+        (
+            pl.DataFrame(schema={"id": pl.Int64, "name": pl.String}),
+            pl.DataFrame(schema={"id": pl.Int64, "name": pl.String}),
+            [],
+        ),
+    ):
+        aligned = _align_union_right_dataframe(left, right)
+
+        assert aligned is right
+        assert pl.concat([left, aligned], how="vertical").to_dicts() == expected
+
+
+def test_different_order_union_still_aligns_right_dataframe_to_left_order():
+    left = pl.DataFrame({"id": [1], "name": ["left"]})
+    right = pl.DataFrame({"name": ["right"], "id": [2]})
+
+    aligned = _align_union_right_dataframe(left, right)
+
+    assert aligned is not right
+    assert aligned.columns == left.columns
+    assert pl.concat([left, aligned], how="vertical").to_dicts() == [
+        {"id": 1, "name": "left"},
+        {"id": 2, "name": "right"},
+    ]
+
+
+def test_identity_projection_returns_original_dataframe_for_rows_and_empty_frames():
+    for df in (
+        pl.DataFrame({"id": [1, 2], "name": ["first", "second"]}),
+        pl.DataFrame(schema={"id": pl.Int64, "name": pl.String}),
+    ):
+        plan = ProjectionExec(
+            child=None,
+            projections=[pl.col(column) for column in df.columns],
+            cache_info=None,
+            session_state=None,
+        )
+
+        result = plan.execute_node([df])
+
+        assert result is df
+        assert result.schema == df.schema
+        assert result.equals(df)
+
+
+def test_projection_keeps_select_for_guard_boundary_expressions():
+    df = pl.DataFrame({"id": [1, 2]})
+    for projections, expected in (
+        ([pl.col("id").alias("id")], [{"id": 1}, {"id": 2}]),
+        ([pl.col("id").cast(pl.Int64)], [{"id": 1}, {"id": 2}]),
+        ([pl.col("^id$")], [{"id": 1}, {"id": 2}]),
+        ([(pl.col("id") + 1).alias("id")], [{"id": 2}, {"id": 3}]),
+    ):
+        plan = ProjectionExec(
+            child=None,
+            projections=projections,
+            cache_info=None,
+            session_state=None,
+        )
+
+        result = plan.execute_node([df])
+
+        assert result is not df
+        assert result.to_dicts() == expected
+
+
+def test_projection_keeps_select_for_reordered_direct_columns():
+    df = pl.DataFrame({"id": [1, 2], "name": ["first", "second"]})
+    plan = ProjectionExec(
+        child=None,
+        projections=[pl.col("name"), pl.col("id")],
+        cache_info=None,
+        session_state=None,
+    )
+
+    result = plan.execute_node([df])
+
+    assert result is not df
+    assert result.columns == ["name", "id"]
+    assert result.to_dicts() == [
+        {"name": "first", "id": 1},
+        {"name": "second", "id": 2},
+    ]


### PR DESCRIPTION
## What problem does this solve?

Local execution was allocating replacement Polars DataFrames for operations
whose inputs already satisfied the requested result, and `semantic.sim_join`
expanded its entire left-side search through one transient transform.

This change removes only those two internal costs. It does not add a public API
or change result shapes.

## Changes

### Bound transient work in semantic similarity joins

`semantic.sim_join` now searches the left input in fixed 1,024-row slices and
concatenates the existing narrow match rows. The final N×k result contract is
unchanged, while the transient search/map/explode/unnest work is bounded.

The regression test forces one-row slices, observes both search calls, and
asserts the complete ordered match set. A second test rejects a non-positive
slice size.

### Skip provable local DataFrame no-ops

- Ingestion returns the original DataFrame only when every target dtype already
  matches; any required coercion follows the existing select-and-cast path.
- Projection returns its child only for raw input columns in the same order.
  Aliases, casts, selectors, computed expressions, and reordered columns still
  use `select`.
- Union skips right-side alignment only when the right column list exactly
  equals the left list; reordered columns still align with `select`.

Focused tests cover row and empty-frame identity behavior, datetime/Struct/
EmbeddingType normalization, required coercions, union reordering, and every
projection guard boundary.

### Document the no-copy boundary

The public `Session.create_dataframe`, `DataFrame.collect`, and
`DataFrame.to_polars` docstrings now state that a schema-free, no-op local plan
may alias an already canonical Polars input rather than copying it. The schema
guide distinguishes this pass-through from explicit-schema ordering/casts and
coercion-required inputs. The timestamp guide retains its UTC value guarantees
while clarifying that already canonical microsecond-UTC Polars columns can pass
through and inputs requiring timezone or precision normalization still
materialize a new frame.

## Verification

```bash
uv run --no-sync pytest tests/_backends/local/physical_plan/test_eager_noop_fast_paths.py
uv run --no-sync pytest tests/_backends/local/dataframe/test_semantic_sim_join.py -k 'batches_left_searches_without_changing_matches or rejects_non_positive_left_batch_size'
uvx ruff check src/fenic/_backends/local/semantic_operators/sim_join.py src/fenic/_backends/local/physical_plan/transform.py src/fenic/_backends/local/physical_plan/utils.py tests/_backends/local/dataframe/test_semantic_sim_join.py tests/_backends/local/physical_plan/test_eager_noop_fast_paths.py
just docs-check
```

Observed locally: 8 eager-no-op tests passed, 2 direct sim-join tests passed,
Ruff passed, `just docs-check` validated 63 sitemap URLs and LLM assets, and
`git diff --check origin/main..HEAD` passed.

## Walkthrough

The accompanying walkthrough comment maps the two changes and their focused
verification coverage.
