### PR TITLE
feat: remove retired Claude Opus 4.1

### DIFF
--- a/src/fenic/core/_inference/model_catalog.py
+++ b/src/fenic/core/_inference/model_catalog.py
@@ -267,8 +267,6 @@ AnthropicLanguageModelName = Literal[
     "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5",
     "claude-haiku-4-5-20251001",
-    "claude-opus-4-1",
-    "claude-opus-4-1-20250805",
 ]
 
 CohereEmbeddingModelName = Literal[
@@ -529,22 +527,6 @@ class ModelCatalog:
                 supports_reasoning=True,
             ),
             snapshots=["claude-haiku-4-5-20251001"],
-        )
-
-        # Claude 4.1 models
-        self._add_model_to_catalog(
-            ModelProvider.ANTHROPIC,
-            "claude-opus-4-1",
-            CompletionModelParameters(
-                input_token_cost=15.00 / 1_000_000,  # $15 per 1M tokens
-                cached_input_token_write_cost=18.75 / 1_000_000,  # $18.75 per 1M tokens
-                cached_input_token_read_cost=1.50 / 1_000_000,  # $1.50 per 1M tokens
-                output_token_cost=75.00 / 1_000_000,  # $75 per 1M tokens
-                context_window_length=200_000,
-                max_output_tokens=32_000,
-                supports_reasoning=True,
-            ),
-            snapshots=["claude-opus-4-1-20250805"],
         )
 
         self._add_model_to_catalog(

--- a/tests/api/test_session.py
+++ b/tests/api/test_session.py
@@ -1075,7 +1075,7 @@ def test_session_config_with_invalid_anthropic_api_key(tmp_path, monkeypatch):
             app_name="test_session_config_with_invalid_anthropic_api_key",
             db_path=tmp_path,
             semantic=SemanticConfig(
-                language_models={"claude": AnthropicLanguageModel(model_name="claude-opus-4-1", rpm=100, input_tpm=100, output_tpm=1000)}
+                language_models={"claude": AnthropicLanguageModel(model_name="claude-opus-4-8", rpm=100, input_tpm=100, output_tpm=1000)}
             )
         )
         _ = Session.get_or_create(config)


### PR DESCRIPTION
## Summary

- Remove the retired `claude-opus-4-1` alias and `claude-opus-4-1-20250805` snapshot from the Anthropic catalog.
- Update the Anthropic configuration test to use the supported `claude-opus-4-8`.

## Validation

- `uv run pytest tests/_inference/test_model_catalog.py tests/api/test_session.py::test_session_config_with_invalid_anthropic_api_key`
- `uvx ruff check src/fenic/core/_inference/model_catalog.py tests/api/test_session.py`
- `git diff --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>