### PR TITLE
ci: make the Renovate config self-contained

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,46 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>typedef-ai/renovate:default.json5'],
+  extends: [
+    // Pulls in config:recommended, :configMigration, docker:pinDigests,
+    // helpers:pinGitHubActionDigests, :pinDevDependencies, abandonments:recommended,
+    // security:minimumReleaseAgeNpm and :maintainLockFilesWeekly.
+    'config:best-practices',
+    ':preserveSemverRanges',
+    ':combinePatchMinorReleases',
+    ':semanticCommitTypeAll(chore)',
+    ':enableVulnerabilityAlerts',
+    'mergeConfidence:all-badges',
+    'group:linters',
+  ],
+  timezone: 'America/Los_Angeles',
+  // 4th of each month, 14:00-14:59 PT. Lock file maintenance keeps its own
+  // weekly schedule from :maintainLockFilesWeekly.
+  schedule: ['* 14 4 * *'],
+  labels: ['dependencies'],
+  dependencyDashboardLabels: ['dependencies'],
+  semanticCommits: 'enabled',
+  semanticCommitType: 'chore',
+  semanticCommitScope: 'deps',
+  automergeStrategy: 'squash',
+  platformAutomerge: true,
+  pruneStaleBranches: true,
+  rebaseWhen: 'conflicted',
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: { enabled: true, labels: ['security'] },
   packageRules: [
+    {
+      description: 'Group and automerge GitHub Actions bumps',
+      matchManagers: ['github-actions'],
+      groupName: 'github-actions',
+      commitMessageTopic: '⬆ github-actions',
+      automerge: true,
+      prPriority: -1,
+      prBodyDefinitions: {
+        Package: '[{{{depName}}}](https://github.com/{{{depName}}})',
+        Change: '[`{{{displayFrom}}}` -> `{{{displayTo}}}`](https://github.com/{{{depName}}}/compare/{{{displayFrom}}}...{{{displayTo}}})',
+      },
+      prBodyColumns: ['Package', 'Change', 'Type', 'Update'],
+    },
     {
       // The polars Rust crate family must be upgraded in lockstep: pyo3-polars
       // pins specific polars/polars-arrow versions, so bumping any one of them


### PR DESCRIPTION
## Why

The central `typedef-ai/renovate` preset repo is being archived. This repo's
`.github/renovate.json5` was a two-line file whose behavior lived entirely in
`github>typedef-ai/renovate:default.json5`, so it needs to stand on its own
before that repo goes away.

Resolves #389 

## What carried over

Only the settings that apply to this repo's ecosystems (uv/pep621, cargo,
github-actions):

- The upstream Renovate presets, which are Renovate-maintained and unaffected by
  the archive: `config:best-practices`, `:preserveSemverRanges`,
  `:combinePatchMinorReleases`, `:semanticCommitTypeAll(chore)`,
  `:enableVulnerabilityAlerts`, `mergeConfidence:all-badges`, `group:linters`.
  `config:best-practices` is what supplies `config:recommended`,
  `:configMigration`, `helpers:pinGitHubActionDigests`, `:pinDevDependencies`,
  and `:maintainLockFilesWeekly` (the source of our weekly "lock file
  maintenance" PRs).
- House settings: monthly schedule on the 4th at 2pm PT, `dependencies` label,
  `chore(deps)` semantic commits, squash plus platform automerge,
  `rebaseWhen: conflicted`, `pruneStaleBranches`, OSV alerts labelled `security`.
- The grouped, auto-merged `github-actions` package rule with its custom PR body
  columns, placed above the existing polars lockstep rule so the effective rule
  ordering matches what preset-then-repo merging produced before.

## What was left out

Rules for ecosystems this repo does not have (confirmed: no `go.mod`, `*.tf`,
Dockerfile/Containerfile, `aqua.yaml`, `dagger.json`, or `package.json`): Go,
Terraform, Docker, Kubernetes, kata, aqua, and dagger rules, `postUpdateOptions`,
the dagger `ignorePaths`, and the generic `# renovate: depName=...` regex
managers, since there are no such annotations here.

Also dropped: five `extends` entries the central config listed that
`config:best-practices` already implies (`:dependencyDashboard`,
`replacements:all`, `workarounds:all`, `helpers:pinGitHubActionDigests`,
`configMigration`).

## Behavioral delta

One, and it is neutral: `schedule` is now an array, which is Renovate's declared
type. The string form only passed validation before because it lived inside a
remote preset.

## Testing

`trunk check --no-fix .github/renovate.json5` passes, including trunk's
`renovate@44.11.4` config validator (both its local and upstream validate steps)
and prettier. `pr_trunkio.yaml` runs the same check on this PR, so no new CI job
was needed. Verified no remaining references to `typedef-ai/renovate` anywhere in
the repo.