### PR TITLE
fix(inference): stop a failed batch from failing later batches

### DIFF
--- a/src/fenic/_inference/model_client.py
+++ b/src/fenic/_inference/model_client.py
@@ -463,6 +463,10 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         logger.info(
             f"Creating batch {batch_id} with {len(requests)} requests for {operation_name} using (model: {self.model})"
         )
+        # A previous batch on this thread may have left a recorded exception behind
+        # after surfacing it to its own caller. Clear it so this batch reports only
+        # its own failures.
+        self._clear_thread_exception()
         try:
             return self._make_batch_requests(requests, operation_name, batch_id, request_timeout=request_timeout)
         except Exception as e:
@@ -530,12 +534,22 @@ class ModelClient(Generic[RequestT, ResponseT], ABC):
         token_estimate = self.estimate_tokens_for_request(request)
         return new_future, token_estimate
 
+    def _clear_thread_exception(self):
+        """Discard any exception recorded for the calling thread."""
+        with self.thread_exceptions_lock:
+            self.thread_exceptions.pop(threading.get_ident(), None)
+
     def _maybe_raise_thread_exception(self):
-        """Surface exceptions from event loop to calling thread immediately."""
+        """Surface exceptions from event loop to calling thread immediately.
+
+        The exception is removed as it is raised. It has been delivered to its
+        caller, so a later batch on the same thread must not observe it again.
+        """
         current_thread_id = threading.get_ident()
         with self.thread_exceptions_lock:
