### PR TITLE
feat(inference): make structured-output validation failures diagnosable

### DIFF
--- a/src/fenic/_inference/common_openai/openai_chat_completions_core.py
+++ b/src/fenic/_inference/common_openai/openai_chat_completions_core.py
@@ -12,6 +12,7 @@ from openai import (
     RateLimitError,
 )
 from openai.types import CompletionUsage
+from pydantic import ValidationError as PydanticValidationError
 
 from fenic._inference.common_openai.openai_profile_manager import (
     OpenAICompletionProfileConfiguration,
@@ -39,7 +40,7 @@ from fenic.core._inference.model_catalog import (
 from fenic.core._inference.output_token_limits import (
     validate_effective_output_token_limit,
 )
-from fenic.core.error import ValidationError
+from fenic.core.error import ExecutionError, ValidationError
 from fenic.core.metrics import LMMetrics
 
 logger = logging.getLogger(__name__)
@@ -141,7 +142,13 @@ class OpenAIChatCompletionsCore:
             # Choose between parse and create based on structured_output
             if request.structured_output:
                 common_params["response_format"] = request.structured_output.pydantic_model
-                response = await self._client.beta.chat.completions.parse(**common_params)
+                try:
+                    response = await self._client.beta.chat.completions.parse(**common_params)
+                except PydanticValidationError as e:
+                    # The SDK parsed the model's content against response_format and it
+                    # did not conform. Surface what actually came back, rather than an
+                    # opaque pydantic error attributed to a DataFrame expression.
+                    return FatalException(_structured_output_validation_error(self._model, request, e))
             else:
                 response = await self._client.chat.completions.create(**common_params)
 
@@ -272,3 +279,38 @@ class OpenAIChatCompletionsCore:
                 else 0
             ),
         )
+_MAX_RAW_PREVIEW_CHARS = 200
+
+
+def _structured_output_validation_error(model, request, error):
+    """Build a diagnosable error for a response that failed structured-output parsing.
+
+    The OpenAI SDK parses the model's content against response_format and raises a
+    pydantic ValidationError when it does not conform. That error is opaque by itself,
+    so this reconstructs the operator, the expected schema and a short preview of what
+    the model actually returned.
+    """
+    schema_name = (
+        request.structured_output.pydantic_model.__name__
+        if request.structured_output is not None
+        else "unknown"
+    )
+    raw_input = next(
+        (item.get("input") for item in error.errors() if "input" in item), None
+    )
+    preview = _truncate_preview(raw_input, _MAX_RAW_PREVIEW_CHARS)
+    operator = request.operation_name or "unknown operator"
+    return ExecutionError(
+        f"Structured-output validation failed for {operator}: expected {schema_name}, "
+        f"but model '{model}' returned content that does not match it: {preview}. "
+        f"This model or provider does not honour response_format. "
+        f"Original error: {error}"
+    )
+
+
+def _truncate_preview(value, max_chars):
+    """Return a capped, single-line string preview of value."""
+    text = repr(value)
+    if len(text) > max_chars:
+        text = text[: max_chars - 3] + "..."
+    return text.replace("\\n", " ")

--- a/src/fenic/_inference/language_model.py
+++ b/src/fenic/_inference/language_model.py
@@ -71,6 +71,7 @@ class LanguageModel:
                 structured_output=response_format,
                 temperature=temperature_param,
                 model_profile=model_profile,
+                operation_name=operation_name,
             )
             requests.append(request)
 

--- a/src/fenic/_inference/types.py
+++ b/src/fenic/_inference/types.py
@@ -69,6 +69,7 @@ class FenicCompletionsRequest:
     structured_output: Optional[ResolvedResponseFormat]  # Resolved JSON schema
     temperature: Optional[float]
     model_profile: Optional[str] = None
+    operation_name: Optional[str] = None
 
 @dataclass
 class FenicEmbeddingsRequest:

