### PR TITLE
ci: add a full Python matrix PR label

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ on:
       - tests/**
       - pyproject.toml
       - uv.lock
+  merge_group:
+    types: [checks_requested]
   schedule:
     # daily at 8am Pacific (15:00 UTC)
     - cron: 0 15 * * *
@@ -32,11 +34,11 @@ jobs:
         id: matrix
         # yamllint disable rule:line-length
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            # Run all combinations on scheduled runs
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ contains(github.event.pull_request.labels.*.name, 'ci:full-matrix') }}" == "true" ]]; then
+            # Full coverage runs on schedule and when a PR opts in.
             matrix='{"dependency": ["true", "min", "max"], "test": ["local", "cloud"], "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"]}'
           else
-            # Run synced local tests at the compatibility boundaries on PR/manual runs.
+            # PR and merge-queue checks cover the supported Python boundaries.
             matrix='{"include": [{"dependency": "true", "test": "local", "python-version": "3.10"}, {"dependency": "true", "test": "local", "python-version": "3.14"}]}'
           fi
           # shellcheck disable=SC2086

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,17 @@ uv run --env-file .env python tools/package_size_matrix.py \
 
 ### Python Tests
 
+### CI matrix
+
+Pull requests run local tests on the supported Python boundaries: 3.10 and
+3.14. Add the `ci:full-matrix` label when a change needs the complete Python
+3.10 through 3.14 matrix, dependency-resolution variants, and cloud coverage.
+
+The full matrix also runs on the daily schedule. Merge-queue checks use the
+boundary matrix so that queue latency stays bounded. Intermediate Python
+versions are covered before merge when a pull request carries the label, and
+on the scheduled full-matrix run.
+
 Run a specific test file:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds the `ci:full-matrix` label for pull requests that need the complete Python
3.10–3.14 test matrix. Unlabeled pull requests keep the faster 3.10/3.14 local
compatibility-boundary checks.

| Event or PR state | Test matrix |
| --- | --- |
| Unlabeled pull request | Local tests on Python 3.10 and 3.14 |
| Pull request with `ci:full-matrix` | Python 3.10–3.14, all dependency modes, local and cloud tests |
| Daily schedule | Full matrix |
| Merge queue | Python 3.10 and 3.14 boundary pair |

The release wheel workflow already builds wheels for Python 3.10 through 3.14.

Merge-queue checks deliberately use the boundary pair. Each current boundary
job takes about 16 minutes; running all 30 full-matrix combinations in the
queue would add substantial queue latency. Intermediate Python versions remain
covered by the scheduled full matrix, and interpreter-sensitive pull requests
can opt in to the full matrix before merge.

`CONTRIBUTING.md` now documents when to apply the label.

## Validation

- `actionlint .github/workflows/test.yaml` passed; it reports only existing
  shellcheck advisories in unchanged commands.
- Verified matrix selection for unlabeled and labeled PRs, scheduled runs, and
  merge-queue runs.
- `git diff --check`

Hold: do not merge until explicit approval.
