### PR TITLE
ci: cache Rust build dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,8 +71,16 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1
         with:
           toolchain: stable
-          cache: true
-          cache-shared-key: shared-rust-cache
+          cache: false
+      - name: cache Rust dependencies
+        id: rust-cache
+        # yamllint disable-line rule:line-length
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          # Stable across the Python matrix; the action also hashes Cargo manifests and locks.
+          shared-key: fenic-rust-v1
+          workspaces: |
+            rust -> target
       - name: Check if Rust unit tests need to be run
         id: rust_changed
         run: |


### PR DESCRIPTION
## Summary

Makes the Rust build cache in the test workflow effective for Fenic's `rust/`
subdirectory workspace.

The previous embedded cache searched the repository root, where there is no
`Cargo.toml`, and saved a 0-byte entry. This uses the same cache implementation
directly with `rust -> target`, so its `cache-hit` output and restore/save logs
are visible in the job.

The `fenic-rust-v1` shared key is intentionally coarse across the Python test
matrix. The action still includes the Cargo manifests and lockfiles in its
environment hash, so a Rust dependency change produces a new cache entry while
the identical 3.10 and 3.14 jobs can share compiled dependencies. Its automatic
target pruning keeps the entry bounded alongside the uv cache.

## Measurement

Two consecutive `workflow_dispatch` runs on the same commit and lockfiles:

| Python | Cold seed (run 31856763186) | Warm hit (run 31857532372) | Change |
| --- | --- | --- | --- |
| 3.10 Rust unit step | 2m22s | 1m29s | 53s faster (37%) |
| 3.14 Rust unit step | 2m26s | 1m28s | 58s faster (40%) |
| 3.10 dependency sync | 6m28s | 4m38s | 1m50s faster |
| 3.14 dependency sync | 6m45s | 4m31s | 2m14s faster |
| Whole workflow run | 16m23s | 14m57s | 1m26s faster (9%) |

The cold run saved a 789 MB Rust cache. The warm run restored a full match for
both jobs (13s on 3.14 and 25s on 3.10); the action reported the same
`v0-rust-fenic-rust-v1-Linux-x64-00e61d8f-8031a4d1` key in both jobs. The
single cold entry was created by the 3.10 job; the concurrent 3.14 save lost
the normal immutable-cache reservation race.

## Validation

- `actionlint .github/workflows/test.yaml` passed with only pre-existing
  shellcheck advisories in unchanged commands.
- `git diff --check`

Hold: do not merge until explicit approval.