--- a/tests/_inference/test_openai_structured_output_diagnostics.py
+++ b/tests/_inference/test_openai_structured_output_diagnostics.py
@@ -1,0 +1,157 @@
+"""Diagnosable failures for structured-output validation in the OpenAI core.
+
+When the OpenAI SDK's .parse() rejects a model's response against the requested
+schema, the resulting pydantic error is opaque by itself. The core should re-raise it
+as a fatal error that names the operator, the expected schema, and a preview of what
+the model actually returned.
+"""
+
+import asyncio
+import enum
+from types import SimpleNamespace
+
+from pydantic import BaseModel, create_model
+from pydantic import ValidationError as PydanticValidationError
+
+from fenic._inference.common_openai.openai_chat_completions_core import (
+    OpenAIChatCompletionsCore,
+)
+from fenic._inference.model_client import FatalException
+from fenic._inference.types import (
+    FenicCompletionsRequest,
+    LMRequestMessages,
+)
+from fenic.core._inference.model_catalog import ModelProvider
+from fenic.core._logical_plan.resolved_types import ResolvedResponseFormat
+
+LabelEnum = enum.Enum("LabelEnum", {"TOOLCHAIN": "toolchain", "NETWORK": "network"})
+EnumModel = create_model("EnumModel", output=(LabelEnum, ...))
+ENUM_FORMAT = ResolvedResponseFormat(
+    pydantic_model=EnumModel, json_schema={}, prompt_schema_definition=""
+)
+
+
+class SvcModel(BaseModel):
+    service: str
+    port: int
+
+
+OBJECT_FORMAT = ResolvedResponseFormat(
+    pydantic_model=SvcModel, json_schema={}, prompt_schema_definition=""
+)
+
+FENCE = chr(96) * 3
+NL = chr(10)
+
+
+def _validation_error(raw_input: str) -> PydanticValidationError:
+    try:
+        EnumModel.model_validate_json(raw_input)
+    except PydanticValidationError as e:
+        return e
+    raise AssertionError("expected a validation error")
+
+
+class FakeParseCompletions:
+    def __init__(self, error=None):
+        self.error = error
+
+    async def parse(self, **kwargs):
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"service": "api", "port": 1}', refusal=None
+                    ),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=1,
+                prompt_tokens_details=None,
+                completion_tokens=1,
+                completion_tokens_details=None,
+            ),
+        )
+
+
+def _core(parse_error=None):
+    return OpenAIChatCompletionsCore(
+        model="gpt-4.1-nano",
+        model_provider=ModelProvider.OPENAI,
+        token_counter=None,
+        client=SimpleNamespace(
+            chat=SimpleNamespace(completions=None),
+            beta=SimpleNamespace(
+                chat=SimpleNamespace(
+                    completions=FakeParseCompletions(error=parse_error)
+                )
+            ),
+        ),
+    )
+
+
+def _request(response_format, operation_name):
+    return FenicCompletionsRequest(
+        messages=LMRequestMessages(system="", examples=[], user="hello"),
+        max_completion_tokens=512,
+        top_logprobs=None,
+        structured_output=response_format,
+        temperature=None,
+        operation_name=operation_name,
+    )
+
+
+def _run(core, request):
+    return asyncio.run(core.make_single_request(request, None))
+
+
+def test_bare_enum_value_produces_diagnosable_fatal():
+    core = _core(parse_error=_validation_error("toolchain"))
+    request = _request(ENUM_FORMAT, "semantic.classify")
+
+    result = _run(core, request)
+
+    assert isinstance(result, FatalException)
+    message = str(result.exception)
+    assert "semantic.classify" in message
+    assert "EnumModel" in message
+    assert "'toolchain'" in message
+    assert "does not honour response_format" in message
+
+
+def test_fenced_json_produces_diagnosable_fatal():
+    fenced = FENCE + "json" + NL + '{"service": "api"}' + NL + FENCE
+    core = _core(parse_error=_validation_error(fenced))
+    request = _request(OBJECT_FORMAT, "semantic.extract")
+
+    result = _run(core, request)
+
+    assert isinstance(result, FatalException)
+    message = str(result.exception)
+    assert "semantic.extract" in message
+    assert "SvcModel" in message
+    assert "does not honour response_format" in message
+
+
+def test_missing_operation_name_falls_back_without_crashing():
+    core = _core(parse_error=_validation_error("toolchain"))
+    request = _request(ENUM_FORMAT, operation_name=None)
+
+    result = _run(core, request)
+
+    assert isinstance(result, FatalException)
+    assert "unknown operator" in str(result.exception)
+
+
+def test_conforming_response_still_succeeds():
+    core = _core(parse_error=None)
+    request = _request(ENUM_FORMAT, "semantic.classify")
+
+    result = _run(core, request)
+
+    assert not isinstance(result, FatalException)
+    assert result.completion == '{"service": "api", "port": 1}'


