### PR TITLE
ci: preserve uv cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
           enable-cache: true
+          prune-cache: false
       - name: setup rust
         # yamllint disable-line rule:line-length
         uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1


### PR DESCRIPTION
## Summary

This one-setting experiment retains uv cache artifacts between Linux jobs with the same lockfile. It makes it possible to measure whether a restored cache improves the separately timed dependency-sync step.

## Measurement plan

Run two consecutive Linux jobs on this unchanged head and lockfile. Keep this change only if the first job saves useful wheel artifacts, the second job reports a cache hit, and dependency sync becomes materially faster without offsetting cache save or restore time. Otherwise, revert it and retain the existing cache configuration.

## Validation

- `actionlint .github/workflows/test.yaml` (only existing shellcheck diagnostics)
- Ruby YAML parse of `.github/workflows/test.yaml`

## Linux measurement

Two consecutive Linux PR jobs used the same lockfile and cache key.

| Measurement | First job | Second job | Result |
| --- | ---: | ---: | --- |
| uv cache | cold miss | full key hit | retained cache restored |
| uv cache size | 489.6 MB saved | 489.6 MB restored | useful artifact cache |
| dependency sync | 6m58s | 5m02s | 1m56s faster (28%) |
| setup-uv overhead | cold setup: 3s | cache restore: 10s | 7s restore cost |
| post-job cache work | 7s save | no save after hit | no compensating cost |

The second job logged `Cache hit` and `Cache restored successfully` for the same
uv key. Its pytest stage passed 1,635 tests (5 skipped, 8 xpassed).

The preparation-path improvement remains after cache overhead: approximately
1m49s versus the first job. The full pytest duration varied between the two
runs, so this experiment supports the dependency-sync result, not a claim about
total job duration.

The configured `prune-cache: false` setting meets the stated keep criteria.
