### PR TITLE
ci: separate dependency sync and local test steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,10 +92,11 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"):$LD_LIBRARY_PATH
           cargo test --no-default-features --locked
-      - name: sync ${{ matrix.dependency == 'true' && 'locked' || matrix.dependency }} dependencies
+      # yamllint disable-line rule:line-length
+      - name: sync ${{ matrix.test }} ${{ matrix.dependency == 'true' && 'locked' || matrix.dependency }} dependencies
         shell: bash
         run: |
-          just sync="${{ matrix.dependency }}"
+          just sync="${{ matrix.dependency }}" sync-${{ matrix.test }}
       # yamllint disable-line rule:line-length
       - name: run ${{ matrix.test }} tests with synced dependencies
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,9 +92,12 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"):$LD_LIBRARY_PATH
           cargo test --no-default-features --locked
-      # yamllint disable-line rule:line-length
-      - name: run ${{ matrix.test }} tests with ${{ matrix.dependency == 'true' && 'synced' || matrix.dependency }} dependencies
+      - name: sync ${{ matrix.dependency == 'true' && 'locked' || matrix.dependency }} dependencies
         shell: bash
         run: |
           just sync="${{ matrix.dependency }}"
-          just test-${{ matrix.test }} openai gpt-4.1-nano openai text-embedding-3-small
+      # yamllint disable-line rule:line-length
+      - name: run ${{ matrix.test }} tests with synced dependencies
+        shell: bash
+        run: |
+          just sync=false test-${{ matrix.test }} openai gpt-4.1-nano openai text-embedding-3-small


### PR DESCRIPTION
## Summary

Dependency preparation and pytest now appear as separate GitHub Actions steps. The preparation step explicitly invokes the matching recipe: `sync-local` for local tests and `sync-cloud` for cloud tests. The pytest step receives `sync=false`, so its recipe prerequisite is intentionally skipped after preparation completes.

## Behavioral correction

The previous combined command began with `just sync="${{ matrix.dependency }}"`, which only assigns a Just variable. With no recipe argument, it invokes the default recipe (`just --list`) and performs no synchronization. The following `just test-${{ matrix.test }}` did run a prerequisite sync, but that prerequisite used the recipe's default `sync=true`; consequently, scheduled `min` and `max` matrix values did not affect dependency resolution.

This change invokes `just sync="${{ matrix.dependency }}" sync-${{ matrix.test }}` explicitly. It preserves the local/cloud extra sets and applies the `min`/`max` resolution flags in the visible preparation step.

## Validation

- `just -n sync="true"` prints `just --list`, confirming the prior command did not select the `sync` recipe.
- `actionlint .github/workflows/test.yaml` (only pre-existing shellcheck diagnostics)
- Ruby YAML parse of `.github/workflows/test.yaml`
- Dry-runs for every local/cloud and `true`/`false`/`min`/`max` combination:

  ```text
  local true:  uv sync --extra=google --extra=anthropic --extra=cohere --extra=mcp
  local false: [ "false" != "false" ] && uv sync --extra=google --extra=anthropic --extra=cohere --extra=mcp || true
  local min:   uv sync --extra=google --extra=anthropic --extra=cohere --extra=mcp --resolution=lowest-direct
  local max:   uv sync --extra=google --extra=anthropic --extra=cohere --extra=mcp --upgrade

  cloud true:  uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp
  cloud false: [ "false" != "false" ] && uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp || true
  cloud min:   uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp --resolution=lowest-direct
  cloud max:   uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp --upgrade
  ```

- For each of those combinations, `just -n sync=false test-local ...` or `just -n sync=false test-cloud ...` prints the false sync guard followed by the relevant `uv run pytest` command:

  ```text
  local: [ "false" != "false" ] && uv sync --extra=google --extra=anthropic --extra=cohere --extra=mcp || true
         POLARS_VERBOSE=1 uv run pytest -m "not cloud" --language-model-provider openai --language-model-name gpt-4.1-nano --embedding-model-provider openai --embedding-model-name text-embedding-3-small tests
  cloud: [ "false" != "false" ] && uv sync --extra=cloud --extra=google --extra=anthropic --extra=cohere --extra=mcp || true
         uv run pytest -m cloud --language-model-provider openai --language-model-name gpt-4.1-nano --embedding-model-provider openai --embedding-model-name text-embedding-3-small tests
  ```

  The false guard prevents the test stage from repeating preparation.
- A successful GitHub Actions rerun on this head confirmed the split: `sync local locked dependencies` passed in 6m51s, then the separate pytest step passed in 10m08s. Pytest reported 1,635 passed, 5 skipped, and 8 xpassed.
- The full local suite was not run because the local Rust extension build fails before test execution on this machine.