### PR DESCRIPTION
## Symptom

When a model ignores `response_format` and returns non-conforming content, fenic fails the whole query with an opaque pydantic error attributed to a DataFrame expression:

```
ExecutionError: Failed to execute query: 1 validation error for EnumModel
  Invalid JSON: expected ident at line 1 column 2 [type=json_invalid, input_value='toolchain']
  ...
This error occurred in the following expression:
  col("t").python_udf()
```

Nothing tells the user which operator failed, what schema it expected, or what the model actually returned. With this change the same failure reads:

```
Structured-output validation failed for semantic.classify: expected EnumModel,
but model 'gpt-4.1-nano' returned content that does not match it: 'toolchain'.
This model or provider does not honour response_format.
Original error: 1 validation error for EnumModel
  Invalid JSON: expected ident at line 1 column 2 [type=json_invalid, input_value='toolchain']
```

## Root cause

`OpenAIChatCompletionsCore.make_single_request` delegates parsing to `client.beta.chat.completions.parse(...)`. That SDK method parses the model's content against the requested schema and raises `pydantic.ValidationError` when it does not conform. The core's exception clauses only catch the SDK's own exception types and fenic's `ValidationError`, so pydantic's escaped unclassified and bubbled up as an `ExecutionError` with no context.

## The change

Catch the pydantic `ValidationError` around the `parse` call and re-raise it as a **fatal** error that names:

- the operator (`semantic.classify`, `semantic.extract`, ...), via the `operation_name` that `get_completions` already receives and now carries on `FenicCompletionsRequest`;
- the expected schema class (`EnumModel`, ...) from `structured_output.pydantic_model`;
- a short preview of the raw content the model returned, extracted from the validation error's `input` and capped at 200 characters.

No repair and no retry. The happy path is untouched: strictly conforming responses never enter this branch.

## Why fatal, not transient

The OpenRouter path catches this same class and returns a `TransientException`, but that is rationalised by provider re-routing — it can retry against a *different* provider that honours the schema. A fixed OpenAI-compatible endpoint has no alternate route, so retrying deterministic schema non-compliance burns quota and lands in the same failure. This path therefore treats it as fatal, consistent with the core's existing comment on deterministic request-construction failures ("retrying cannot help").

Worth considering separately: the two paths now classify the same condition differently, for good reason but without a shared type. Would a shared `StructuredOutputValidationException` (or similar) carrying the operator/schema/preview be useful as a cross-provider primitive? Raising it here as a question, not insisting.

## Tests

`tests/_inference/test_openai_structured_output_diagnostics.py`, following the fake-core pattern in `test_output_token_limits.py` (a `.parse()` that raises, no network):

- a bare enum value produces a fatal error carrying `semantic.classify`, `EnumModel`, and the raw `'toolchain'` preview;
- fenced JSON produces a fatal error carrying `semantic.extract` and the object schema name;
- a missing `operation_name` falls back to `unknown operator` instead of crashing;
- a strictly conforming response still succeeds and returns its content unchanged.

```
$ uv run ruff check <4 changed files>
All checks passed!

$ uv run pytest tests/_inference/test_openai_structured_output_diagnostics.py -q
4 passed

$ uv run pytest tests/_inference -q -m "not cloud"
1 failed, 196 passed, 4 skipped, 2 errors
```

The failure and errors are pre-existing on unmodified `main` in the same tree (a home-directory path assertion; two tests needing live API keys). No public API change, so the generated reference is unchanged. No version bump, no dependency changes.

Verified end to end against a local OpenAI-compatible server whose model returns a bare enum value: the error now names the operator, schema, and raw value, as shown at the top.