-            if current_thread_id in self.thread_exceptions:
-                raise self.thread_exceptions[current_thread_id]
+            exception = self.thread_exceptions.pop(current_thread_id, None)
+        if exception is not None:
+            raise exception
 
     def _calculate_backoff_time(self, backoff_iteration: int) -> float:
         """Calculates the backoff duration using exponential backoff with a maximum limit.

--- a/tests/_inference/test_model_client_thread_exception.py
+++ b/tests/_inference/test_model_client_thread_exception.py
@@ -1,0 +1,159 @@
+"""Batch isolation for exceptions surfaced from the event loop.
+
+`_handle_exception` records a failure against the submitting thread so a long
+batch fails fast instead of waiting on every future. That record must not outlive
+the batch that produced it: a later batch on the same thread would otherwise
+re-raise a stale exception belonging to an earlier, unrelated operation.
+"""
+
+import threading
+from typing import List, Optional, Union
+
+import pytest
+
+from fenic._inference.model_client import (
+    FatalException,
+    ModelClient,
+    TransientException,
+)
+from fenic._inference.rate_limit_strategy import RateLimitStrategy, TokenEstimate
+from fenic._inference.types import (
+    FenicCompletionsRequest,
+    FenicCompletionsResponse,
+    LMRequestMessages,
+)
+from fenic.core._inference.model_catalog import ModelProvider
+from fenic.core._inference.model_provider import ModelProviderClass
+from fenic.core.error import ExecutionError
+from fenic.core.metrics import LMMetrics
+
+
+class DummyProvider(ModelProviderClass):
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    def create_client(self):
+        return object()
+
+    def create_aio_client(self):
+        return object()
+
+    async def validate_api_key(self) -> None:
+        return
+
+
+class DummyRateLimitStrategy(RateLimitStrategy):
+    def __init__(self):
+        super().__init__(rpm=100)
+
+    def backoff(self, curr_time: float) -> int:
+        return 0
+
+    def check_and_consume_rate_limit(self, token_estimate: TokenEstimate) -> bool:
+        return True
+
+    def context_tokens_per_minute(self) -> int:
+        return 60_000
+
+
+class DummyTokenCounter:
+    def count_tokens(self, messages, ignore_file: bool = False) -> int:
+        return 0
+
+    def count_file_input_tokens(self, messages) -> int:
+        return 0
+
+    def count_file_output_tokens(self, messages) -> int:
+        return 0
+
+
+class FlakyCompletionClient(ModelClient[FenicCompletionsRequest, FenicCompletionsResponse]):
+    """Raises an unhandled error on the first request, then succeeds."""
+
+    def __init__(self, failures: int = 1):
+        super().__init__(
+            model="dummy-completion",
+            model_provider=ModelProvider.OPENAI,
+            model_provider_class=DummyProvider(),
+            rate_limit_strategy=DummyRateLimitStrategy(),
+            token_counter=DummyTokenCounter(),
+        )
+        self._metrics = LMMetrics()
+        self.remaining_failures = failures
+        self.call_count = 0
+
+    async def make_single_request(
+        self, request: FenicCompletionsRequest
+    ) -> Union[None, FenicCompletionsResponse, TransientException, FatalException]:
+        self.call_count += 1
+        if self.remaining_failures > 0:
+            self.remaining_failures -= 1
+            # Not a Transient/Fatal wrapper: an unhandled error, the shape a
+            # response that fails structured-output validation takes.
+            raise ValueError("first batch failure")
+        return FenicCompletionsResponse(
+            completion=f"response-for-{request.messages.user}",
+            logprobs=None,
+            usage=None,
+        )
+
+    def estimate_tokens_for_request(self, request: FenicCompletionsRequest) -> TokenEstimate:
+        return TokenEstimate(input_tokens=1, output_tokens=1)
+
+    def get_metrics(self) -> LMMetrics:
+        return self._metrics
+
+    def reset_metrics(self):
+        self._metrics = LMMetrics()
+
+    def _get_max_output_token_request_limit(self, request: FenicCompletionsRequest) -> int:
+        return 8
+
+    def _get_max_output_tokens_estimate(self, request: FenicCompletionsRequest) -> int:
+        return 8
+
+
+def _request(user: str) -> FenicCompletionsRequest:
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="s", examples=[], user=user),
+        max_completion_tokens=8,
+        top_logprobs=None,
+        structured_output=None,
+        temperature=None,
+    )
+
+
+def _batch(client: FlakyCompletionClient, user: str) -> List[Optional[FenicCompletionsResponse]]:
+    return client.make_batch_requests([_request(user)], operation_name="test")
+
+
+def test_failed_batch_does_not_fail_the_next_batch():
+    client = FlakyCompletionClient(failures=1)
+    try:
+        with pytest.raises(ExecutionError, match="first batch failure"):
+            _batch(client, "first")
+
+        # The endpoint is healthy again, so this batch must report its own outcome.
+        responses = _batch(client, "second")
+        assert responses[0].completion == "response-for-second"
+
+        responses = _batch(client, "third")
+        assert responses[0].completion == "response-for-third"
+    finally:
+        client.shutdown()
+
+
+def test_thread_exception_is_delivered_only_once():
+    client = FlakyCompletionClient(failures=0)
+    try:
+        client.thread_exceptions[threading.get_ident()] = ValueError("stale")
+
+        with pytest.raises(ValueError, match="stale"):
+            client._maybe_raise_thread_exception()
+
+        # Delivered once: a second call is a no-op rather than a repeat raise.
+        client._maybe_raise_thread_exception()
+        assert client.thread_exceptions == {}
+    finally:
+        client.shutdown()


### PR DESCRIPTION
## Symptom

One failed batch permanently breaks the model client. Every later query on the same thread fails with a **stale exception from the earlier, unrelated operation** — even after the provider has recovered and is returning perfectly good responses.

Reproduced against a local OpenAI-compatible server rigged to return exactly one non-conforming structured-output response and strictly conforming JSON from then on. Three sequential `semantic.classify` queries:

```
query 1 (server returns 1 bad response):     ExecutionError: 1 validation error for EnumModel
query 2 (server now STRICTLY CONFORMING):    ExecutionError: 1 validation error for EnumModel   <- stale
query 3 (server now STRICTLY CONFORMING):    ExecutionError: 1 validation error for EnumModel   <- stale
```

Queries 2 and 3 never had a problem. Their responses were valid. They failed because query 1 did.

This is badly misleading in practice: the reported error describes a schema and an input value from an operation that already finished, while `This error occurred in the following expression` names the *current* expression. Debugging leads straight to the wrong operator. It also means a single transient provider hiccup poisons the rest of the session rather than failing one batch.

## Root cause

`_handle_exception` records the failure against the submitting thread so a long batch can fail fast instead of waiting on every future:

```python
with self.thread_exceptions_lock:
    self.thread_exceptions[queue_item.thread_id] = exception
```

`_maybe_raise_thread_exception` is called repeatedly while submitting a batch and re-raises it:

```python
with self.thread_exceptions_lock:
    if current_thread_id in self.thread_exceptions:
        raise self.thread_exceptions[current_thread_id]
```

Nothing ever removes the entry. `self.thread_exceptions` is created once per client in `__init__`, and there is no `pop`, `del` or `clear` anywhere in the file. Because clients are cached per model for the life of a session, the record survives every subsequent batch on that thread.

Any unhandled exception reaches this path, so this is not specific to one failure mode — a structured-output validation error is simply the easiest way to trigger it.

## The change

Two lines of intent:

- clear the calling thread's record when a batch starts, so a batch reports only its own failures;
- remove the exception as it is raised, so it is delivered exactly once.

```python
def _clear_thread_exception(self):
    """Discard any exception recorded for the calling thread."""
    with self.thread_exceptions_lock:
        self.thread_exceptions.pop(threading.get_ident(), None)
```

Fail-fast behaviour within a batch is unchanged: the record is still written on failure and still surfaces on the next `_maybe_raise_thread_exception()` call inside that batch. Only cross-batch leakage is removed. Nothing about success paths, retry classification, rate limiting or metrics is touched.

Clearing at the start of the batch is what fixes the user-visible bug; popping on raise is what keeps the invariant true if a batch calls the check more than once after a failure. Both are needed — with only the pop, the first stale delivery still lands on the following batch.

## Tests

`tests/_inference/test_model_client_thread_exception.py`, built on the `DummyProvider` / `DummyRateLimitStrategy` / `DummyTokenCounter` harness already used by `test_model_client_cache_behavior.py`, with a client that raises once and then succeeds:

- `test_failed_batch_does_not_fail_the_next_batch` — the first batch raises `ExecutionError`, and the next two batches return their own results. This is the regression test for the symptom above.
- `test_thread_exception_is_delivered_only_once` — a recorded exception raises once, then the check is a no-op and the map is empty.

Both fail on current `main` and pass with the change.

```
$ uv run ruff check src/fenic/_inference/model_client.py tests/_inference/test_model_client_thread_exception.py
All checks passed!

$ uv run pytest tests/_inference/test_model_client_thread_exception.py -q
2 passed

$ uv run pytest tests/_inference -q -m "not cloud"
1 failed, 194 passed, 4 skipped, 2 errors
```

The failure and errors are pre-existing on unmodified `main` in the same tree (a home-directory path assertion, and two tests needing live API keys). No public API change, so the generated reference is unchanged. No version bump, no dependency changes.
