### PR TITLE
fix(inference): handle nullable usage detail tokens

### DIFF
--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -159,7 +159,7 @@ class OpenAIChatCompletionsCore:
             usage: CompletionUsage = response.usage
 
             cached_input_tokens = (
-                usage.prompt_tokens_details.cached_tokens
+                (usage.prompt_tokens_details.cached_tokens or 0)
                 if usage.prompt_tokens_details
                 else 0
             )
@@ -168,7 +168,7 @@ class OpenAIChatCompletionsCore:
 
             # Extract reasoning (thinking) tokens if available
             reasoning_tokens = (
-                usage.completion_tokens_details.reasoning_tokens
+                (usage.completion_tokens_details.reasoning_tokens or 0)
                 if usage.completion_tokens_details
                 else 0
             )

--- a/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
+++ b/src/fenic/_inference/openrouter/openrouter_batch_chat_completions_client.py
@@ -245,14 +245,14 @@ class OpenRouterBatchChatCompletionsClient(
 
             usage = response.usage
             cached_input_tokens = (
-                usage.prompt_tokens_details.cached_tokens
+                (usage.prompt_tokens_details.cached_tokens or 0)
                 if usage.prompt_tokens_details
                 else 0
             )
             uncached_input_tokens = usage.prompt_tokens - cached_input_tokens
             total_prompt_tokens = usage.prompt_tokens
             reasoning_tokens = (
-                usage.completion_tokens_details.reasoning_tokens
+                (usage.completion_tokens_details.reasoning_tokens or 0)
                 if usage.completion_tokens_details
                 else 0
             )

--- a/tests/_inference/test_openrouter_structured_output.py
+++ b/tests/_inference/test_openrouter_structured_output.py
@@ -2,6 +2,8 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from openai.types import CompletionUsage
+from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 from pydantic import BaseModel
 
 from fenic._inference.model_client import FatalException, TransientException
@@ -84,6 +86,26 @@ def _response(*, content=None, tool_calls=None):
             model_extra={"cost": 0.0},
         ),
     )
+
+
+def test_usage_detail_fields_none_are_treated_as_zero():
+    response = _response(content='{"answer":true}')
+    response.usage = CompletionUsage(
+        prompt_tokens=2,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=None),
+        completion_tokens=3,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=None),
+        total_tokens=5,
+    )
+    client, _ = _client(
+        {"structured_outputs"}, response, model="openai/gpt-4.1-nano"
+    )
+
+    result = asyncio.run(client.make_single_request(_request()))
+
+    assert result.usage.cached_tokens == 0
+    assert result.usage.thinking_tokens == 0
+    assert result.usage.completion_tokens == 3
 
 
 def _request(*, profile=None):

--- a/tests/_inference/test_output_token_limits.py
+++ b/tests/_inference/test_output_token_limits.py
@@ -2,6 +2,8 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from openai.types import CompletionUsage
+from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 
 from fenic._inference.common_openai.openai_chat_completions_core import (
     OpenAIChatCompletionsCore,
@@ -75,8 +77,9 @@ def test_openai_core_output_limit_uses_internal_model_identity():
 
 
 class FakeOpenAICompletions:
-    def __init__(self):
+    def __init__(self, usage=None):
         self.kwargs = None
+        self.usage = usage
 
     async def create(self, **kwargs):
         self.kwargs = kwargs
@@ -88,7 +91,8 @@ class FakeOpenAICompletions:
                     logprobs=None,
                 )
             ],
-            usage=SimpleNamespace(
+            usage=self.usage
+            or SimpleNamespace(
                 prompt_tokens=1,
                 prompt_tokens_details=None,
                 completion_tokens=1,
@@ -97,8 +101,8 @@ class FakeOpenAICompletions:
         )
 
 
-def _make_openai_core_with_fake_completions():
-    fake_completions = FakeOpenAICompletions()
+def _make_openai_core_with_fake_completions(usage=None):
+    fake_completions = FakeOpenAICompletions(usage)
     return (
         OpenAIChatCompletionsCore(
             model="gpt-4.1-nano",
@@ -111,6 +115,65 @@ def _make_openai_core_with_fake_completions():
         ),
         fake_completions,
     )
+
+
+@pytest.mark.parametrize(
+    ("reasoning_tokens", "expected_completion_tokens", "expected_thinking_tokens"),
+    [(None, 3, 0), (0, 3, 0), (2, 1, 2)],
+)
+def test_openai_core_accounts_for_optional_reasoning_tokens(
+    reasoning_tokens, expected_completion_tokens, expected_thinking_tokens
+):
+    usage = CompletionUsage(
+        prompt_tokens=1,
+        completion_tokens=3,
+        total_tokens=4,
+        completion_tokens_details=CompletionTokensDetails(
+            reasoning_tokens=reasoning_tokens
+        ),
+    )
+    core, _ = _make_openai_core_with_fake_completions(usage)
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    result = asyncio.run(
+        core.make_single_request(request, OpenAICompletionProfileConfiguration())
+    )
+
+    assert result.usage.completion_tokens == expected_completion_tokens
+    assert result.usage.thinking_tokens == expected_thinking_tokens
+    assert result.usage.total_tokens == 4
+    assert core.get_metrics().num_output_tokens == 3
+
+
+def test_openai_core_accounts_for_optional_cached_tokens():
+    usage = CompletionUsage(
+        prompt_tokens=2,
+        completion_tokens=1,
+        total_tokens=3,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=None),
+    )
+    core, _ = _make_openai_core_with_fake_completions(usage)
+    request = FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+    result = asyncio.run(
+        core.make_single_request(request, OpenAICompletionProfileConfiguration())
+    )
+
+    assert result.usage.cached_tokens == 0
+    assert core.get_metrics().num_cached_input_tokens == 0
+    assert core.get_metrics().num_uncached_input_tokens == 2
 
 
 def test_openai_core_omits_zero_temperature():


### PR DESCRIPTION
## Summary

OpenAI-compatible completions no longer fail after a successful model response when a token-details object contains a null cached or reasoning token count. The clients treat these optional detail values as zero while preserving the provider's prompt, output, and total token counts.

The regression coverage uses the OpenAI SDK models to represent the exact response shape: the details container is present and its inner field is `None`. It covers null, zero, and positive reasoning counts and exercises both the shared OpenAI path and OpenRouter accounting.

## Validation

- `47 passed` across the two focused response-accounting test files.
- `171 passed, 8 skipped` across `tests/_inference`, excluding the cache end-to-end file that requires provider credentials during client setup.
- Ruff lint passed for all four changed files.
- The full inference run was also attempted. Its only two setup errors were the credential-dependent cache end-to-end cases without an OpenAI API key.

## Post-Deploy Monitoring & Validation

- Search inference logs for `unsupported operand type(s) for -` and unretrieved asynchronous task exceptions.
- Watch the standard inference error-rate and token-usage metrics for OpenAI-compatible providers.
- Healthy behavior: completed responses return normally, and null detail fields contribute zero cached or reasoning tokens.
- Failure signal: the subtraction error returns or successful provider calls do not produce client responses. Roll back this commit if either signal recurs.
- Validation window: the first 24 hours after release. Owner: inference maintainers.
