### PR TITLE
fix(inference): guard nullable usage token fields for Anthropic and Cohere

### DIFF
--- a/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
+++ b/src/fenic/_inference/anthropic/anthropic_batch_chat_completions_client.py
@@ -218,8 +218,10 @@ class AnthropicBatchCompletionsClient(
                 return FenicCompletionsResponse(completion="", logprobs=None)
             if usage_data:
                 # Extract usage metrics
-                num_cache_tokens_written = usage_data.cache_creation_input_tokens
-                num_pre_cached_tokens = usage_data.cache_read_input_tokens
+                # The cache token counts are Optional in the Anthropic SDK: they are
+                # absent whenever prompt caching is not in play, so treat them as zero.
+                num_cache_tokens_written = usage_data.cache_creation_input_tokens or 0
+                num_pre_cached_tokens = usage_data.cache_read_input_tokens or 0
                 num_uncached_input_tokens = usage_data.input_tokens
                 prompt_tokens = (
                     num_pre_cached_tokens
@@ -247,7 +249,7 @@ class AnthropicBatchCompletionsClient(
                     model_name=self.model,
                     uncached_input_tokens=num_uncached_input_tokens,
                     cached_input_tokens_read=num_pre_cached_tokens,
-                    cached_input_tokens_written=usage_data.cache_creation_input_tokens,
+                    cached_input_tokens_written=num_cache_tokens_written,
                     output_tokens=output_tokens,
                 )
         except RateLimitError as e:

--- a/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
+++ b/src/fenic/_inference/cohere/cohere_batch_embeddings_client.py
@@ -108,9 +108,13 @@ class CohereBatchEmbeddingsClient(
             embedding_values = response.embeddings.float[0]
 
             # Count tokens and update metrics
-            if hasattr(response, 'meta') and hasattr(response.meta, 'billed_units'):
+            # meta, billed_units and input_tokens are all Optional in the Cohere SDK,
+            # so read through them defensively rather than assuming they are populated.
+            billed_units = getattr(getattr(response, "meta", None), "billed_units", None)
+            billed_input_tokens = getattr(billed_units, "input_tokens", None)
+            if billed_input_tokens is not None:
                 # Use Cohere's billed token count if available
-                total_tokens = response.meta.billed_units.input_tokens
+                total_tokens = billed_input_tokens
             else:
                 # Fall back to our token counter
                 total_tokens = self.token_counter.count_tokens(request.doc)

--- a/tests/_inference/test_anthropic_usage_accounting.py
+++ b/tests/_inference/test_anthropic_usage_accounting.py
@@ -1,0 +1,138 @@
+"""Usage accounting for the Anthropic completions client.
+
+`cache_creation_input_tokens` and `cache_read_input_tokens` are Optional in the
+Anthropic SDK and are absent whenever prompt caching is not in play, so the
+accounting block must treat them as zero instead of adding None.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from anthropic.types import Usage  # noqa: E402
+
+from fenic._inference.anthropic.anthropic_batch_chat_completions_client import (  # noqa: E402
+    AnthropicBatchCompletionsClient,
+)
+from fenic._inference.rate_limit_strategy import (
+    SeparatedTokenRateLimitStrategy,  # noqa: E402
+)
+from fenic._inference.types import (  # noqa: E402
+    FenicCompletionsRequest,
+    LMRequestMessages,
+)
+from fenic.core._inference.model_catalog import (  # noqa: E402
+    ModelProvider,
+    model_catalog,
+)
+
+MODEL = "claude-sonnet-4-6"
+
+
+def _request() -> FenicCompletionsRequest:
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="s", examples=[], user="u"),
+        max_completion_tokens=128,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=0.0,
+    )
+
+
+def _respond_with(monkeypatch, usage: Usage) -> AnthropicBatchCompletionsClient:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    client = AnthropicBatchCompletionsClient(
+        model=MODEL,
+        rate_limit_strategy=SeparatedTokenRateLimitStrategy(
+            rpm=100, input_tpm=10_000, output_tpm=10_000
+        ),
+    )
+
+    async def _stream(_payload):
+        return "hello", usage
+
+    # Returning from the streaming handler exercises the real accounting block
+    # without any network call.
+    monkeypatch.setattr(client, "_handle_text_streaming_response", _stream)
+    return client
+
+
+def _make_request(monkeypatch, usage: Usage):
+    client = _respond_with(monkeypatch, usage)
+    try:
+        return asyncio.run(client.make_single_request(_request())), client
+    finally:
+        client.shutdown()
+
+
+def test_absent_cache_token_fields_are_treated_as_zero(monkeypatch):
+    # A Usage without any cache fields is what Anthropic returns when prompt
+    # caching is not in play; both fields default to None.
+    usage = Usage(input_tokens=7, output_tokens=3)
+    assert usage.cache_creation_input_tokens is None
+    assert usage.cache_read_input_tokens is None
+
+    result, client = _make_request(monkeypatch, usage)
+
+    assert result.usage.prompt_tokens == 7
+    assert result.usage.cached_tokens == 0
+    assert result.usage.completion_tokens == 3
+    assert result.usage.total_tokens == 10
+    assert client.get_metrics().num_cached_input_tokens == 0
+    assert client.get_metrics().num_uncached_input_tokens == 7
+
+
+@pytest.mark.parametrize(
+    ("cache_read", "cache_written"),
+    [(None, None), (0, 0), (None, 4), (4, None)],
+)
+def test_nullable_cache_token_fields_do_not_raise(monkeypatch, cache_read, cache_written):
+    usage = Usage(
+        input_tokens=5,
+        output_tokens=2,
+        cache_read_input_tokens=cache_read,
+        cache_creation_input_tokens=cache_written,
+    )
+
+    result, _ = _make_request(monkeypatch, usage)
+
+    assert result.usage.prompt_tokens == 5 + (cache_read or 0) + (cache_written or 0)
+    assert result.usage.cached_tokens == (cache_read or 0)
+
+
+def test_absent_cache_token_fields_contribute_no_cost(monkeypatch):
+    # Covers the second unguarded read: the raw cache_creation_input_tokens was
+    # also passed to calculate_completion_model_cost, where None * float raises.
+    usage = Usage(input_tokens=1000, output_tokens=500)
+
+    _, client = _make_request(monkeypatch, usage)
+
+    # Derive the expectation from the catalog so catalog price updates do not
+    # break this test; the cache components must contribute exactly nothing.
+    parameters = model_catalog.get_completion_model_parameters(
+        ModelProvider.ANTHROPIC, MODEL
+    )
+    expected_cost = (
+        1000 * parameters.input_token_cost + 500 * parameters.output_token_cost
+    )
+    assert client.get_metrics().cost == pytest.approx(expected_cost)
+
+
+def test_populated_cache_token_fields_are_still_counted(monkeypatch):
+    # Guards against the None-coalescing accidentally discarding real counts.
+    usage = Usage(
+        input_tokens=10,
+        output_tokens=4,
+        cache_read_input_tokens=6,
+        cache_creation_input_tokens=2,
+    )
+
+    result, client = _make_request(monkeypatch, usage)
+
+    assert result.usage.prompt_tokens == 18
+    assert result.usage.cached_tokens == 6
+    assert result.usage.total_tokens == 22
+    assert client.get_metrics().num_cached_input_tokens == 6
+    assert client.get_metrics().num_uncached_input_tokens == 10

--- a/tests/_inference/test_cohere_usage_accounting.py
+++ b/tests/_inference/test_cohere_usage_accounting.py
@@ -1,0 +1,80 @@
+"""Usage accounting for the Cohere embeddings client.
+
+`meta`, `meta.billed_units` and `billed_units.input_tokens` are all Optional in
+the Cohere SDK, so the billed token count must be read defensively and fall back
+to the local token counter when it is not populated.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("cohere")
+
+from fenic._inference.cohere.cohere_batch_embeddings_client import (  # noqa: E402
+    CohereBatchEmbeddingsClient,
+)
+from fenic._inference.rate_limit_strategy import (
+    UnifiedTokenRateLimitStrategy,  # noqa: E402
+)
+from fenic._inference.types import FenicEmbeddingsRequest  # noqa: E402
+
+DOC = "a document to embed"
+
+
+def _request() -> FenicEmbeddingsRequest:
+    return FenicEmbeddingsRequest(doc=DOC)
+
+
+def _respond_with(monkeypatch, meta) -> CohereBatchEmbeddingsClient:
+    monkeypatch.setenv("COHERE_API_KEY", "test-key")
+    client = CohereBatchEmbeddingsClient(
+        model="embed-v4.0",
+        rate_limit_strategy=UnifiedTokenRateLimitStrategy(rpm=100, tpm=10_000),
+    )
+
+    async def _embed(**_kwargs):
+        return SimpleNamespace(
+            embeddings=SimpleNamespace(float=[[0.1, 0.2, 0.3]]),
+            meta=meta,
+        )
+
+    # Replacing the SDK call exercises the real accounting block with no network.
+    monkeypatch.setattr(client._client, "embed", _embed)
+    return client
+
+
+def _make_request(monkeypatch, meta):
+    client = _respond_with(monkeypatch, meta)
+    try:
+        return asyncio.run(client.make_single_request(_request())), client
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        None,
+        SimpleNamespace(billed_units=None),
+        SimpleNamespace(billed_units=SimpleNamespace(input_tokens=None)),
+    ],
+    ids=["no_meta", "no_billed_units", "no_input_tokens"],
+)
+def test_missing_billed_units_falls_back_to_token_counter(monkeypatch, meta):
+    result, client = _make_request(monkeypatch, meta)
+
+    assert result == [0.1, 0.2, 0.3]
+    # Falls back to the local counter rather than raising or counting None.
+    assert client.get_metrics().num_input_tokens == client.token_counter.count_tokens(DOC)
+    assert client.get_metrics().num_requests == 1
+
+
+def test_billed_input_tokens_are_used_when_present(monkeypatch):
+    meta = SimpleNamespace(billed_units=SimpleNamespace(input_tokens=42))
+
+    result, client = _make_request(monkeypatch, meta)
+
+    assert result == [0.1, 0.2, 0.3]
+    assert client.get_metrics().num_input_tokens == 42


### PR DESCRIPTION
## The bug

`AnthropicBatchCompletionsClient.make_single_request` reads two usage fields that the Anthropic SDK types as `Optional[int]` and adds them without a guard:

```python
num_cache_tokens_written = usage_data.cache_creation_input_tokens
num_pre_cached_tokens = usage_data.cache_read_input_tokens
num_uncached_input_tokens = usage_data.input_tokens
prompt_tokens = (
    num_pre_cached_tokens + num_uncached_input_tokens + num_cache_tokens_written
)
```

Both fields are `None` whenever prompt caching is not in play, which is the common case:

```python
>>> from anthropic.types import Usage
>>> Usage(input_tokens=10, output_tokens=5).cache_read_input_tokens is None
True
```

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
  anthropic_batch_chat_completions_client.py:225
```

A `TypeError` is not an `AnthropicError`, so it escapes the classification block and fails the whole query with an opaque `ExecutionError: unsupported operand type(s) for +`.

The same `cache_creation_input_tokens` value is read a second time, unguarded, as the `cached_input_tokens_written` cost input (line 250), where `None * float` would raise inside `calculate_completion_model_cost`.

**This is the pattern #380 fixed for OpenAI and OpenRouter.** That change added `or 0` to `prompt_tokens_details.cached_tokens` and `completion_tokens_details.reasoning_tokens`; the Anthropic and Cohere clients were not covered and still read their Optional usage fields directly.

### Cohere has the same class of bug, with two failure modes

```python
if hasattr(response, 'meta') and hasattr(response.meta, 'billed_units'):
    total_tokens = response.meta.billed_units.input_tokens
```

In the Cohere SDK, `ApiMeta.billed_units` is `Optional[ApiMetaBilledUnits]` and `ApiMetaBilledUnits.input_tokens` is `Optional[float]`. `hasattr` returns `True` for an attribute whose value is `None`, so the guard passes and then:

- `billed_units is None` → `AttributeError: 'NoneType' object has no attribute 'input_tokens'`
- `input_tokens is None` → `TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'`

Here it is arguably worse than a hard failure: the client's `except Exception` catch-all converts both into `TransientException`, so fenic **retries** through the full backoff budget on a condition no retry can fix.

## The change

Mirrors #380's idiom exactly — coalesce the Optional fields to zero, and read the Cohere chain defensively:

```python
num_cache_tokens_written = usage_data.cache_creation_input_tokens or 0
num_pre_cached_tokens = usage_data.cache_read_input_tokens or 0
```

```python
billed_units = getattr(getattr(response, "meta", None), "billed_units", None)
billed_input_tokens = getattr(billed_units, "input_tokens", None)
if billed_input_tokens is not None:
    total_tokens = billed_input_tokens
else:
    total_tokens = self.token_counter.count_tokens(request.doc)
```

The cost call now reuses the already-coalesced local instead of re-reading the raw Optional. `input_tokens` and `output_tokens` are left alone: the SDK types them as required on the accumulated `Usage` that the streaming handlers return.

Fixing at the read site rather than making `calculate_completion_model_cost` None-tolerant is deliberate, and matches how the codebase is layered: `ResponseUsage` (`_inference/types.py`) types every field as a non-Optional `int`, so normalising provider Optionals is the client's job, and the cost calculator is entitled to receive numbers. It is also the convention #380 established for the OpenAI and OpenRouter clients.

### Audit of every other usage-extraction site

| Site | Verdict |
|---|---|
| `common_openai/openai_chat_completions_core.py:162,171` | already guarded by #380 |
| `openrouter/openrouter_batch_chat_completions_client.py:248,255` | already guarded by #380 |
| `google/gemini_native_chat_completions_client.py:281-298` | already guarded — `if ... else 0` on all four fields |
| `cache/sqlite_cache.py:429-435, 506-520` | already correct — reads fenic's own `ResponseUsage` (all fields non-Optional `int`), guards the `usage` container for None, and performs **no arithmetic**; the values are bound as INSERT params into nullable columns |
| `anthropic_batch_chat_completions_client.py:221,222,250` | **fixed here** |
| `cohere_batch_embeddings_client.py:111-113` | **fixed here** |

Anthropic and Cohere were the only sites left.

## Who this affects

Not only Anthropic-compatible gateways. Direct Anthropic returns no cache fields whenever the request has no cache breakpoints, so any `semantic.*` call against an Anthropic model without prompt caching hits this. Self-hosted and gateway-fronted deployments hit it consistently, since those responses rarely carry cache accounting at all.

## Tests

Two new files, following `tests/_inference/test_anthropic_429_classification.py` (monkeypatch the streaming handler, exercise the real accounting block, no network) and #380's parametrized "None is treated as zero" style:

`tests/_inference/test_anthropic_usage_accounting.py`
- absent cache fields → `prompt_tokens == input_tokens`, `cached_tokens == 0`, metrics correct
- parametrized over `(None, None)`, `(0, 0)`, `(None, 4)`, `(4, None)` → no raise, arithmetic correct
- **absent cache fields contribute no cost** — asserts the reported cost equals `input_tokens * input_token_cost + output_tokens * output_token_cost`, derived from the catalog rather than hardcoded so catalog price updates cannot break it. This is what covers the second read site: with only lines 221/222 guarded, this test fails with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'` at `model_catalog.py:1687`.
- populated cache fields are still counted (guards against the coalescing discarding real values)

`tests/_inference/test_cohere_usage_accounting.py`
- parametrized over missing `meta`, missing `billed_units`, missing `input_tokens` → falls back to the local token counter
- a present `input_tokens` is still used

Both files `pytest.importorskip` their provider SDK, matching the existing provider tests.

```
$ uv run pytest tests/_inference/test_anthropic_usage_accounting.py tests/_inference/test_cohere_usage_accounting.py -q
11 passed

$ uv run pytest tests/_inference -q -m "not cloud"
1 failed, 203 passed, 4 skipped, 2 errors
```

The failure and errors are pre-existing on unmodified `main` in the same tree (a home-directory path assertion and two tests needing live API keys).

Restoring only the two `src/` files to their current `main` content makes the new tests fail with exactly these errors:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'    (anthropic, line 225)
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'    (anthropic, line 225)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'  (model_catalog.py:1687, line-250 read)
AttributeError: 'NoneType' object has no attribute 'input_tokens'     (cohere)
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'   (cohere)
```

`ruff check` is clean on all four files. No public API change, so the fenic-mechanics reference is unchanged. No version bump, no dependency changes.
